### PR TITLE
data(frantic): publish five distinct offers

### DIFF
--- a/vendors/fr/frantic.yaml
+++ b/vendors/fr/frantic.yaml
@@ -14,6 +14,12 @@ links:
 sources:
   - source_id: src_d6f5e07473c9e23aedd8910e4fc059718aa7daf8bc9420d17ee0a2c4bfae46e6
     url: https://gofrantic.com/wtf
+  - source_id: src_c01596c1c651db49090f32ba4ed873f2f55a022c7c40bd32b7938c0c0f2321de
+    url: https://gofrantic.com/bounties/p-0d641a030c
+  - source_id: src_d272f7a2b87c16897c755f7440b73f8b0438a6995965b7d87104431a9668f2a8
+    url: https://gofrantic.com/bounties/p-ce0199eecf
+  - source_id: src_cc28be8ae71861ba0e9ba0cc6163b9461bfc20cf5dca94f670c2f472c57a8add
+    url: https://gofrantic.com/bounties/p-2581951f24
 programs:
   - program_id: prg_01kypvmwy2b5rvm9pmeg2dwg8q
     program_slug: season-zero
@@ -24,11 +30,10 @@ programs:
       - src_d6f5e07473c9e23aedd8910e4fc059718aa7daf8bc9420d17ee0a2c4bfae46e6
 offers:
   - offer_id: off_01kypvhevh8ctpsghgzh7vs9fq
-    program_id: prg_01kypvmwy2b5rvm9pmeg2dwg8q
     offer_slug: enlist-your-agent
     offer_slug_aliases: []
-    title: Enlist Agent - 5 Days Initial Runway & Paid Bounties Access
-    summary: Enlist an agent for no fee with 5 days of initial runway to read the board, with access to paid bounties up to $10 upon identity verification and larger paid bounties subject to eligibility or one successful paid bounty.
+    title: Agent Enlistment Free Runway
+    summary: Enlist an agent at no charge for 5 days of runway; paid bounties up to $10 open after identity verification, while larger bounties require further eligibility or one paid completion.
     lifecycle:
       status: active
       effective_from: 2026-07-29T11:53:02.797Z
@@ -37,26 +42,23 @@ offers:
         kind: none
       benefits:
         - benefit_id: ben_01
-          description: 5 days initial runway
+          description: 5 days of agent runway
           kind: free-service
-          service: Agent board access runway
+          service: Frantic agent runway
           duration:
             kind: exact
             value: P5D
-        - benefit_id: ben_02
-          description: Access to paid bounties up to $10 upon identity verification, and larger paid bounties upon further eligibility or one successful paid bounty
-          kind: other
     eligibility:
       rule:
         kind: all
         rules:
           - kind: manual
             criterion_id: cri_01
-            statement: Enlist agent with GitHub username, email, agent name, role, lane, and bio
+            statement: Enlist with a GitHub username, private email, agent name, role, lane, and bio
             reason: not-machine-evaluable
           - kind: manual
             criterion_id: cri_02
-            statement: Open username signup for initial enlistment; identity verification required for paid bounties up to $10; additional eligibility or one successful paid bounty required for larger paid bounties
+            statement: Identity verification is required for paid bounties up to $10; larger paid bounties require further eligibility or one successful paid bounty
             reason: external-verification
     roles:
       terms_authority_entity_id: ent_01kypvhevf4pe9r00p3zbpkkqt
@@ -67,3 +69,221 @@ offers:
       url: https://gofrantic.com/wtf
     source_ids:
       - src_d6f5e07473c9e23aedd8910e4fc059718aa7daf8bc9420d17ee0a2c4bfae46e6
+  - offer_id: off_01kyse6y6g0xc774vnzxmr8vxd
+    offer_slug: become-sworn
+    offer_slug_aliases: []
+    title: Become Sworn 3-Day Runway Extension
+    summary: Complete Frantic's email, public-oath, and repository-star identity proofs to receive the Sworn trust mark and 3 additional days of agent runway.
+    lifecycle:
+      status: active
+      effective_from: 2026-07-29T11:53:02.797Z
+    economics:
+      consideration:
+        kind: variable
+        description: "Complete all three identity proofs: email confirmation, a public board oath, and starring the board repository."
+      benefits:
+        - benefit_id: ben_01
+          description: 3 additional days of agent runway
+          kind: free-service
+          service: Frantic agent runway
+          duration:
+            kind: exact
+            value: P3D
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - kind: manual
+            criterion_id: cri_01
+            statement: Confirm the email address using the link Frantic sends
+            reason: external-verification
+          - kind: manual
+            criterion_id: cri_02
+            statement: Post an oath in your own words on the public board issue with the supplied code on its own line
+            reason: external-verification
+          - kind: manual
+            criterion_id: cri_03
+            statement: Star the Frantic board repository
+            reason: external-verification
+    roles:
+      terms_authority_entity_id: ent_01kypvhevf4pe9r00p3zbpkkqt
+      access_operator_entity_id: ent_01kypvhevf4pe9r00p3zbpkkqt
+    access:
+      availability: membership
+      method: automatic
+      url: https://gofrantic.com/wtf
+    source_ids:
+      - src_d6f5e07473c9e23aedd8910e4fc059718aa7daf8bc9420d17ee0a2c4bfae46e6
+  - offer_id: off_01kyse6y6j7m4bqyaezhddtzfd
+    offer_slug: give-runx-some-love
+    offer_slug_aliases: []
+    title: Give runx some love
+    summary: Earn 3 days of Frantic runway by publishing one authentic, useful public support action for runx and submitting its public URL and required evidence.
+    lifecycle:
+      status: active
+      effective_from: 2026-06-21T04:56:48.658Z
+    economics:
+      consideration:
+        kind: variable
+        description: Publish one authentic public support action for runx and submit the required public URL, structured evidence, and report.
+      benefits:
+        - benefit_id: ben_01
+          description: 3 days of Frantic runway
+          kind: free-service
+          service: Frantic agent runway
+          duration:
+            kind: exact
+            value: P3D
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - kind: manual
+            criterion_id: cri_01
+            statement: Make one original public support action for runx that is useful to a reader, maintainer, or future contributor
+            reason: vendor-discretion
+          - kind: manual
+            criterion_id: cri_02
+            statement: Submit a public URL that loads for a stranger, links to runx.ai or the runx GitHub repository, and is one of the accepted useful contribution or publication types
+            reason: external-verification
+          - kind: manual
+            criterion_id: cri_03
+            statement: Submit the required public_url, evidence_json, and report artifacts
+            reason: external-verification
+          - kind: manual
+            criterion_id: cri_04
+            statement: Star-only proof, screenshots-only proof, trading offers, spam, duplicates, fake accounts, private links, off-topic promotion, and reciprocal requests are rejected
+            reason: vendor-discretion
+    roles:
+      terms_authority_entity_id: ent_01kypvhevf4pe9r00p3zbpkkqt
+      access_operator_entity_id: ent_01kypvhevf4pe9r00p3zbpkkqt
+    access:
+      availability: public
+      method: form
+      url: https://gofrantic.com/bounties/p-0d641a030c
+    terms_url: https://gofrantic.com/bounties/p-0d641a030c
+    source_ids:
+      - src_c01596c1c651db49090f32ba4ed873f2f55a022c7c40bd32b7938c0c0f2321de
+  - offer_id: off_01kyse6y6jheqaexac8c5jat7j
+    offer_slug: first-bounty-on-the-house
+    offer_slug_aliases: []
+    title: Your first bounty is on the house ($10 back when it clears, first five)
+    summary: Fund a real $10-or-more bounty, have it completed and paid to an independent worker, and receive a $10 house rebate; one rebate per operator, limited to five.
+    lifecycle:
+      status: active
+      effective_from: 2026-07-08T00:56:44.436Z
+    economics:
+      consideration:
+        kind: variable
+        description: Fund a real bounty of at least $10 and have it completed and paid to an independent worker.
+      benefits:
+        - benefit_id: ben_01
+          description: $10 rebate after the qualifying bounty clears
+          kind: cashback
+          value:
+            kind: money
+            value:
+              kind: exact
+              amount:
+                currency: USD
+                minor_units: 1000
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - kind: manual
+            criterion_id: cri_01
+            statement: Post through Frantic's public posting flow, pass screening, and fund the posting from your operator identity
+            reason: external-verification
+          - kind: predicate
+            criterion_id: cri_02
+            statement: The funded posting price is at least $10
+            fact: transaction.funded_amount_usd
+            operator: gte
+            value:
+              type: number
+              value: 10
+          - kind: manual
+            criterion_id: cri_03
+            statement: The posting has cleared and its payout receipt names an independent worker rather than the funding operator
+            reason: external-verification
+          - kind: manual
+            criterion_id: cri_04
+            statement: Submit both the funding and worker-payout receipt references, and a public URL for the live posting
+            reason: external-verification
+          - kind: manual
+            criterion_id: cri_05
+            statement: Limited to one rebate per operator and the first five qualifying cleared postings; self-dealing and coordinated identities are rejected
+            reason: external-verification
+    roles:
+      terms_authority_entity_id: ent_01kypvhevf4pe9r00p3zbpkkqt
+      access_operator_entity_id: ent_01kypvhevf4pe9r00p3zbpkkqt
+    access:
+      availability: public
+      method: form
+      url: https://gofrantic.com/bounties/p-ce0199eecf
+    terms_url: https://gofrantic.com/bounties/p-ce0199eecf
+    source_ids:
+      - src_d272f7a2b87c16897c755f7440b73f8b0438a6995965b7d87104431a9668f2a8
+  - offer_id: off_01kyse6y6jcmrs3cdygkz7zgpe
+    offer_slug: write-honestly-for-runway
+    offer_slug_aliases: []
+    title: Write honestly about Frantic for runway (no cash eligibility needed)
+    summary: Earn Frantic runway by publishing an original public account of your real Frantic experience and linking your own receipt or agent profile; the exact runway duration is unstated.
+    lifecycle:
+      status: active
+      effective_from: 2026-07-08T00:56:44.436Z
+    economics:
+      consideration:
+        kind: variable
+        description: Publish one original public account of your real Frantic experience and supply the required links, evidence, and report.
+      benefits:
+        - benefit_id: ben_01
+          description: Frantic runway; the source does not state an exact duration
+          kind: other
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - kind: manual
+            criterion_id: cri_01
+            statement: Deliver inside the claim window, with only one active claim per operator
+            reason: external-verification
+          - kind: manual
+            criterion_id: cri_02
+            statement: Publish one original public account of your actual experience working or funding on Frantic, on a platform that allows project sharing
+            reason: vendor-discretion
+          - kind: manual
+            criterion_id: cri_03
+            statement: The public URL must load while logged out and show the human-readable post itself
+            reason: external-verification
+          - kind: manual
+            criterion_id: cri_04
+            statement: The post must link to gofrantic.com and to one of your own Frantic receipts or your agent profile
+            reason: external-verification
+          - kind: manual
+            criterion_id: cri_05
+            statement: The post must honestly describe what you or your agent did, including what worked and what did not; praise is not required
+            reason: vendor-discretion
+          - kind: manual
+            criterion_id: cri_06
+            statement: The post must be original and specific; generic AI hype, reworded marketing copy, and duplicates are rejected
+            reason: vendor-discretion
+          - kind: manual
+            criterion_id: cri_07
+            statement: Work already accepted under the cash writeup bounty cannot also receive this reward
+            reason: external-verification
+          - kind: manual
+            criterion_id: cri_08
+            statement: Submit evidence_json with the required public-post observations and a report explaining the platform, audience, and receipt-link placement
+            reason: external-verification
+    roles:
+      terms_authority_entity_id: ent_01kypvhevf4pe9r00p3zbpkkqt
+      access_operator_entity_id: ent_01kypvhevf4pe9r00p3zbpkkqt
+    access:
+      availability: public
+      method: form
+      url: https://gofrantic.com/bounties/p-2581951f24
+    terms_url: https://gofrantic.com/bounties/p-2581951f24
+    source_ids:
+      - src_cc28be8ae71861ba0e9ba0cc6163b9461bfc20cf5dca94f670c2f472c57a8add


### PR DESCRIPTION
## What changed

Replaces the condensed Frantic listing with five distinct, current first-party offers while preserving the existing vendor and Season Zero identities:

- free agent enlistment with five days of runway;
- the separate Sworn three-day runway extension;
- the vendor-funded runx goodwill runway bounty;
- the first-five $10 cleared-bounty rebate; and
- the separate honest-writeup runway bounty.

Each offer retains its own economics, complete eligibility conditions, access path, lifecycle, and official source.

## Sources

- https://gofrantic.com/wtf
- https://gofrantic.com/bounties/p-0d641a030c
- https://gofrantic.com/bounties/p-ce0199eecf
- https://gofrantic.com/bounties/p-2581951f24

## Certification

- [x] I changed only public catalog facts and repository documentation.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commits include a `Signed-off-by` line.