### PR TITLE
Add Frantic agent enlistment offer

### DIFF
--- a/vendors/fr/frantic.yaml
+++ b/vendors/fr/frantic.yaml
@@ -1,0 +1,52 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kypvhevf4pe9r00p3zbpkkqt
+slug: frantic
+slug_aliases: []
+name: Frantic
+domains:
+  - value: gofrantic.com
+    role: primary
+    valid_from: 2026-07-29T11:53:02.797Z
+category: ai-ml
+description: A bounty board where AI agents do honest work for real money, backed by public records and explicit receipt integrity state.
+links:
+  site: https://gofrantic.com
+sources:
+  - source_id: src_d6f5e07473c9e23aedd8910e4fc059718aa7daf8bc9420d17ee0a2c4bfae46e6
+    url: https://gofrantic.com/wtf
+programs: []
+offers:
+  - offer_id: off_01kypvhevh8ctpsghgzh7vs9fq
+    offer_slug: enlist-your-agent
+    offer_slug_aliases: []
+    title: Enlist your agent
+    summary: Enlist an AI agent to receive 5 days of runway to start with no fee, allowing access to read the board and take paid bounties up to $10 once identity is verified.
+    lifecycle:
+      status: active
+      effective_from: 2026-07-29T11:53:02.797Z
+    economics:
+      consideration:
+        kind: none
+      benefits:
+        - benefit_id: ben_01
+          description: Initial 5 days of runway to start upon enlisting an agent.
+          kind: free-service
+          service: Frantic runway
+          duration:
+            kind: exact
+            value: P5D
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_01
+        statement: Agent must be enlisted on the board and identity must be verified for paid bounties up to $10.
+        reason: external-verification
+    roles:
+      terms_authority_entity_id: ent_01kypvhevf4pe9r00p3zbpkkqt
+      access_operator_entity_id: ent_01kypvhevf4pe9r00p3zbpkkqt
+    access:
+      availability: public
+      method: form
+      url: https://gofrantic.com/wtf
+    source_ids:
+      - src_d6f5e07473c9e23aedd8910e4fc059718aa7daf8bc9420d17ee0a2c4bfae46e6


### PR DESCRIPTION
Adds Frantic and its five-day agent runway offer from the reviewed first-party gofrantic.com evidence.\n\nThe change is one canonical vendor YAML file; Catalog CI validates only this changed identity closure.