### PR TITLE
Catalog slice 2A: 20 reviewed startup offers

### DIFF
--- a/vendors/ai/aikido.yaml
+++ b/vendors/ai/aikido.yaml
@@ -1,0 +1,65 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyy6rm0yk2csvrbxjgcd7r1k
+slug: aikido
+slug_aliases: []
+name: Aikido
+domains:
+  - value: aikido.dev
+    role: primary
+    valid_from: 2026-08-01T07:17:32.298Z
+category: auth-security
+description: Aikido Security is an all-in-one application security platform.
+links:
+  site: https://www.aikido.dev
+sources:
+  - source_id: src_2c305f68d98ef708655b53cd12e291e78aaf984a74b77901f4cfbb2e0990e15a
+    url: https://aikido.dev/industries/aikido-for-startups
+programs: []
+offers:
+  - offer_id: off_01kyy6rm0zc3q32b8z73rj2nm4
+    offer_slug: aikido-startup-discount
+    offer_slug_aliases: []
+    title: Aikido Startup Discount
+    summary: Get up to 30% off Aikido for eligible startups that raised less than $1.5M in funding or nonprofit organizations.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:17:32.298Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Discounts of up to 30% on Aikido.
+          kind: discount
+          percentage:
+            basis_points: 3000
+            kind: up-to
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: any
+        rules:
+          - criterion_id: cri_01
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: Raised less than $1.5M in funding
+            value:
+              type: number
+              value: 1500000
+          - criterion_id: cri_02
+            fact: company.is_nonprofit
+            kind: predicate
+            operator: eq
+            statement: Is a nonprofit organization
+            value:
+              type: boolean
+              value: true
+    roles:
+      terms_authority_entity_id: ent_01kyy6rm0yk2csvrbxjgcd7r1k
+      access_operator_entity_id: ent_01kyy6rm0yk2csvrbxjgcd7r1k
+    access:
+      availability: public
+      method: form
+      url: https://aikido.dev/industries/aikido-for-startups
+    source_ids:
+      - src_2c305f68d98ef708655b53cd12e291e78aaf984a74b77901f4cfbb2e0990e15a

--- a/vendors/an/ansys.yaml
+++ b/vendors/an/ansys.yaml
@@ -1,0 +1,94 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyy6rm0zzbgrxey2r7n3nm0v
+slug: ansys
+slug_aliases: []
+name: Ansys
+domains:
+  - value: ansys.com
+    role: primary
+    valid_from: 2026-08-01T07:20:23.974Z
+category: devtools-other
+description: Ansys provides simulation software bundles custom bundled and priced for early-stage startups with limited funding and revenue.
+links:
+  site: https://www.ansys.com/experiences/startup-program
+sources:
+  - source_id: src_b80bed90d7f4ee8728a49a49319cf6568976994bd269ca4d5440c4c2e4f960e4
+    url: https://ansys.com/experiences/startup-program
+programs:
+  - program_id: prg_01kyy6rm0z5hqqw2zmn89wr8vw
+    program_slug: ansys-startup-program
+    program_slug_aliases: []
+    title: Ansys Startup Program
+    summary: The Ansys Startup Program provides early-stage startups with access to discounted simulation software bundles across multiple physics disciplines, high-performance computing, and technical support.
+    source_ids:
+      - src_b80bed90d7f4ee8728a49a49319cf6568976994bd269ca4d5440c4c2e4f960e4
+offers:
+  - offer_id: off_01kyy6rm0zc6gjtteqae4x2q3b
+    program_id: prg_01kyy6rm0z5hqqw2zmn89wr8vw
+    offer_slug: ansys-startup-program
+    offer_slug_aliases: []
+    title: Ansys Startup Program
+    summary: Eligible early-stage startups get access to discounted multiphysics simulation software bundles (Structures & Fluids, Electromagnetics, Embedded Software, Optics and Photonics) along with high-performance computing and technical support.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:20:23.974Z
+    economics:
+      benefits:
+        - applies_to: Ansys simulation software bundles
+          benefit_id: ben_01
+          description: Discounted access to simulation software product bundles spanning Structures & Fluids, Electromagnetics, Embedded Software, Optics and Photonics.
+          kind: discount
+          percentage:
+            basis_points: 9900
+            kind: up-to
+        - benefit_id: ben_02
+          description: Technical support and opportunities to engage on mutually beneficial marketing opportunities.
+          kind: other
+      consideration:
+        description: Priced for early-stage startups; exact discounted pricing is not specified on the page.
+        kind: unknown
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.is_private
+            kind: predicate
+            operator: eq
+            statement: Must be a privately held company.
+            value:
+              type: boolean
+              value: true
+          - criterion_id: cri_02
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: Company age must be less than 10 years.
+            value:
+              type: number
+              value: 120
+          - criterion_id: cri_03
+            fact: company.annual_revenue_usd
+            kind: predicate
+            operator: lt
+            statement: Annual revenue must be less than USD $5 million.
+            value:
+              type: number
+              value: 5000000
+          - criterion_id: cri_04
+            fact: company.industry
+            kind: predicate
+            operator: neq
+            statement: Must not be an engineering consulting or simulation services company.
+            value:
+              type: string
+              value: engineering consulting or simulation services
+    roles:
+      terms_authority_entity_id: ent_01kyy6rm0zzbgrxey2r7n3nm0v
+      access_operator_entity_id: ent_01kyy6rm0zzbgrxey2r7n3nm0v
+    access:
+      availability: membership
+      method: form
+      url: https://www.ansys.com/experiences/startup-program
+    source_ids:
+      - src_b80bed90d7f4ee8728a49a49319cf6568976994bd269ca4d5440c4c2e4f960e4

--- a/vendors/ar/arm.yaml
+++ b/vendors/ar/arm.yaml
@@ -1,0 +1,63 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyy6rm0zk1x5yqj2mbyypt8m
+slug: arm
+slug_aliases: []
+name: Arm
+domains:
+  - value: arm.com
+    role: primary
+    valid_from: 2026-08-01T07:51:14.289Z
+category: devtools-other
+description: Arm Flexible Access for Startups offers broad access to verified IP, tools, and support for efficient SoC development with transparent, upfront pricing.
+links:
+  site: https://www.arm.com/products/flexible-access/startup
+sources:
+  - source_id: src_45d7632820aec1cb24d21e7526ab92b5ec8269eaf51efd8ec84260b2586393a3
+    url: https://www.arm.com/products/flexible-access/startup
+programs: []
+offers:
+  - offer_id: off_01kyy6rm0zp8hr58y9gjqe8dzy
+    offer_slug: arm-flexible-access-for-startups
+    offer_slug_aliases: []
+    title: Arm Flexible Access for Startups
+    summary: Provides $0 upfront access to Arm SoC design IP, tools, training, and technical support to build prototypes, with license fees due only when manufacturing.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:51:14.289Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: $0 access to Arm IP, tools, training, and support for SoC development, with license fees due only at manufacture.
+          kind: free-service
+          service: Arm SoC design IP, tools, training, and support
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: Funding raised must be less than $50,000,000.
+            value:
+              type: number
+              value: 50000000
+          - criterion_id: cri_02
+            fact: company.annual_revenue_usd
+            kind: predicate
+            operator: lt
+            statement: Annual revenue must be less than $5,000,000.
+            value:
+              type: number
+              value: 5000000
+    roles:
+      terms_authority_entity_id: ent_01kyy6rm0zk1x5yqj2mbyypt8m
+      access_operator_entity_id: ent_01kyy6rm0zk1x5yqj2mbyypt8m
+    access:
+      availability: public
+      method: form
+      url: https://www.arm.com/products/flexible-access/startup
+    source_ids:
+      - src_45d7632820aec1cb24d21e7526ab92b5ec8269eaf51efd8ec84260b2586393a3

--- a/vendors/br/bright-data.yaml
+++ b/vendors/br/bright-data.yaml
@@ -1,0 +1,84 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyy6rm0zntgna8jr7617kxrm
+slug: bright-data
+slug_aliases: []
+name: Bright Data
+domains:
+  - value: brightdata.com
+    role: primary
+    valid_from: 2026-08-01T07:20:42.184Z
+category: data-analytics
+description: Bright Data provides web data platform services, proxy infrastructure, web access APIs, and dataset solutions.
+links:
+  site: https://brightdata.com
+sources:
+  - source_id: src_23f98d23d268fa2ce9d9dbcf099506f5e72aa586e5245e650affc4e67352acae
+    url: https://brightdata.com/ai/ai-startups-program
+programs:
+  - program_id: prg_01kyy6rm0zthh4dryyrtxcz9cw
+    program_slug: ai-startup-program
+    program_slug_aliases: []
+    title: AI Startup Program
+    summary: Bright Data's program offering credits, expert support, and marketing opportunities to early-stage AI startups.
+    source_ids:
+      - src_23f98d23d268fa2ce9d9dbcf099506f5e72aa586e5245e650affc4e67352acae
+offers:
+  - offer_id: off_01kyy6rm0zjk5k4w0d5536t8dy
+    program_id: prg_01kyy6rm0zthh4dryyrtxcz9cw
+    offer_slug: ai-startup-program
+    offer_slug_aliases: []
+    title: AI Startup Program
+    summary: Eligible startups can receive up to $20,000 in Bright Data credits along with expert support and co-marketing opportunities.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:20:42.184Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $20,000 in platform credits for Bright Data services.
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 2000000
+            kind: up-to
+        - benefit_id: ben_02
+          description: Expert support and technical resources.
+          kind: other
+        - benefit_id: ben_03
+          description: Mutually beneficial co-marketing opportunities.
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: not-machine-evaluable
+            statement: AI is central to your product
+          - criterion_id: cri_02
+            fact: company.stage
+            kind: predicate
+            operator: in
+            statement: Startup stage must be between Pre-Seed and Series A
+            value:
+              type: string-set
+              values:
+                - pre-seed
+                - seed
+                - series-a
+          - criterion_id: cri_03
+            kind: manual
+            reason: not-machine-evaluable
+            statement: You need public web data to grow
+    roles:
+      terms_authority_entity_id: ent_01kyy6rm0zntgna8jr7617kxrm
+      access_operator_entity_id: ent_01kyy6rm0zntgna8jr7617kxrm
+    access:
+      availability: public
+      method: form
+      url: https://brightdata.com/ai/ai-startups-program
+    source_ids:
+      - src_23f98d23d268fa2ce9d9dbcf099506f5e72aa586e5245e650affc4e67352acae

--- a/vendors/cl/cleura.yaml
+++ b/vendors/cl/cleura.yaml
@@ -1,0 +1,74 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyy6rm10vdr56kt6h38bk4ny
+slug: cleura
+slug_aliases: []
+name: Cleura
+domains:
+  - value: cleura.com
+    role: primary
+    valid_from: 2026-08-01T07:21:02.787Z
+category: hosting-infra
+description: European cloud provider offering sovereign, open-source infrastructure built on OpenStack and Ceph.
+links:
+  site: https://cleura.com
+sources:
+  - source_id: src_283d106a3bf9626121f6cc8746a584fbbe847f65d66b78d7b29002a0fb4ecc99
+    url: https://cleura.com/cleura-startup-program
+programs:
+  - program_id: prg_01kyy6rm10s3dtz0scyj6cc4bc
+    program_slug: cleura-startup-program
+    program_slug_aliases: []
+    title: Cleura Startup Program
+    summary: Cleura Startup Program offers free European cloud credits and resources to support early-stage startups building on an open-source, compliant foundation.
+    source_ids:
+      - src_283d106a3bf9626121f6cc8746a584fbbe847f65d66b78d7b29002a0fb4ecc99
+offers:
+  - offer_id: off_01kyy6rm10vr28zp4fbgp5sgx4
+    program_id: prg_01kyy6rm10s3dtz0scyj6cc4bc
+    offer_slug: cleura-startup-program
+    offer_slug_aliases: []
+    title: Cleura Startup Program
+    summary: Get up to €20,000 in free Cleura Public Cloud credits for compute, storage, and networking, valid for up to 18 months for early-stage startups legally registered in Europe.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:21:02.787Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to €20,000 in free Cleura Public Cloud credits for compute, storage, and networking.
+          duration:
+            kind: up-to
+            value: P18M
+          kind: credit
+          value:
+            amount:
+              currency: EUR
+              minor_units: 2000000
+            kind: up-to
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: Open to early-stage, legally registered startups in Europe (proof may be required).
+          - criterion_id: cri_02
+            fact: company.is_subsidiary
+            kind: predicate
+            operator: eq
+            statement: Subsidiaries or corporate-owned startups are not eligible.
+            value:
+              type: boolean
+              value: false
+    roles:
+      terms_authority_entity_id: ent_01kyy6rm10vdr56kt6h38bk4ny
+      access_operator_entity_id: ent_01kyy6rm10vdr56kt6h38bk4ny
+    access:
+      availability: public
+      method: form
+      url: https://cleura.com/cleura-startup-program/
+    source_ids:
+      - src_283d106a3bf9626121f6cc8746a584fbbe847f65d66b78d7b29002a0fb4ecc99

--- a/vendors/co/coderabbit.yaml
+++ b/vendors/co/coderabbit.yaml
@@ -1,0 +1,81 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyy6rm10vssbvzayfspaare9
+slug: coderabbit
+slug_aliases: []
+name: CodeRabbit
+domains:
+  - value: coderabbit.ai
+    role: primary
+    valid_from: 2026-08-01T07:51:13.783Z
+category: ai-ml
+description: AI-first pull request reviewer with context-aware feedback, line-by-line code suggestions, and real-time chat.
+links:
+  site: https://www.coderabbit.ai
+sources:
+  - source_id: src_7cbed5d00777f5371620a7e5f022f258d67bd6883f4e6673e3aebb04c3c3cb91
+    url: https://www.coderabbit.ai/startup-program
+programs:
+  - program_id: prg_01kyy6rm100x8e6ndff4qc6vaa
+    program_slug: coderabbit-startup-program
+    program_slug_aliases: []
+    title: CodeRabbit Startup Program
+    summary: CodeRabbit's program for eligible VC or accelerator-backed startups to get discounted access to AI code review tools.
+    source_ids:
+      - src_7cbed5d00777f5371620a7e5f022f258d67bd6883f4e6673e3aebb04c3c3cb91
+offers:
+  - offer_id: off_01kyy6rm109kpd8xe2gynsjc5p
+    program_id: prg_01kyy6rm100x8e6ndff4qc6vaa
+    offer_slug: 50-off-coderabbit-pro-plus-for-6-months
+    offer_slug_aliases: []
+    title: 50% off CodeRabbit Pro Plus for 6 months
+    summary: Eligible startups receive a 50% discount on a Pro Plus annual plan for 6 months.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:51:13.783Z
+    economics:
+      benefits:
+        - applies_to: CodeRabbit Pro Plus annual plan
+          benefit_id: ben_01
+          description: 50% off CodeRabbit Pro Plus annual plan for 6 months
+          duration:
+            kind: exact
+            value: P6M
+          kind: discount
+          percentage:
+            basis_points: 5000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: VC or accelerator-backed startups.
+          - criterion_id: cri_02
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: Limited to funding of less than $25 million.
+            value:
+              type: number
+              value: 25000000
+          - criterion_id: cri_03
+            kind: manual
+            reason: vendor-discretion
+            statement: Requires a Pro Plus annual plan
+          - criterion_id: cri_04
+            kind: manual
+            reason: not-machine-evaluable
+            statement: Sign up with your organization's GitHub or GitLab account and submit this form to claim the offer.
+    roles:
+      terms_authority_entity_id: ent_01kyy6rm10vssbvzayfspaare9
+      access_operator_entity_id: ent_01kyy6rm10vssbvzayfspaare9
+    access:
+      availability: public
+      method: form
+      url: https://www.coderabbit.ai/startup-program
+    source_ids:
+      - src_7cbed5d00777f5371620a7e5f022f258d67bd6883f4e6673e3aebb04c3c3cb91

--- a/vendors/de/deel.yaml
+++ b/vendors/de/deel.yaml
@@ -14,6 +14,8 @@ links:
 sources:
   - source_id: src_6e369733bfa8e965ff97164c047da6f18a586e5e58fef7db3c7225d5142b6c70
     url: https://www.deel.com/segments/startups/
+  - source_id: src_11482e30b1e1cf00925499a7a256cc5c36accecf3c0d790c06af55f3ccde94c7
+    url: https://www.deel.com/segments/startups
 programs: []
 offers:
   - offer_id: off_01kyh8fpe2r151y0shvrzcmkwt
@@ -48,3 +50,38 @@ offers:
       url: https://www.deel.com/segments/startups/
     source_ids:
       - src_6e369733bfa8e965ff97164c047da6f18a586e5e58fef7db3c7225d5142b6c70
+  - offer_id: off_01kyy6rm10k6r1bdkckarf7wh9
+    offer_slug: free-u-s-payroll-for-founders
+    offer_slug_aliases: []
+    title: Free U.S. Payroll for Founders
+    summary: Free U.S. Payroll for founders for life.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:51:50.371Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Free U.S. Payroll for founders for life
+          kind: free-service
+          service: U.S. Payroll for founders
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        fact: company.is_founder
+        kind: predicate
+        operator: eq
+        statement: User must be a founder using U.S. payroll
+        value:
+          type: boolean
+          value: true
+    roles:
+      terms_authority_entity_id: ent_01kyh8fpe2k0kd5rfqh8es0ccs
+      access_operator_entity_id: ent_01kyh8fpe2k0kd5rfqh8es0ccs
+    access:
+      availability: public
+      method: form
+      url: https://www.deel.com/segments/startups/
+    source_ids:
+      - src_11482e30b1e1cf00925499a7a256cc5c36accecf3c0d790c06af55f3ccde94c7

--- a/vendors/de/devrev.yaml
+++ b/vendors/de/devrev.yaml
@@ -1,0 +1,92 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyy6rm10t4ab53aq8rxhxqjp
+slug: devrev
+slug_aliases: []
+name: DevRev
+domains:
+  - value: devrev.ai
+    role: primary
+    valid_from: 2026-08-01T07:21:38.391Z
+category: support
+description: DevRev marries a beautifully designed, in-app support experience, with a scalable and customizable ticketing platform that unifies support and engineering.
+links:
+  site: https://devrev.ai
+sources:
+  - source_id: src_4aebab453dfd4d505385c94699df8bd86e359be221a5b6e0d7ce886981848da3
+    url: https://devrev.ai/startups/apply
+programs:
+  - program_id: prg_01kyy6rm10y0hz9abjhrnfv0a3
+    program_slug: startup-program
+    program_slug_aliases: []
+    title: Startup Program
+    summary: Program providing technical and business benefits to accelerate early-stage startups on their AI-first journey.
+    source_ids:
+      - src_4aebab453dfd4d505385c94699df8bd86e359be221a5b6e0d7ce886981848da3
+offers:
+  - offer_id: off_01kyy6rm103s425h55jcec794t
+    program_id: prg_01kyy6rm10y0hz9abjhrnfv0a3
+    offer_slug: devrev-startup-program
+    offer_slug_aliases: []
+    title: DevRev Startup Program
+    summary: Eligible early-stage startups get up to $10k in credits for 12 months free, 50% off their first paid commitments, and access to technical and business enablement.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:21:38.391Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Get up to $10k in credits at sign-up
+          duration:
+            kind: exact
+            value: P1Y
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 1000000
+            kind: up-to
+        - applies_to: first paid commitments
+          benefit_id: ben_02
+          description: 50% off your first paid commitments
+          kind: discount
+          percentage:
+            basis_points: 5000
+            kind: exact
+        - benefit_id: ben_03
+          description: Get access to technical experts, training modules and learning guides.
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: Seed or Series A funded startups.
+          - criterion_id: cri_02
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: Must be a new DevRev customer
+            value:
+              type: boolean
+              value: false
+          - criterion_id: cri_03
+            fact: company.age_months
+            kind: predicate
+            operator: lte
+            statement: Companies founded within the last 5 years
+            value:
+              type: number
+              value: 60
+    roles:
+      terms_authority_entity_id: ent_01kyy6rm10t4ab53aq8rxhxqjp
+      access_operator_entity_id: ent_01kyy6rm10t4ab53aq8rxhxqjp
+    access:
+      availability: public
+      method: form
+      url: https://devrev.ai/startups/apply
+    source_ids:
+      - src_4aebab453dfd4d505385c94699df8bd86e359be221a5b6e0d7ce886981848da3

--- a/vendors/do/document360.yaml
+++ b/vendors/do/document360.yaml
@@ -1,0 +1,98 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyy6rm10e74gkywq5bgr0xyg
+slug: document360
+slug_aliases: []
+name: Document360
+domains:
+  - value: document360.com
+    role: primary
+    valid_from: 2026-08-01T07:51:51.676Z
+category: support
+description: Instantly create a knowledge base for your customers and teams. Build FAQ, User guides, Product Documentation, Standard Operating Procedures and many more
+links:
+  site: https://document360.com
+sources:
+  - source_id: src_d492f932dbaec08ed988c2cd06512cba203a77e7ae00747c82de83def97bd0f6
+    url: https://www.document360.com/partners/startup-program
+programs:
+  - program_id: prg_01kyy6rm10sn87x4crqqntrvee
+    program_slug: document360-startup-program
+    program_slug_aliases: []
+    title: Document360 Startup Program
+    summary: Join Document360's startup program to access exclusive benefits, including discounted pricing on Business and Enterprise plans and white-glove onboarding for early-stage startups.
+    source_ids:
+      - src_d492f932dbaec08ed988c2cd06512cba203a77e7ae00747c82de83def97bd0f6
+offers:
+  - offer_id: off_01kyy6rm105402mvyagm168cjb
+    program_id: prg_01kyy6rm10sn87x4crqqntrvee
+    offer_slug: document360-startup-program-offer
+    offer_slug_aliases: []
+    title: Document360 Startup Program Offer
+    summary: Eligible early-stage startups get a 12-month subscription to Document360 Business or Enterprise plans for the price of 6 months (50% off), plus a personalized KB site setup.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:51:51.676Z
+    economics:
+      benefits:
+        - applies_to: Business and Enterprise plans
+          benefit_id: ben_01
+          description: 50% discount on 12-month subscription (billed for 6 months, receive 12 months)
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            basis_points: 5000
+            kind: exact
+        - benefit_id: ben_02
+          description: Wow site – personalized setup and implementation for your knowledge base site
+          kind: other
+      consideration:
+        description: Billed for six months of subscription
+        kind: variable
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: Must be a new customer
+            value:
+              type: boolean
+              value: false
+          - criterion_id: cri_02
+            fact: company.employee_count
+            kind: predicate
+            operator: lt
+            statement: Must have less than 50 employees
+            value:
+              type: number
+              value: 50
+          - criterion_id: cri_03
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: Must have raised under $5M in funding
+            value:
+              type: number
+              value: 5000000
+          - criterion_id: cri_04
+            fact: company.partner_memberships
+            kind: predicate
+            operator: present
+            statement: Must be associated with one of the startup accelerators, incubators, VCs or startup communities
+          - criterion_id: cri_05
+            kind: manual
+            reason: external-verification
+            statement: Bootstrapped startups must submit all relevant documents to validate eligibility criteria
+    roles:
+      terms_authority_entity_id: ent_01kyy6rm10e74gkywq5bgr0xyg
+      access_operator_entity_id: ent_01kyy6rm10e74gkywq5bgr0xyg
+    access:
+      availability: membership
+      method: form
+      url: https://document360.com/partners/startup-program/
+    source_ids:
+      - src_d492f932dbaec08ed988c2cd06512cba203a77e7ae00747c82de83def97bd0f6

--- a/vendors/do/dodo-payments.yaml
+++ b/vendors/do/dodo-payments.yaml
@@ -1,0 +1,105 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyy6rm10pd1y04n0aymh2g2f
+slug: dodo-payments
+slug_aliases: []
+name: Dodo Payments
+domains:
+  - value: dodopayments.com
+    role: primary
+    valid_from: 2026-08-01T07:21:33.644Z
+category: payments-fintech
+description: Billing and payments platform for fast-growing startups.
+links:
+  site: https://dodopayments.com
+sources:
+  - source_id: src_68c0fc301e39ab507fda9f0d9e3752fde0c49d6960828e193aa305722bffa7f1
+    url: https://dodopayments.com/startups
+programs:
+  - program_id: prg_01kyy6rm106pxqdg14jf5mqh2r
+    program_slug: dodo-payments-for-startups
+    program_slug_aliases: []
+    title: Dodo Payments for Startups
+    summary: Program providing early-stage SaaS, AI, and digital product startups with up to 12 months of free credits, ongoing startup pricing, and full access to the Dodo Payments platform.
+    source_ids:
+      - src_68c0fc301e39ab507fda9f0d9e3752fde0c49d6960828e193aa305722bffa7f1
+offers:
+  - offer_id: off_01kyy6rm10f65rtfgytey9g3mb
+    program_id: prg_01kyy6rm106pxqdg14jf5mqh2r
+    offer_slug: dodo-payments-for-startups
+    offer_slug_aliases: []
+    title: Dodo Payments for Startups
+    summary: Eligible early-stage startups get up to 12 months of free credits applied upfront, forever startup pricing, and full access to the Dodo Payments platform without tier-gating.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:21:33.644Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to 12 months of free credits applied upfront.
+          duration:
+            kind: up-to
+            value: P12M
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 0
+            kind: exact
+        - benefit_id: ben_02
+          description: Forever startup pricing with preferential rates that scale as you grow.
+          kind: other
+        - benefit_id: ben_03
+          description: Full Dodo Payments platform access with no tier-gating including subscriptions, usage metering, credit-based billing, and 40+ payment methods.
+          kind: free-service
+          service: Full Dodo Payments platform access with no tier-gating
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.industry
+            kind: predicate
+            operator: in
+            statement: Building SaaS, AI, or digital products.
+            value:
+              type: string-set
+              values:
+                - SaaS
+                - AI
+                - digital products
+          - criterion_id: cri_02
+            fact: company.sells_internationally
+            kind: predicate
+            operator: eq
+            statement: Selling (or planning to sell) internationally.
+            value:
+              type: boolean
+              value: true
+          - criterion_id: cri_03
+            fact: company.stage
+            kind: predicate
+            operator: in
+            statement: Bootstrapped through Series B.
+            value:
+              type: string-set
+              values:
+                - bootstrapped
+                - pre-seed
+                - seed
+                - series-a
+                - series-b
+          - criterion_id: cri_04
+            kind: manual
+            reason: external-verification
+            statement: Must complete standard business verification/onboarding.
+    roles:
+      terms_authority_entity_id: ent_01kyy6rm10pd1y04n0aymh2g2f
+      access_operator_entity_id: ent_01kyy6rm10pd1y04n0aymh2g2f
+    access:
+      availability: public
+      method: form
+      url: https://dodopayments.com/startups
+    source_ids:
+      - src_68c0fc301e39ab507fda9f0d9e3752fde0c49d6960828e193aa305722bffa7f1

--- a/vendors/ga/ganttpro.yaml
+++ b/vendors/ga/ganttpro.yaml
@@ -1,0 +1,94 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyy6rm10p1vw9wg6ww029c6v
+slug: ganttpro
+slug_aliases: []
+name: GanttPRO
+domains:
+  - value: ganttpro.com
+    role: primary
+    valid_from: 2026-08-01T07:22:15.489Z
+category: productivity
+description: Online Gantt chart software for project management, timeline planning, resource allocation, and team collaboration.
+links:
+  site: https://ganttpro.com
+sources:
+  - source_id: src_048684c6adda2f84883d8b55a12bb6c6c8682c11a439c73932b94b961d185f2b
+    url: https://ganttpro.com/startup-program
+programs:
+  - program_id: prg_01kyy6rm10p40vqp6xyfvevsj7
+    program_slug: ganttpro-startup-program
+    program_slug_aliases: []
+    title: GanttPRO Startup Program
+    summary: GanttPRO program providing qualifying startups with discounted access to annual GanttPRO plans.
+    source_ids:
+      - src_048684c6adda2f84883d8b55a12bb6c6c8682c11a439c73932b94b961d185f2b
+offers:
+  - offer_id: off_01kyy6rm10jm4dk6v7v20g9sap
+    program_id: prg_01kyy6rm10p40vqp6xyfvevsj7
+    offer_slug: ganttpro-startup-program-50-off-first-annual-subscription
+    offer_slug_aliases: []
+    title: GanttPRO Startup Program 50% Off First Annual Subscription
+    summary: Eligible early-stage startups receive 50% off their first annual subscription on any GanttPRO plan.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:22:15.489Z
+    economics:
+      benefits:
+        - applies_to: GanttPRO first annual subscription
+          benefit_id: ben_01
+          description: 50% off first annual subscription on any GanttPRO plan
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            basis_points: 5000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.age_months
+            kind: predicate
+            operator: lte
+            statement: Incorporated less than 3 years ago or an accelerator/incubator operating for 3 years or less
+            value:
+              type: number
+              value: 36
+          - criterion_id: cri_02
+            fact: company.domain
+            kind: predicate
+            operator: present
+            statement: Unique website and company domain
+          - criterion_id: cri_03
+            fact: company.employee_count
+            kind: predicate
+            operator: lte
+            statement: 30 team members or less
+            value:
+              type: number
+              value: 30
+          - criterion_id: cri_04
+            kind: manual
+            reason: external-verification
+            statement: Have raised a max of Series B round funding or not undergone a funding round/change of control/IPO
+          - criterion_id: cri_05
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: Never had a paid subscription to GanttPRO or received another coupon code/discount
+            value:
+              type: boolean
+              value: false
+    roles:
+      terms_authority_entity_id: ent_01kyy6rm10p1vw9wg6ww029c6v
+      access_operator_entity_id: ent_01kyy6rm10p1vw9wg6ww029c6v
+    access:
+      availability: public
+      method: form
+      url: https://ganttpro.com/startup-program
+    source_ids:
+      - src_048684c6adda2f84883d8b55a12bb6c6c8682c11a439c73932b94b961d185f2b

--- a/vendors/gr/gracker-ai.yaml
+++ b/vendors/gr/gracker-ai.yaml
@@ -1,0 +1,126 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyy6rm10fqjjtev2tra9xbgf
+slug: gracker-ai
+slug_aliases: []
+name: GrackerAI
+domains:
+  - value: gracker.ai
+    role: primary
+    valid_from: 2026-08-01T07:22:13.864Z
+category: marketing
+description: Cybersecurity and DevTools startups get 50% off GrackerAI. Become the brand AI search engines cite when buyers ask 'What's the best [your category] tool?' Other B2B SaaS startups welcome to apply.
+links:
+  site: https://gracker.ai
+sources:
+  - source_id: src_7d43a5c544b34600b29fb06a5e2be68f7f12cfe379c95aac09627ebe146854ad
+    url: https://gracker.ai/startup
+programs: []
+offers:
+  - offer_id: off_01kyy6rm10thw471czngxh1zp4
+    offer_slug: grackerai-for-startups
+    offer_slug_aliases: []
+    title: GrackerAI for Startups
+    summary: Qualified Cybersecurity, DevTools, and B2B SaaS startups receive a 50% discount on the GrackerAI Scale plan for 12 months in exchange for participating in a published case study after seeing results.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:22:13.864Z
+    economics:
+      benefits:
+        - applies_to: GrackerAI Scale plan
+          benefit_id: ben_01
+          description: 50% off the standard Scale plan for 12 months.
+          duration:
+            kind: exact
+            value: P12M
+          kind: discount
+          percentage:
+            basis_points: 5000
+            kind: exact
+      consideration:
+        description: Participation in a published case study documenting success story, baseline, and outcomes once results are achieved (around month 3-4).
+        kind: variable
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - kind: any
+            rules:
+              - criterion_id: cri_01
+                fact: company.industry
+                kind: predicate
+                operator: in
+                statement: Company primary focus is Cybersecurity or DevTools, or another B2B SaaS vertical.
+                value:
+                  type: string-set
+                  values:
+                    - Cybersecurity
+                    - DevTools
+                    - B2B SaaS
+              - criterion_id: cri_02
+                fact: company.industry
+                kind: predicate
+                operator: in
+                statement: Sub-category belongs to AppSec, CloudSec, Identity, SOC tooling, GRC, threat intel, observability, CI/CD, API tooling, infra, or internal dev platforms.
+                value:
+                  type: string-set
+                  values:
+                    - AppSec
+                    - CloudSec
+                    - Identity
+                    - SOC tooling
+                    - GRC
+                    - threat intel
+                    - observability
+                    - CI/CD
+                    - API tooling
+                    - infra
+                    - internal dev platforms
+          - criterion_id: cri_03
+            fact: company.arr_usd
+            kind: predicate
+            operator: lt
+            statement: Annual recurring revenue is less than $5M.
+            value:
+              type: number
+              value: 5000000
+          - criterion_id: cri_04
+            fact: company.age_years
+            kind: predicate
+            operator: lt
+            statement: Company was incorporated less than 5 years ago.
+            value:
+              type: number
+              value: 5
+          - criterion_id: cri_05
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: Total external funding raised is less than $10M.
+            value:
+              type: number
+              value: 10000000
+          - criterion_id: cri_06
+            fact: company.has_active_product
+            kind: predicate
+            operator: eq
+            statement: Company has an active product with at least one paying customer or live free tier.
+            value:
+              type: boolean
+              value: true
+          - criterion_id: cri_07
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: Company has no prior GrackerAI subscription.
+            value:
+              type: boolean
+              value: false
+    roles:
+      terms_authority_entity_id: ent_01kyy6rm10fqjjtev2tra9xbgf
+      access_operator_entity_id: ent_01kyy6rm10fqjjtev2tra9xbgf
+    access:
+      availability: public
+      method: form
+      url: https://gracker.ai/startup/
+    source_ids:
+      - src_7d43a5c544b34600b29fb06a5e2be68f7f12cfe379c95aac09627ebe146854ad

--- a/vendors/gr/grafana.yaml
+++ b/vendors/gr/grafana.yaml
@@ -1,0 +1,101 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyy6rm10nyqc4zemqs24a6db
+slug: grafana
+slug_aliases: []
+name: Grafana Labs
+domains:
+  - value: grafana.com
+    role: primary
+    valid_from: 2026-08-01T07:22:35.202Z
+category: observability
+description: At Grafana Labs, we believe in providing observability solutions for organizations of every size and stage.
+links:
+  site: https://grafana.com
+sources:
+  - source_id: src_b68d66e5e5699aadab7955ae4cd44a8d2834e4f1d45a8bcdf6867735d08436e1
+    url: https://grafana.com/blog/grafana-labs-startup-program
+programs:
+  - program_id: prg_01kyy6rm102ahn1a0mqjx9aypj
+    program_slug: grafana-labs-startup-program
+    program_slug_aliases: []
+    title: Grafana Labs Startup Program
+    summary: The Grafana Labs Startup Program provides eligible startups with up to $100,000 in Grafana Cloud credits for 12 months, support, enterprise plugins, and ongoing discounts.
+    source_ids:
+      - src_b68d66e5e5699aadab7955ae4cd44a8d2834e4f1d45a8bcdf6867735d08436e1
+offers:
+  - offer_id: off_01kyy6rm10gcph1hq63c1h7ery
+    program_id: prg_01kyy6rm102ahn1a0mqjx9aypj
+    offer_slug: grafana-labs-startup-program
+    offer_slug_aliases: []
+    title: Grafana Labs Startup Program
+    summary: Eligible startups receive up to $100,000 in Grafana Cloud credits for 12 months, free Enterprise data source plugins and 24x7 support, integration team access, and a guaranteed minimum 20% discount after credits or duration end.
+    lifecycle:
+      status: active
+      effective_from: 2024-09-25T00:00:00Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: $100,000 in credits for any Grafana Cloud services for 12 months.
+          duration:
+            kind: exact
+            value: P12M
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 10000000
+            kind: up-to
+        - benefit_id: ben_02
+          description: All Enterprise data source plugins and 24x7 Grafana support
+          kind: waiver
+          waived_item: Fees for Enterprise data source plugins and 24x7 Grafana support
+        - applies_to: Grafana Cloud list prices after credits depletion or 12 months
+          benefit_id: ben_03
+          description: Guaranteed 20% discount from list prices after credits are depleted or 12 months completed.
+          kind: discount
+          percentage:
+            basis_points: 2000
+            kind: at-least
+        - benefit_id: ben_04
+          description: Access to integrations team to strategize creation of a plugin and/or solution to better integrate with Grafana Cloud ecosystem.
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: Applicants ideally have raised less than $10 million in funding.
+            value:
+              type: number
+              value: 10000000
+          - criterion_id: cri_02
+            fact: company.employee_count
+            kind: predicate
+            operator: lt
+            statement: Applicants ideally have under 25 employees.
+            value:
+              type: number
+              value: 25
+          - criterion_id: cri_03
+            kind: manual
+            reason: vendor-discretion
+            statement: All new customers (including Grafana Cloud Free accounts) and Grafana OSS users moving to managed solution are eligible to apply; Grafana Labs determines admission at sole discretion.
+          - criterion_id: cri_04
+            kind: manual
+            reason: not-machine-evaluable
+            statement: Accepted startups agree to be a reference customer and may be asked to mutually agree to marketing activities.
+    roles:
+      terms_authority_entity_id: ent_01kyy6rm10nyqc4zemqs24a6db
+      access_operator_entity_id: ent_01kyy6rm10nyqc4zemqs24a6db
+    access:
+      availability: public
+      method: form
+      url: https://grafana.com/blog/grafana-labs-startup-program/
+    terms_url: https://grafana.com/legal/terms-of-service/
+    source_ids:
+      - src_b68d66e5e5699aadab7955ae4cd44a8d2834e4f1d45a8bcdf6867735d08436e1

--- a/vendors/gr/granola.yaml
+++ b/vendors/gr/granola.yaml
@@ -1,0 +1,76 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyy6rm10yjjvvwknhb5m556g
+slug: granola
+slug_aliases: []
+name: Granola
+domains:
+  - value: granola.ai
+    role: primary
+    valid_from: 2026-08-01T07:22:34.528Z
+category: productivity
+description: The AI notepad for back-to-back meetings.
+links:
+  site: https://www.granola.ai
+sources:
+  - source_id: src_c15d51e8b8144b84eeac6cbd0a6df455a10bed13567240f8db1818c6f1331712
+    url: https://granola.ai/startups
+programs:
+  - program_id: prg_01kyy6rm10a571xgrmesdyg5ej
+    program_slug: granola-for-startups
+    program_slug_aliases: []
+    title: Granola for Startups
+    summary: Granola's startup program offering 1 year free of Granola Business for eligible early-stage startups.
+    source_ids:
+      - src_c15d51e8b8144b84eeac6cbd0a6df455a10bed13567240f8db1818c6f1331712
+offers:
+  - offer_id: off_01kyy6rm10t38zvf3ysjv0ph0g
+    program_id: prg_01kyy6rm10a571xgrmesdyg5ej
+    offer_slug: 1-year-free-of-granola-business
+    offer_slug_aliases: []
+    title: 1 year free of Granola Business
+    summary: Eligible pre-seed or seed startups with fewer than 30 employees get 1 year free of Granola Business.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:22:34.528Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: 1 year free of Granola Business
+          duration:
+            kind: exact
+            value: P1Y
+          kind: free-service
+          service: Granola Business
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.employee_count
+            kind: predicate
+            operator: lt
+            statement: Company has fewer than 30 employees
+            value:
+              type: number
+              value: 30
+          - criterion_id: cri_02
+            fact: company.stage
+            kind: predicate
+            operator: in
+            statement: Company has raised pre-seed or seed funding
+            value:
+              type: string-set
+              values:
+                - pre-seed
+                - seed
+    roles:
+      terms_authority_entity_id: ent_01kyy6rm10yjjvvwknhb5m556g
+      access_operator_entity_id: ent_01kyy6rm10yjjvvwknhb5m556g
+    access:
+      availability: public
+      method: form
+      url: https://granola.ai/startups
+    source_ids:
+      - src_c15d51e8b8144b84eeac6cbd0a6df455a10bed13567240f8db1818c6f1331712

--- a/vendors/he/heroku.yaml
+++ b/vendors/he/heroku.yaml
@@ -1,0 +1,91 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyy6rm10g6b7jtmft8n6qr0n
+slug: heroku
+slug_aliases: []
+name: Heroku
+domains:
+  - value: heroku.com
+    role: primary
+    valid_from: 2026-08-01T07:52:32.793Z
+category: hosting-infra
+description: Heroku is a cloud application platform based on a managed container system, providing PaaS features and managed data services.
+links:
+  site: https://www.heroku.com/
+sources:
+  - source_id: src_d382abbba5efb102619acb5f82ed5b847d8e5be62c9ee1bd05d2c745443c74ae
+    url: https://www.heroku.com/open-source-credit-program
+programs:
+  - program_id: prg_01kyy6rm10n2rph7sn8jaxhpnq
+    program_slug: heroku-open-source-software-credit-program
+    program_slug_aliases: []
+    title: Heroku Open Source Software Credit Program
+    summary: Provides platform credits to qualifying open source software projects hosted on Heroku for one year.
+    source_ids:
+      - src_d382abbba5efb102619acb5f82ed5b847d8e5be62c9ee1bd05d2c745443c74ae
+offers:
+  - offer_id: off_01kyy6rm11g847yyf4psvfj6xj
+    program_id: prg_01kyy6rm10n2rph7sn8jaxhpnq
+    offer_slug: heroku-open-source-software-credit-program
+    offer_slug_aliases: []
+    title: Heroku Open Source Software Credit Program
+    summary: Qualifying open source software projects hosted on Heroku receive 12 months of monthly platform credits, typically ranging between $25 and $500 USD per month, applicable to Heroku products.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:52:32.793Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Set monthly credit allocation for 12 months, expected to range between $25 and $500 USD per month, applicable to Heroku products like Dynos, Postgres, and Key-Value Store.
+          duration:
+            kind: exact
+            value: P1Y
+          kind: credit
+          value:
+            kind: range
+            maximum:
+              currency: USD
+              minor_units: 50000
+            minimum:
+              currency: USD
+              minor_units: 2500
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: Must be a maintainer on the open source software project.
+          - criterion_id: cri_02
+            kind: manual
+            reason: not-machine-evaluable
+            statement: Supporting infrastructure must run or intend to run on Heroku.
+          - criterion_id: cri_03
+            kind: manual
+            reason: external-verification
+            statement: Must have an active Heroku account (personal or team) verified with a valid credit or debit card on file.
+          - criterion_id: cri_04
+            kind: manual
+            reason: external-verification
+            statement: Must maintain and adhere to a Code of Conduct.
+          - criterion_id: cri_05
+            kind: manual
+            reason: external-verification
+            statement: Project must use an open source standard license.
+          - kind: not
+            rule:
+              criterion_id: cri_06
+              kind: manual
+              reason: external-verification
+              statement: Salesforce employees or officials of government entities are not eligible.
+    roles:
+      terms_authority_entity_id: ent_01kyy6rm10g6b7jtmft8n6qr0n
+      access_operator_entity_id: ent_01kyy6rm10g6b7jtmft8n6qr0n
+    access:
+      availability: public
+      method: form
+      url: https://www.heroku.com/open-source-credit-program/
+    source_ids:
+      - src_d382abbba5efb102619acb5f82ed5b847d8e5be62c9ee1bd05d2c745443c74ae

--- a/vendors/in/infobip.yaml
+++ b/vendors/in/infobip.yaml
@@ -1,0 +1,61 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyy6rm118txnxw89bwedy5za
+slug: infobip
+slug_aliases: []
+name: Infobip
+domains:
+  - value: infobip.com
+    role: primary
+    valid_from: 2026-08-01T07:45:57.212Z
+category: communication
+description: Infobip Startup Tribe is a global perks program supporting startups and providing them with tools and resources to help their growth.
+links:
+  site: https://startups.infobip.com/
+sources:
+  - source_id: src_40ad940d613ab9ddb36a242856dd077f8f37a49a2682058f75ad4cbd185e014c
+    url: https://startups.infobip.com/
+programs:
+  - program_id: prg_01kyy6rm11xak7d44a8h0nbxts
+    program_slug: infobip-startup-tribe
+    program_slug_aliases: []
+    title: Infobip Startup Tribe
+    summary: Infobip Startup Tribe is a global perks program supporting startups and providing them with tools and resources to help their growth.
+    source_ids:
+      - src_40ad940d613ab9ddb36a242856dd077f8f37a49a2682058f75ad4cbd185e014c
+offers:
+  - offer_id: off_01kyy6rm113283702knrn3jd2r
+    program_id: prg_01kyy6rm11xak7d44a8h0nbxts
+    offer_slug: infobip-startup-tribe-product-credits
+    offer_slug_aliases: []
+    title: Infobip Startup Tribe Product Credits
+    summary: Eligible startups can receive up to $60,000 in product credits for Infobip solutions alongside dedicated support service.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:45:57.212Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $60,000 in product credits for Infobip solutions and dedicated support service.
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 6000000
+            kind: up-to
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: vendor-discretion
+        statement: Qualify as a startup eligible for the Infobip Startup Tribe program.
+    roles:
+      terms_authority_entity_id: ent_01kyy6rm118txnxw89bwedy5za
+      access_operator_entity_id: ent_01kyy6rm118txnxw89bwedy5za
+    access:
+      availability: public
+      method: form
+      url: https://startups.infobip.com/
+    source_ids:
+      - src_40ad940d613ab9ddb36a242856dd077f8f37a49a2682058f75ad4cbd185e014c

--- a/vendors/in/instatus.yaml
+++ b/vendors/in/instatus.yaml
@@ -1,0 +1,60 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyy6rm11hm2dymvf2c2pzerx
+slug: instatus
+slug_aliases: []
+name: Instatus
+domains:
+  - value: instatus.com
+    role: primary
+    valid_from: 2026-08-01T07:23:36.417Z
+category: observability
+description: Monitor your services, fix incidents with your team, and share your status with customers. Beautiful, fast status pages in seconds.
+links:
+  site: https://instatus.com
+sources:
+  - source_id: src_5b7b90a514fa995dbf9db84b4b2510dd87626e8b41fc92bf8cc049c10a74758a
+    url: https://instatus.com/startups
+programs: []
+offers:
+  - offer_id: off_01kyy6rm11kxrvh3g6w6xmprtd
+    offer_slug: instatus-pro-plan-1-year-free-for-startups
+    offer_slug_aliases: []
+    title: Instatus Pro Plan 1 Year Free for Startups
+    summary: Members of partner communities including Secret, FounderPass, RocketHub, or StartGround can receive 1 year free on the Instatus Pro plan.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:23:36.417Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: 1 year free on the Pro plan
+          duration:
+            kind: exact
+            value: P1Y
+          kind: free-service
+          service: Instatus Pro plan
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        fact: company.partner_memberships
+        kind: predicate
+        operator: in
+        statement: Must be a member of Secret, FounderPass, RocketHub, or StartGround
+        value:
+          type: string-set
+          values:
+            - Secret
+            - FounderPass
+            - RocketHub
+            - StartGround
+    roles:
+      terms_authority_entity_id: ent_01kyy6rm11hm2dymvf2c2pzerx
+      access_operator_entity_id: ent_01kyy6rm11hm2dymvf2c2pzerx
+    access:
+      availability: membership
+      method: form
+      url: https://instatus.com/startups
+    source_ids:
+      - src_5b7b90a514fa995dbf9db84b4b2510dd87626e8b41fc92bf8cc049c10a74758a

--- a/vendors/le/leadsquared.yaml
+++ b/vendors/le/leadsquared.yaml
@@ -1,0 +1,104 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyy6rm11kwr4wc8z78k88vpf
+slug: leadsquared
+slug_aliases: []
+name: LeadSquared
+domains:
+  - value: leadsquared.com
+    role: primary
+    valid_from: 2026-08-01T07:52:32.914Z
+category: crm-sales
+description: LeadSquared provides sales CRM, service CRM, and marketing automation solutions to help businesses manage leads and scale operations.
+links:
+  site: https://www.leadsquared.com
+sources:
+  - source_id: src_9103159771e2eeda06ba7f868d6fd9f9aefe53085b1d91a7dfd7d0b19eb2d40d
+    url: https://www.leadsquared.com/startup-crm-plan
+programs: []
+offers:
+  - offer_id: off_01kyy6rm1148f41n9qkdtpnj5p
+    offer_slug: leadsquared-crm-plan-for-start-ups
+    offer_slug_aliases: []
+    title: LeadSquared CRM Plan For Start-ups
+    summary: Eligible startups in India can receive up to 60% off LeadSquared Super or Enterprise plans for their first 15 users for one year, along with free admin certification and a named account manager.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:52:32.914Z
+    economics:
+      benefits:
+        - applies_to: first 15 users on Super/ Enterprise plans
+          benefit_id: ben_01
+          description: 60% off on the first 15 users on Super/ Enterprise plans
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            basis_points: 6000
+            kind: exact
+        - benefit_id: ben_02
+          description: Free admin certification for 1 user
+          kind: waiver
+          waived_item: admin certification for 1 user
+        - benefit_id: ben_03
+          description: Named account manager
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.user_count
+            kind: predicate
+            operator: gte
+            statement: Minimum of 5 users
+            value:
+              type: number
+              value: 5
+          - criterion_id: cri_02
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: Startup should be launched less than 5 years ago
+            value:
+              type: number
+              value: 60
+          - criterion_id: cri_03
+            fact: company.stage
+            kind: predicate
+            operator: in
+            statement: Funding stage up to series B
+            value:
+              type: string-set
+              values:
+                - pre-seed
+                - seed
+                - series-a
+                - series-b
+          - criterion_id: cri_04
+            fact: company.country_code
+            kind: predicate
+            operator: eq
+            statement: Only for startups registered in India
+            value:
+              type: string
+              value: IND
+          - criterion_id: cri_05
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: Only for startups with no prior billing history with LeadSquared
+            value:
+              type: boolean
+              value: false
+    roles:
+      terms_authority_entity_id: ent_01kyy6rm11kwr4wc8z78k88vpf
+      access_operator_entity_id: ent_01kyy6rm11kwr4wc8z78k88vpf
+    access:
+      availability: public
+      method: form
+      url: https://www.leadsquared.com/startup-crm-plan
+    source_ids:
+      - src_9103159771e2eeda06ba7f868d6fd9f9aefe53085b1d91a7dfd7d0b19eb2d40d

--- a/vendors/li/linode.yaml
+++ b/vendors/li/linode.yaml
@@ -1,0 +1,76 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyy6rm112acrfvna23vhdx0y
+slug: linode
+slug_aliases: []
+name: Linode
+domains:
+  - value: linode.com
+    role: primary
+    valid_from: 2026-08-01T07:52:41.220Z
+category: hosting-infra
+description: Grow your startup with powerful and easy-to-use cloud infrastructure, cut your monthly cloud bills in half, plus these and other benefits.
+links:
+  site: https://www.linode.com
+sources:
+  - source_id: src_aef2895dcfeab0ea63144f42ecaea5d7a30ad59fe505c2df0a3c026a20020312
+    url: https://www.linode.com/content/rise-startup-program
+programs:
+  - program_id: prg_01kyy6rm11nqabqtytn5x220kn
+    program_slug: linode-rise-startup-program
+    program_slug_aliases: []
+    title: Linode Rise Startup Program
+    summary: Linode Rise Startup Program offers startups up to $120,000 in free cloud infrastructure credits during their first year alongside consulting, IT services, community access, and prioritized support.
+    source_ids:
+      - src_aef2895dcfeab0ea63144f42ecaea5d7a30ad59fe505c2df0a3c026a20020312
+offers:
+  - offer_id: off_01kyy6rm11bj4d10zfpz0y23c3
+    program_id: prg_01kyy6rm11nqabqtytn5x220kn
+    offer_slug: linode-rise-startup-program
+    offer_slug_aliases: []
+    title: Linode Rise Startup Program
+    summary: Qualify for up to $120,000 in free cloud infrastructure credits during your first year, along with cloud consulting, IT services guidance, community access, and prioritized 24/7/365 support.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:52:41.220Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $120,000 in free cloud infrastructure credits during your first year as a Linode Rise member.
+          duration:
+            kind: exact
+            value: P1Y
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 12000000
+            kind: up-to
+        - benefit_id: ben_02
+          description: Cloud consulting leveraging cloud architecture experts to help build, launch, and scale your business.
+          kind: other
+        - benefit_id: ben_03
+          description: IT services guidance on architecture, migrations, and more ($250/hour value).
+          kind: other
+        - benefit_id: ben_04
+          description: Connect with other program members, alumni, advisors, and Linode resources.
+          kind: other
+        - benefit_id: ben_05
+          description: Prioritized 24/7/365 award-winning customer support via phone, email, or social media.
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: vendor-discretion
+        statement: Qualify for the Linode Rise Startup Program.
+    roles:
+      terms_authority_entity_id: ent_01kyy6rm112acrfvna23vhdx0y
+      access_operator_entity_id: ent_01kyy6rm112acrfvna23vhdx0y
+    access:
+      availability: public
+      method: other
+      url: https://www.linode.com/content/rise-startup-program/
+    source_ids:
+      - src_aef2895dcfeab0ea63144f42ecaea5d7a30ad59fe505c2df0a3c026a20020312

--- a/vendors/mo/mojoauth.yaml
+++ b/vendors/mo/mojoauth.yaml
@@ -1,0 +1,95 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyy6rm11tqmdj1t2djz0e5n9
+slug: mojoauth
+slug_aliases: []
+name: MojoAuth
+domains:
+  - value: mojoauth.com
+    role: primary
+    valid_from: 2026-08-01T07:24:19.707Z
+category: auth-security
+description: MojoAuth provides passwordless authentication solutions supporting magic links, biometrics, OTPs, passkeys, and social logins for web and mobile applications.
+links:
+  site: https://mojoauth.com/startup/
+sources:
+  - source_id: src_f531867c7c84fc043f4d8583bce8c4b741a8a0a8a4186d76b1b47268939ec364
+    url: https://mojoauth.com/startup
+programs: []
+offers:
+  - offer_id: off_01kyy6rm11rehsejy2wess6stj
+    offer_slug: startup-and-non-profit-discount
+    offer_slug_aliases: []
+    title: Startup and Non-Profit Discount
+    summary: MojoAuth offers eligible early-stage startups and non-profit organizations a 50% discount on annual Business Pro plans.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:24:19.707Z
+    economics:
+      benefits:
+        - applies_to: annual Business Pro plans
+          benefit_id: ben_01
+          description: 50% discount on annual Business Pro authentication plans.
+          kind: discount
+          percentage:
+            basis_points: 5000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - kind: any
+            rules:
+              - kind: all
+                rules:
+                  - criterion_id: cri_01
+                    fact: company.age_months
+                    kind: predicate
+                    operator: lt
+                    statement: Company was founded less than 5 years ago.
+                    value:
+                      type: number
+                      value: 60
+                  - criterion_id: cri_02
+                    fact: company.funding_raised_usd
+                    kind: predicate
+                    operator: lte
+                    statement: Company has raised not more than $10M USD in total funding.
+                    value:
+                      type: number
+                      value: 10000000
+              - criterion_id: cri_03
+                fact: company.industry
+                kind: predicate
+                operator: eq
+                statement: Organization is a non-profit / NGO.
+                value:
+                  type: string
+                  value: non-profit
+          - criterion_id: cri_04
+            kind: manual
+            reason: external-verification
+            statement: Ensure the business email in your application matches your organization's website domain.
+          - criterion_id: cri_05
+            fact: company.website_url
+            kind: predicate
+            operator: present
+            statement: Must have a publicly available website.
+          - criterion_id: cri_06
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: Must not be an existing MojoAuth customer.
+            value:
+              type: boolean
+              value: false
+    roles:
+      terms_authority_entity_id: ent_01kyy6rm11tqmdj1t2djz0e5n9
+      access_operator_entity_id: ent_01kyy6rm11tqmdj1t2djz0e5n9
+    access:
+      availability: public
+      method: form
+      url: https://mojoauth.com/startup/
+    source_ids:
+      - src_f531867c7c84fc043f4d8583bce8c4b741a8a0a8a4186d76b1b47268939ec364


### PR DESCRIPTION
Adds 20 genuinely valuable startup offers through the canonical first-party scan, curation, evidence review, and admission pipeline.

- 20 changed vendor YAML files only
- 20 net-new offers
- immutable evidence authority set: `sha256:1042fe8b5c124d3bb6525f7b5d3774c4f673f346bde93c6ff9f40a849b634b6e`
- prebuilt changed-only candidate: `sha256:663284676f70283ddf1f6bfdf0b9b345ad011680bf81af0000013f3e272003e9`
- expected successor release: `sha256:312edf809619bb41fedb94ebd47a2d66ab8d8ad537badfa3683666dff1cb944f`