### PR TITLE
data: add reviewed startup offers slice 1

### DIFF
--- a/vendors/ag/agenta.yaml
+++ b/vendors/ag/agenta.yaml
@@ -1,0 +1,51 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyy3083t4kpnqzc9xp0acpf2
+slug: agenta
+slug_aliases: []
+name: Agenta
+domains:
+  - value: agenta.ai
+    role: primary
+    valid_from: 2026-08-01T06:40:08.661Z
+category: devtools-other
+description: Open-source agent workspace with prompt management, evaluation, and observability.
+links:
+  site: https://agenta.ai
+sources:
+  - source_id: src_3e71879f94b2a315503688d82fb5a8e88ca1dd69c541c214c14d2f11daabf736
+    url: https://agenta.ai/pricing
+programs: []
+offers:
+  - offer_id: off_01kyy3083w3k33krxmrqx1kr3q
+    offer_slug: startup-student-researcher-discount
+    offer_slug_aliases: []
+    access:
+      availability: public
+      method: contact
+      url: https://agenta.ai/pricing
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Discounted or free access to Agenta.
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: any
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: vendor-discretion
+            statement: Applicant is an early-stage startup, student, or researcher.
+    lifecycle:
+      effective_from: 2026-08-01T06:40:08.661Z
+      status: active
+    roles:
+      terms_authority_entity_id: ent_01kyy3083t4kpnqzc9xp0acpf2
+      access_operator_entity_id: ent_01kyy3083t4kpnqzc9xp0acpf2
+    summary: Early-stage startups, students, and researchers can email Agenta to request discounted or free access by sharing what they are building and how they plan to use Agenta.
+    terms_url: https://agenta.ai/pricing
+    title: Discounted or Free Access for Startups, Students, and Researchers
+    source_ids:
+      - src_3e71879f94b2a315503688d82fb5a8e88ca1dd69c541c214c14d2f11daabf736

--- a/vendors/ar/archbee.yaml
+++ b/vendors/ar/archbee.yaml
@@ -1,0 +1,68 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyy3083w3k33krxmrqx1kr43
+slug: archbee
+slug_aliases: []
+name: Archbee
+domains:
+  - value: archbee.com
+    role: primary
+    valid_from: 2026-08-01T07:03:40.270Z
+category: devtools-other
+description: Knowledge portal platform for creating, managing, and sharing external and internal documentation.
+links:
+  site: https://www.archbee.com
+sources:
+  - source_id: src_f282545a7eecaddec966984fc10e581a19f30b641e7058bf7efccc309ac7738a
+    url: https://www.archbee.com/pricing
+programs:
+  - program_id: prg_01kyy34e2e59kg833c1jzmrvgk
+    program_slug: startup-program
+    program_slug_aliases: []
+    title: Startup Program
+    summary: 50% discount on any plan for 2 years for early-stage companies.
+    source_ids:
+      - src_f282545a7eecaddec966984fc10e581a19f30b641e7058bf7efccc309ac7738a
+offers:
+  - offer_id: off_01kyy3083w3k33krxmrqx1kr44
+    program_id: prg_01kyy34e2e59kg833c1jzmrvgk
+    offer_slug: startup-program
+    offer_slug_aliases: []
+    access:
+      availability: public
+      method: form
+      url: https://www.archbee.com/pricing
+    economics:
+      benefits:
+        - applies_to: Any Archbee plan
+          benefit_id: ben_01
+          description: 50% discount on any plan for 2 years
+          duration:
+            kind: exact
+            value: P2Y
+          kind: discount
+          percentage:
+            basis_points: 5000
+            kind: exact
+      consideration:
+        description: Selected Archbee plan subscription
+        kind: unknown
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        fact: company.stage
+        kind: predicate
+        operator: eq
+        statement: Company must be an early-stage product & company
+        value:
+          type: string
+          value: early-stage
+    lifecycle:
+      effective_from: 2026-08-01T07:03:40.270Z
+      status: active
+    roles:
+      terms_authority_entity_id: ent_01kyy3083w3k33krxmrqx1kr43
+      access_operator_entity_id: ent_01kyy3083w3k33krxmrqx1kr43
+    summary: Early-stage product companies get a 50% discount on any Archbee plan for 2 years.
+    title: Archbee Startup Program
+    source_ids:
+      - src_f282545a7eecaddec966984fc10e581a19f30b641e7058bf7efccc309ac7738a

--- a/vendors/ch/checkly.yaml
+++ b/vendors/ch/checkly.yaml
@@ -1,0 +1,56 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyy3083w3k33krxmrqx1kr3r
+slug: checkly
+slug_aliases: []
+name: Checkly
+domains:
+  - value: checklyhq.com
+    role: primary
+    valid_from: 2026-08-01T06:47:55.295Z
+category: observability
+description: Synthetic monitoring, uptime monitoring, and alerting for APIs, websites, and applications, defined and deployed as monitoring-as-code.
+links:
+  site: https://www.checklyhq.com
+sources:
+  - source_id: src_8d51763913c4bee6156f8e1c68c2540161d4d727b0d81d4da91c33ff729b4d12
+    url: https://www.checklyhq.com/pricing
+programs: []
+offers:
+  - offer_id: off_01kyy3083w3k33krxmrqx1kr3s
+    offer_slug: startup-discount
+    offer_slug_aliases: []
+    access:
+      availability: public
+      method: form
+      url: https://www.checklyhq.com/pricing/
+    economics:
+      benefits:
+        - applies_to: all plans
+          benefit_id: ben_01
+          description: 30% discount on all Checkly plans
+          kind: discount
+          percentage:
+            basis_points: 3000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        fact: company.age_months
+        kind: predicate
+        operator: lt
+        statement: Company must be an early-stage startup younger than two years.
+        value:
+          type: number
+          value: 24
+    lifecycle:
+      effective_from: 2026-08-01T06:47:55.295Z
+      status: active
+    roles:
+      terms_authority_entity_id: ent_01kyy3083w3k33krxmrqx1kr3r
+      access_operator_entity_id: ent_01kyy3083w3k33krxmrqx1kr3r
+    summary: Early-stage startups younger than two years get a 30% discount on all Checkly plans.
+    title: Checkly Startup Discount
+    source_ids:
+      - src_8d51763913c4bee6156f8e1c68c2540161d4d727b0d81d4da91c33ff729b4d12

--- a/vendors/co/configcat.yaml
+++ b/vendors/co/configcat.yaml
@@ -1,0 +1,111 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyy3083w3k33krxmrqx1kr45
+slug: configcat
+slug_aliases: []
+name: ConfigCat
+domains:
+  - value: configcat.com
+    role: primary
+    valid_from: 2026-08-01T06:57:54.944Z
+category: devtools-other
+description: ConfigCat is a feature flag service for teams with unlimited seats, awesome support, and a reasonable price tag.
+links:
+  site: https://configcat.com/
+sources:
+  - source_id: src_2751dfe5080d170834dfe4e9da4d51737ee8a819d84b85c926f21d80d376c14c
+    url: https://configcat.com/startup-program
+programs:
+  - program_id: prg_01kyy34e2g5qnaej7jz1vx37ab
+    program_slug: startup-program
+    program_slug_aliases: []
+    title: ConfigCat Startup Program
+    summary: ConfigCat Startup Program offers early-stage startups discounted access to feature flag plans along with early feature access in exchange for community feedback.
+    source_ids:
+      - src_2751dfe5080d170834dfe4e9da4d51737ee8a819d84b85c926f21d80d376c14c
+offers:
+  - offer_id: off_01kyy3083w3k33krxmrqx1kr46
+    program_id: prg_01kyy34e2g5qnaej7jz1vx37ab
+    offer_slug: startup-program
+    offer_slug_aliases: []
+    access:
+      availability: public
+      method: form
+      url: https://configcat.com/startup-program/
+    economics:
+      benefits:
+        - applies_to: ConfigCat Pro or Smart annual plans
+          benefit_id: ben_01
+          description: 50% off ConfigCat Pro or Smart annual plans during your first year.
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            basis_points: 5000
+            kind: exact
+        - applies_to: ConfigCat Pro or Smart annual plans
+          benefit_id: ben_02
+          description: 25% off ConfigCat Pro or Smart annual plans in your second year upon completing agreed feedback commitments.
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            basis_points: 2500
+            kind: exact
+        - benefit_id: ben_03
+          description: Early access to upcoming feature flag capabilities and platform improvements.
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: Your company was founded less than 5 years ago
+            value:
+              type: number
+              value: 60
+          - criterion_id: cri_02
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: You've raised under $5M USD in total funding
+            value:
+              type: number
+              value: 5000000
+          - criterion_id: cri_03
+            fact: company.has_live_product
+            kind: predicate
+            operator: eq
+            statement: You have a live website or product
+            value:
+              type: boolean
+              value: true
+          - criterion_id: cri_04
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: You haven't had a paid ConfigCat subscription in the past 12 months
+            value:
+              type: boolean
+              value: false
+          - criterion_id: cri_05
+            kind: manual
+            reason: not-machine-evaluable
+            statement: Sharing an honest public review on platforms like G2, TrustRadius or Trustpilot, contributing a short case study, and providing occasional feedback through surveys or short conversations to receive the second-year discount.
+    lifecycle:
+      effective_from: 2026-08-01T06:57:54.944Z
+      status: active
+    roles:
+      terms_authority_entity_id: ent_01kyy3083w3k33krxmrqx1kr45
+      access_operator_entity_id: ent_01kyy3083w3k33krxmrqx1kr45
+    summary: Eligible early-stage startups receive 50% off Pro or Smart annual plans in Year 1, 25% off in Year 2 upon completing partner feedback commitments, and early access to new features.
+    terms_url: https://configcat.com/startup-program/
+    title: ConfigCat Startup Program
+    source_ids:
+      - src_2751dfe5080d170834dfe4e9da4d51737ee8a819d84b85c926f21d80d376c14c

--- a/vendors/gu/guepard.yaml
+++ b/vendors/gu/guepard.yaml
@@ -1,0 +1,101 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyy3083w3k33krxmrqx1kr47
+slug: guepard
+slug_aliases: []
+name: Guepard
+domains:
+  - value: guepard.run
+    role: primary
+    valid_from: 2026-08-01T06:59:23.794Z
+category: databases
+description: Ephemeral databases for humans and agents.
+links:
+  site: https://guepard.run
+sources:
+  - source_id: src_c24dba9f1aa5796b6330f8a83fd6b65560961206338d6398acebcbccf87df563
+    url: https://guepard.run/startups
+programs:
+  - program_id: prg_01kyy34e2g5qnaej7jz1vx37ac
+    program_slug: startup-program
+    program_slug_aliases: []
+    title: Guepard for Startups
+    summary: Guepard for Startups gives eligible early-stage software companies platform credits and direct access to the team.
+    source_ids:
+      - src_c24dba9f1aa5796b6330f8a83fd6b65560961206338d6398acebcbccf87df563
+offers:
+  - offer_id: off_01kyy3083w3k33krxmrqx1kr48
+    program_id: prg_01kyy34e2g5qnaej7jz1vx37ac
+    offer_slug: startup-program
+    offer_slug_aliases: []
+    access:
+      availability: public
+      method: form
+      url: https://guepard.run/startups
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $30,000 in platform credits
+          duration:
+            kind: exact
+            value: P1Y
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 3000000
+            kind: up-to
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.stage
+            kind: predicate
+            operator: in
+            statement: Early-stage companies at Series A or earlier
+            value:
+              type: string-set
+              values:
+                - pre-seed
+                - seed
+                - series-a
+          - criterion_id: cri_02
+            fact: company.employee_count
+            kind: predicate
+            operator: lt
+            statement: Typically under 20 employees
+            value:
+              type: number
+              value: 20
+          - criterion_id: cri_03
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: Less than 3 years old
+            value:
+              type: number
+              value: 36
+          - criterion_id: cri_04
+            kind: manual
+            reason: not-machine-evaluable
+            statement: You need a live product or MVP
+          - criterion_id: cri_05
+            kind: manual
+            reason: external-verification
+            statement: Verifiable company profile
+          - criterion_id: cri_06
+            kind: manual
+            reason: not-machine-evaluable
+            statement: Must be building software (not an agency or dev shop)
+    lifecycle:
+      effective_from: 2026-08-01T06:59:23.794Z
+      status: active
+    roles:
+      terms_authority_entity_id: ent_01kyy3083w3k33krxmrqx1kr47
+      access_operator_entity_id: ent_01kyy3083w3k33krxmrqx1kr47
+    summary: Up to $30,000 in Guepard platform credits for one year for eligible early-stage startups.
+    title: Guepard for Startups
+    source_ids:
+      - src_c24dba9f1aa5796b6330f8a83fd6b65560961206338d6398acebcbccf87df563

--- a/vendors/he/helicone.yaml
+++ b/vendors/he/helicone.yaml
@@ -1,0 +1,68 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyy3083w3k33krxmrqx1kr3y
+slug: helicone
+slug_aliases: []
+name: Helicone
+domains:
+  - value: helicone.ai
+    role: primary
+    valid_from: 2026-08-01T06:42:24.370Z
+category: observability
+description: Usage-based pricing that scales with you. Ship your AI app with confidence.
+links:
+  site: https://helicone.ai/pricing
+sources:
+  - source_id: src_08748e1772018d22159b79a5bb6028806188d25f8fb84b3e68fa7554606b6a6b
+    url: https://helicone.ai/pricing
+programs: []
+offers:
+  - offer_id: off_01kyy3083w3k33krxmrqx1kr3z
+    offer_slug: startup-discount
+    offer_slug_aliases: []
+    access:
+      availability: public
+      method: form
+      url: https://helicone.ai/pricing
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: 50% off first year
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            basis_points: 5000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: Startup is under 2 years old
+            value:
+              type: number
+              value: 24
+          - criterion_id: cri_02
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: Startup has raised less than $5M in funding
+            value:
+              type: number
+              value: 5000000
+    lifecycle:
+      effective_from: 2026-08-01T06:42:24.370Z
+      status: active
+    roles:
+      terms_authority_entity_id: ent_01kyy3083w3k33krxmrqx1kr3y
+      access_operator_entity_id: ent_01kyy3083w3k33krxmrqx1kr3y
+    summary: Eligible startups under 2 years old with under $5M in funding receive 50% off their first year.
+    title: Startups Discount
+    source_ids:
+      - src_08748e1772018d22159b79a5bb6028806188d25f8fb84b3e68fa7554606b6a6b

--- a/vendors/ma/mathworks.yaml
+++ b/vendors/ma/mathworks.yaml
@@ -1,0 +1,128 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyy3083w3k33krxmrqx1kr49
+slug: mathworks
+slug_aliases: []
+name: MathWorks
+domains:
+  - value: mathworks.com
+    role: primary
+    valid_from: 2026-08-01T07:07:51.497Z
+category: devtools-other
+description: MathWorks is the leading developer of mathematical computing software for engineers and scientists.
+links:
+  site: https://www.mathworks.com/products/startups.html
+sources:
+  - source_id: src_3b83e62c852dbbf91a7d58a7f8372156d657bf8ddeb387125048874a39c634ef
+    url: https://www.mathworks.com/products/startups.html
+programs:
+  - program_id: prg_01kyy33f479f70d96vrf3y53cc
+    program_slug: startup-program
+    program_slug_aliases: []
+    title: MathWorks Startup Program
+    summary: Program providing early-stage startups low-cost access to MATLAB and Simulink suites, technical support, discounted training, and accelerator partnerships.
+    source_ids:
+      - src_3b83e62c852dbbf91a7d58a7f8372156d657bf8ddeb387125048874a39c634ef
+offers:
+  - offer_id: off_01kyy3083w3k33krxmrqx1kr4b
+    program_id: prg_01kyy33f479f70d96vrf3y53cc
+    offer_slug: startup-program
+    offer_slug_aliases: []
+    access:
+      availability: public
+      method: form
+      url: https://www.mathworks.com/products/startups.html
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Low startup pricing on MATLAB Suite or MATLAB and Simulink Suite annual individual licenses with add-on products
+          kind: other
+        - benefit_id: ben_02
+          description: Free access to the Online Training Suite Subscription for suite license holders
+          kind: free-service
+          service: Online Training Suite Subscription
+        - applies_to: Training credits
+          benefit_id: ben_03
+          description: 50% off training credits
+          kind: discount
+          percentage:
+            basis_points: 5000
+            kind: exact
+        - benefit_id: ben_04
+          description: Support from application engineers and technical support, and co-marketing opportunities
+          kind: other
+      consideration:
+        description: Low startup pricing (exact amounts vary by suite option selected)
+        kind: unknown
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.age_months
+            kind: predicate
+            operator: lte
+            statement: Company was founded within the last 5 years
+            value:
+              type: number
+              value: 60
+          - criterion_id: cri_02
+            fact: company.employee_count
+            kind: predicate
+            operator: lt
+            statement: Fewer than 15 engineers
+            value:
+              type: number
+              value: 15
+          - criterion_id: cri_03
+            fact: company.annual_revenue_usd
+            kind: predicate
+            operator: lt
+            statement: Less than $1 million USD in annual revenue
+            value:
+              type: number
+              value: 1000000
+    lifecycle:
+      effective_from: 2026-08-01T07:07:51.497Z
+      status: active
+    roles:
+      terms_authority_entity_id: ent_01kyy3083w3k33krxmrqx1kr49
+      access_operator_entity_id: ent_01kyy3083w3k33krxmrqx1kr49
+    summary: Eligible early-stage startups get low startup pricing on MATLAB and Simulink product suites, technical support, 50% off training credits, and co-marketing opportunities.
+    title: MathWorks Startup Program
+    source_ids:
+      - src_3b83e62c852dbbf91a7d58a7f8372156d657bf8ddeb387125048874a39c634ef
+  - offer_id: off_01kyy3083w3k33krxmrqx1kr4a
+    program_id: prg_01kyy33f479f70d96vrf3y53cc
+    offer_slug: accelerator-program
+    offer_slug_aliases: []
+    access:
+      availability: membership
+      method: other
+      url: https://www.mathworks.com/products/startups.html
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Free licensing to startups via accelerator partnerships
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        fact: company.partner_memberships
+        kind: predicate
+        operator: contains
+        statement: Must be a startup affiliated with a partnered accelerator (over 500 partner accelerators)
+        value:
+          type: string
+          value: partnered_accelerator
+    lifecycle:
+      effective_from: 2026-08-01T07:07:51.497Z
+      status: active
+    roles:
+      terms_authority_entity_id: ent_01kyy3083w3k33krxmrqx1kr49
+      access_operator_entity_id: ent_01kyy3083w3k33krxmrqx1kr49
+    summary: Free MATLAB and Simulink licensing for startups participating in partnered accelerators.
+    title: MathWorks Accelerator Program
+    source_ids:
+      - src_3b83e62c852dbbf91a7d58a7f8372156d657bf8ddeb387125048874a39c634ef

--- a/vendors/nv/nvidia.yaml
+++ b/vendors/nv/nvidia.yaml
@@ -1,0 +1,154 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyy3083w3k33krxmrqx1kr4c
+slug: nvidia
+slug_aliases: []
+name: NVIDIA
+domains:
+  - value: nvidia.com
+    role: primary
+    valid_from: 2026-08-01T07:07:27.100Z
+category: ai-ml
+description: NVIDIA Inception is a free program designed to nurture startups, providing co-marketing support, and opportunities to connect with NVIDIA experts.
+links:
+  site: https://www.nvidia.com/en-us/startups
+sources:
+  - source_id: src_f7c1020816fa353e5a80ce3916288595bf4779b64b7d7163ca19626fab3a7844
+    url: https://www.nvidia.com/en-us/startups
+programs:
+  - program_id: prg_01kyy34e2h771sj46tqgzsw431
+    program_slug: inception
+    program_slug_aliases: []
+    title: NVIDIA Inception Program
+    summary: NVIDIA Inception is a free program guiding AI startups from prototype to production with technical training, preferred pricing on hardware and software, partner cloud credits, and investor access.
+    source_ids:
+      - src_f7c1020816fa353e5a80ce3916288595bf4779b64b7d7163ca19626fab3a7844
+offers:
+  - offer_id: off_01kyy3083w3k33krxmrqx1kr4d
+    program_id: prg_01kyy34e2h771sj46tqgzsw431
+    offer_slug: inception-program
+    offer_slug_aliases: []
+    access:
+      availability: public
+      method: form
+      url: https://www.nvidia.com/en-us/startups/
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Preferred pricing on select enterprise-grade NVIDIA hardware and software (functioning as a rebate deducted from standard supplier price)
+          kind: other
+        - benefit_id: ben_02
+          description: Free self-paced technical courses through NVIDIA Deep Learning Institute
+          kind: free-service
+          service: Free self-paced technical courses through NVIDIA Deep Learning Institute
+        - benefit_id: ben_03
+          description: Discounted expert-led / instructor-led workshops through NVIDIA Deep Learning Institute
+          kind: other
+        - benefit_id: ben_04
+          description: Access to free cloud credits from NVIDIA and partners
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 0
+            kind: at-least
+        - benefit_id: ben_05
+          description: Exposure to investors in NVIDIA's VC network through Inception Capital Connect for eligible startups
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.employee_count
+            kind: predicate
+            operator: gte
+            statement: Company must employ at least one developer.
+            value:
+              type: number
+              value: 1
+          - criterion_id: cri_02
+            fact: company.website_status
+            kind: predicate
+            operator: eq
+            statement: Company must maintain a working website.
+            value:
+              type: string
+              value: working
+          - criterion_id: cri_03
+            fact: company.is_incorporated
+            kind: predicate
+            operator: eq
+            statement: Company must be officially incorporated.
+            value:
+              type: boolean
+              value: true
+          - criterion_id: cri_04
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: Company must be less than 10 years old.
+            value:
+              type: number
+              value: 120
+          - kind: not
+            rule:
+              criterion_id: cri_05
+              fact: company.industry
+              kind: predicate
+              operator: eq
+              statement: Consulting and outsourced development firms do not qualify.
+              value:
+                type: string
+                value: consulting_or_outsourced_development
+          - kind: not
+            rule:
+              criterion_id: cri_06
+              fact: company.industry
+              kind: predicate
+              operator: eq
+              statement: Companies associated with cryptocurrency do not qualify.
+              value:
+                type: string
+                value: cryptocurrency
+          - kind: not
+            rule:
+              criterion_id: cri_07
+              fact: company.industry
+              kind: predicate
+              operator: eq
+              statement: Cloud service providers do not qualify.
+              value:
+                type: string
+                value: cloud_service_provider
+          - kind: not
+            rule:
+              criterion_id: cri_08
+              fact: company.business_model
+              kind: predicate
+              operator: eq
+              statement: Resellers and distributors do not qualify.
+              value:
+                type: string
+                value: reseller_or_distributor
+          - kind: not
+            rule:
+              criterion_id: cri_09
+              fact: company.is_public
+              kind: predicate
+              operator: eq
+              statement: Public companies do not qualify.
+              value:
+                type: boolean
+                value: true
+    lifecycle:
+      effective_from: 2026-08-01T07:07:27.100Z
+      status: active
+    roles:
+      terms_authority_entity_id: ent_01kyy3083w3k33krxmrqx1kr4c
+      access_operator_entity_id: ent_01kyy3083w3k33krxmrqx1kr4c
+    summary: Free membership program for AI, data science, and HPC startups offering preferred pricing on select NVIDIA hardware and software, free self-paced courses, cloud credits, and investor exposure.
+    title: NVIDIA Inception Program for Startups
+    source_ids:
+      - src_f7c1020816fa353e5a80ce3916288595bf4779b64b7d7163ca19626fab3a7844

--- a/vendors/re/resend.yaml
+++ b/vendors/re/resend.yaml
@@ -17,33 +17,104 @@ sources:
 programs: []
 offers:
   - offer_id: off_01kyh8fpe58md549t4y2367ghd
-    offer_slug: resend-yc-deal
-    offer_slug_aliases: []
-    title: Resend YC Deal
-    summary: Current YC batch startups receive $25,000 in credits for 12 months, while YC alumni receive $15,000 in credits. Includes a dedicated Slack channel with the Resend team.
-    lifecycle:
-      status: active
-      effective_from: 2026-07-27T07:43:12.688Z
+    offer_slug: current-yc-batch-credits
+    offer_slug_aliases:
+      - resend-yc-deal
+    access:
+      availability: membership
+      instructions: Get your YC verification link to claim deal.
+      method: form
+      url: https://resend.com/yc
     economics:
-      consideration:
-        kind: unknown
-        description: The source record did not establish separate consideration.
       benefits:
-        - benefit_id: ben_primary
-          description: $25,000 credits (current batch) or $15,000 credits (alumni)
+        - benefit_id: ben_01
+          description: $25,000 in credits for 12 months
+          duration:
+            kind: exact
+            value: P1Y
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 2500000
+            kind: exact
+        - benefit_id: ben_02
+          description: Dedicated Slack channel with the founders and engineers
           kind: other
+        - benefit_id: ben_03
+          description: Feature your company as a use case on the Resend website (optional)
+          kind: other
+        - benefit_id: ben_04
+          description: Direct access to the CEO's phone number on WhatsApp or text
+          kind: other
+      consideration:
+        kind: none
     eligibility:
       rule:
-        kind: manual
-        criterion_id: cri_requirement_01
-        statement: Must be a YC startup in the current batch or a YC alumni company.
-        reason: not-machine-evaluable
+        criterion_id: cri_01
+        fact: company.partner_memberships
+        kind: predicate
+        operator: contains
+        statement: Must be a company in the current YC batch.
+        value:
+          type: string
+          value: YC current batch
+    lifecycle:
+      effective_from: 2026-08-01T06:45:24.386Z
+      status: active
     roles:
       terms_authority_entity_id: ent_01kyh8fpe5xfhy18q4ccs4a07n
       access_operator_entity_id: ent_01kyh8fpe5xfhy18q4ccs4a07n
+    summary: Current YC batch startups receive $25,000 in Resend credits for 12 months, along with a dedicated Slack channel, optional website feature, and direct access to the CEO's phone number.
+    title: $25,000 in credits for current YC batch
+    source_ids:
+      - src_237675ce6a4816ed8dc73a67ef2aa59013ce648c281704b0ea6208fb5afd73dc
+  - offer_id: off_01kyy3083w3k33krxmrqx1kr41
+    offer_slug: yc-alumni-credits
+    offer_slug_aliases: []
     access:
-      availability: public
+      availability: membership
+      instructions: Get your YC verification link to claim deal.
       method: form
       url: https://resend.com/yc
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: $15,000 in credits for YC alumni
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 1500000
+            kind: exact
+        - benefit_id: ben_02
+          description: Dedicated Slack channel with the founders and engineers
+          kind: other
+        - benefit_id: ben_03
+          description: Feature your company as a use case on the Resend website (optional)
+          kind: other
+        - benefit_id: ben_04
+          description: Direct access to the CEO's phone number on WhatsApp or text
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        fact: company.partner_memberships
+        kind: predicate
+        operator: contains
+        statement: Must be a YC alumni company.
+        value:
+          type: string
+          value: YC alumni
+    lifecycle:
+      effective_from: 2026-08-01T06:45:24.386Z
+      status: active
+    roles:
+      terms_authority_entity_id: ent_01kyh8fpe5xfhy18q4ccs4a07n
+      access_operator_entity_id: ent_01kyh8fpe5xfhy18q4ccs4a07n
+    summary: YC alumni companies receive $15,000 in Resend credits, along with a dedicated Slack channel, optional website feature, and direct access to the CEO's phone number.
+    title: $15,000 in credits for YC alumni
     source_ids:
       - src_237675ce6a4816ed8dc73a67ef2aa59013ce648c281704b0ea6208fb5afd73dc

--- a/vendors/st/stream.yaml
+++ b/vendors/st/stream.yaml
@@ -1,0 +1,114 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyy3083w3k33krxmrqx1kr3t
+slug: stream
+slug_aliases: []
+name: Stream
+domains:
+  - value: getstream.io
+    role: primary
+    valid_from: 2026-08-01T06:41:47.766Z
+category: communication
+description: Stream provides APIs and SDKs to build chat messaging, activity feeds, video and audio calling, and content moderation.
+links:
+  site: https://getstream.io
+sources:
+  - source_id: src_74aa65916bac8aee9d14b901778840e2d0aee544eebd1ecc0d33baf0bafe6012
+    url: https://getstream.io/partners
+programs: []
+offers:
+  - offer_id: off_01kyy3083w3k33krxmrqx1kr3w
+    offer_slug: yc-under-3m-discount
+    offer_slug_aliases: []
+    access:
+      availability: membership
+      method: form
+      url: https://getstream.io/partners/
+    economics:
+      benefits:
+        - applies_to: Stream APIs
+          benefit_id: ben_01
+          description: 25% discount on Stream APIs
+          kind: discount
+          percentage:
+            basis_points: 2500
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.partner_memberships
+            kind: predicate
+            operator: contains
+            statement: Must be a Y Combinator startup
+            value:
+              type: string
+              value: Y Combinator
+          - criterion_id: cri_02
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: Must have raised under $3,000,000 in funding
+            value:
+              type: number
+              value: 3000000
+    lifecycle:
+      effective_from: 2026-08-01T06:41:47.766Z
+      status: active
+    roles:
+      terms_authority_entity_id: ent_01kyy3083w3k33krxmrqx1kr3t
+      access_operator_entity_id: ent_01kyy3083w3k33krxmrqx1kr3t
+    summary: Y Combinator startups that have raised under $3M receive 25% off Stream Chat, Video, Feeds, and Moderation APIs.
+    title: Stream x YC Discount (Under $3M Raised)
+    source_ids:
+      - src_74aa65916bac8aee9d14b901778840e2d0aee544eebd1ecc0d33baf0bafe6012
+  - offer_id: off_01kyy3083w3k33krxmrqx1kr3x
+    offer_slug: yc-under-10m-discount
+    offer_slug_aliases: []
+    access:
+      availability: membership
+      method: form
+      url: https://getstream.io/partners/
+    economics:
+      benefits:
+        - applies_to: Stream APIs
+          benefit_id: ben_01
+          description: 15% discount on Stream APIs
+          kind: discount
+          percentage:
+            basis_points: 1500
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.partner_memberships
+            kind: predicate
+            operator: contains
+            statement: Must be a Y Combinator startup
+            value:
+              type: string
+              value: Y Combinator
+          - criterion_id: cri_02
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: Must have raised under $10,000,000 in funding
+            value:
+              type: number
+              value: 10000000
+    lifecycle:
+      effective_from: 2026-08-01T06:41:47.766Z
+      status: active
+    roles:
+      terms_authority_entity_id: ent_01kyy3083w3k33krxmrqx1kr3t
+      access_operator_entity_id: ent_01kyy3083w3k33krxmrqx1kr3t
+    summary: Y Combinator startups that have raised under $10M receive 15% off Stream Chat, Video, Feeds, and Moderation APIs.
+    title: Stream x YC Discount (Under $10M Raised)
+    source_ids:
+      - src_74aa65916bac8aee9d14b901778840e2d0aee544eebd1ecc0d33baf0bafe6012

--- a/vendors/to/together-ai.yaml
+++ b/vendors/to/together-ai.yaml
@@ -1,0 +1,176 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyy3083w3k33krxmrqx1kr4e
+slug: together-ai
+slug_aliases: []
+name: Together AI
+domains:
+  - value: together.ai
+    role: primary
+    valid_from: 2026-08-01T07:08:27.771Z
+category: ai-ml
+description: Together AI gives startups the fastest path from idea to scale, across model training, fine-tuning, and inference, on the most performant and cost-efficient platform.
+links:
+  site: https://www.together.ai
+sources:
+  - source_id: src_5cc27a2787e67f1c577d136f167c25d59b92eed9f0abd1b4f301ea2fb7996447
+    url: https://www.together.ai/startup-accelerator
+programs:
+  - program_id: prg_01kyy3083w3k33krxmrqx1kr4f
+    program_slug: startup-accelerator
+    program_slug_aliases: []
+    title: Together AI Startup Accelerator
+    summary: A targeted selection-based program for startups offering compute credits, forward-deployed engineering, exclusive content, joint GTM, community access, and VC network connections.
+    source_ids:
+      - src_5cc27a2787e67f1c577d136f167c25d59b92eed9f0abd1b4f301ea2fb7996447
+offers:
+  - offer_id: off_01kyy3083w3k33krxmrqx1kr4g
+    program_id: prg_01kyy3083w3k33krxmrqx1kr4f
+    offer_slug: build-tier
+    offer_slug_aliases: []
+    access:
+      availability: public
+      method: form
+      url: https://www.together.ai/startup-accelerator
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $15K in free platform credits (does not apply to Reserved GPU Clusters)
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 1500000
+            kind: up-to
+        - benefit_id: ben_02
+          description: 3 hours of free forward-deployed engineering time
+          duration:
+            kind: exact
+            value: PT3H
+          kind: free-service
+          service: forward-deployed engineering time
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        fact: company.funding_raised_usd
+        kind: predicate
+        operator: lte
+        statement: Startup has raised up to $5M
+        value:
+          type: number
+          value: 5000000
+    lifecycle:
+      effective_from: 2026-08-01T07:08:27.771Z
+      status: active
+    roles:
+      terms_authority_entity_id: ent_01kyy3083w3k33krxmrqx1kr4e
+      access_operator_entity_id: ent_01kyy3083w3k33krxmrqx1kr4e
+    summary: Build tier startups with up to $5M raised receive up to $15K in free platform credits and 3 hours of forward-deployed engineering time.
+    title: Together AI Startup Accelerator - Build Tier
+    source_ids:
+      - src_5cc27a2787e67f1c577d136f167c25d59b92eed9f0abd1b4f301ea2fb7996447
+  - offer_id: off_01kyy3083w3k33krxmrqx1kr4j
+    program_id: prg_01kyy3083w3k33krxmrqx1kr4f
+    offer_slug: grow-tier
+    offer_slug_aliases: []
+    access:
+      availability: public
+      method: form
+      url: https://www.together.ai/startup-accelerator
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $50K in free platform credits (does not apply to Reserved GPU Clusters)
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 5000000
+            kind: up-to
+        - benefit_id: ben_02
+          description: 10 hours of free forward-deployed engineering time
+          duration:
+            kind: exact
+            value: PT10H
+          kind: free-service
+          service: forward-deployed engineering time
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        fact: company.funding_raised_usd
+        kind: predicate
+        operator: gt
+        statement: Startup has raised over $10M
+        value:
+          type: number
+          value: 10000000
+    lifecycle:
+      effective_from: 2026-08-01T07:08:27.771Z
+      status: active
+    roles:
+      terms_authority_entity_id: ent_01kyy3083w3k33krxmrqx1kr4e
+      access_operator_entity_id: ent_01kyy3083w3k33krxmrqx1kr4e
+    summary: Grow tier startups with over $10M raised receive up to $50K in free platform credits and 10 hours of forward-deployed engineering time.
+    title: Together AI Startup Accelerator - Grow Tier
+    source_ids:
+      - src_5cc27a2787e67f1c577d136f167c25d59b92eed9f0abd1b4f301ea2fb7996447
+  - offer_id: off_01kyy3083w3k33krxmrqx1kr4h
+    program_id: prg_01kyy3083w3k33krxmrqx1kr4f
+    offer_slug: scale-tier
+    offer_slug_aliases: []
+    access:
+      availability: public
+      method: form
+      url: https://www.together.ai/startup-accelerator
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $30K in free platform credits (does not apply to Reserved GPU Clusters)
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 3000000
+            kind: up-to
+        - benefit_id: ben_02
+          description: 6 hours of free forward-deployed engineering time
+          duration:
+            kind: exact
+            value: PT6H
+          kind: free-service
+          service: forward-deployed engineering time
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: gte
+            statement: Startup has raised at least $5M
+            value:
+              type: number
+              value: 5000000
+          - criterion_id: cri_02
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lte
+            statement: Startup has raised up to $10M
+            value:
+              type: number
+              value: 10000000
+    lifecycle:
+      effective_from: 2026-08-01T07:08:27.771Z
+      status: active
+    roles:
+      terms_authority_entity_id: ent_01kyy3083w3k33krxmrqx1kr4e
+      access_operator_entity_id: ent_01kyy3083w3k33krxmrqx1kr4e
+    summary: Scale tier startups with $5M–$10M raised receive up to $30K in free platform credits and 6 hours of forward-deployed engineering time.
+    title: Together AI Startup Accelerator - Scale Tier
+    source_ids:
+      - src_5cc27a2787e67f1c577d136f167c25d59b92eed9f0abd1b4f301ea2fb7996447

--- a/vendors/zo/zoom.yaml
+++ b/vendors/zo/zoom.yaml
@@ -1,0 +1,89 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyy3083w3k33krxmrqx1kr4k
+slug: zoom
+slug_aliases: []
+name: Zoom Communications
+domains:
+  - value: zoom.com
+    role: primary
+    valid_from: 2026-08-01T07:09:00.969Z
+category: communication
+description: "Modernize workflows with Zoom's trusted collaboration tools: including video meetings, Zoom Chat, VoIP phone, webinars, whiteboard, contact center, and events."
+links:
+  site: https://www.zoom.com/
+sources:
+  - source_id: src_e152a28231129176c62cdaa48879f305bae1d3b7fcf39e1a425f0c83712e552e
+    url: https://www.zoom.com/en/lp/zoom-for-startups
+programs:
+  - program_id: prg_01kyy34e2h771sj46tqgzsw432
+    program_slug: zoom-for-startups
+    program_slug_aliases: []
+    title: Zoom for Startups
+    summary: Zoom's program providing early-stage startups with collaboration tools and benefits.
+    source_ids:
+      - src_e152a28231129176c62cdaa48879f305bae1d3b7fcf39e1a425f0c83712e552e
+offers:
+  - offer_id: off_01kyy3083w3k33krxmrqx1kr4m
+    program_id: prg_01kyy34e2h771sj46tqgzsw432
+    offer_slug: startup-business-plus
+    offer_slug_aliases: []
+    access:
+      availability: referral
+      method: form
+      url: https://www.zoom.com/en/lp/zoom-for-startups/
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: One year of Zoom Workplace Business Plus for up to 25 seats
+          duration:
+            kind: exact
+            value: P1Y
+          kind: free-service
+          service: Zoom Workplace Business Plus (up to 25 seats)
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.stage
+            kind: predicate
+            operator: in
+            statement: Pre-Seed to Series A Companies
+            value:
+              type: string-set
+              values:
+                - Pre-Seed
+                - Seed
+                - Series A
+          - criterion_id: cri_02
+            fact: company.employee_count
+            kind: predicate
+            operator: lt
+            statement: Fewer than 50 employees
+            value:
+              type: number
+              value: 50
+          - criterion_id: cri_03
+            kind: manual
+            reason: external-verification
+            statement: Affiliated with select startup partners
+          - criterion_id: cri_04
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: Not an existing paid customer
+            value:
+              type: boolean
+              value: false
+    lifecycle:
+      effective_from: 2026-08-01T07:09:00.969Z
+      status: active
+    roles:
+      terms_authority_entity_id: ent_01kyy3083w3k33krxmrqx1kr4k
+      access_operator_entity_id: ent_01kyy3083w3k33krxmrqx1kr4k
+    summary: Eligible early-stage startups affiliated with select startup partners receive one year of Zoom Workplace Business Plus for up to 25 seats.
+    title: One year of Zoom Workplace Business Plus for up to 25 seats
+    source_ids:
+      - src_e152a28231129176c62cdaa48879f305bae1d3b7fcf39e1a425f0c83712e552e


### PR DESCRIPTION
Adds the first reviewed slice of the 200-offer expansion.

- 11 new vendors
- 16 net-new offers
- splits the existing Resend YC record into two exact offers while retaining its route alias
- all changes are backed by the exact reviewed data admission for this Git tree

The repository remains data-only; scanner and authority state stay outside this public tree.