### PR TITLE
Add 16 reviewed startup offers

### DIFF
--- a/vendors/op/openrouter.yaml
+++ b/vendors/op/openrouter.yaml
@@ -1,0 +1,116 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyy6rm11txma0afjpbmd0wr7
+slug: openrouter
+slug_aliases: []
+name: OpenRouter
+domains:
+  - value: openrouter.ai
+    role: primary
+    valid_from: 2026-08-01T07:25:22.175Z
+category: ai-ml
+description: Everything an early-stage team needs to build, experiment, and scale with AI — without managing multiple providers.
+links:
+  site: https://openrouter.ai
+sources:
+  - source_id: src_4426499e39beb6ef34e0c6908222fc3526896f1dbc2517568a83e65f051fea96
+    url: https://openrouter.ai/startup-program
+programs:
+  - program_id: prg_01kyy6rm114c1epkc37ek9hm0n
+    program_slug: openrouter-for-startups
+    program_slug_aliases: []
+    title: OpenRouter for Startups
+    summary: Program offering credits, fee waivers, and multi-model API access to early-stage startups building with AI.
+    source_ids:
+      - src_4426499e39beb6ef34e0c6908222fc3526896f1dbc2517568a83e65f051fea96
+offers:
+  - offer_id: off_01kyy6rm11sx0g8q587c41vrgp
+    program_id: prg_01kyy6rm114c1epkc37ek9hm0n
+    offer_slug: openrouter-for-startups
+    offer_slug_aliases: []
+    title: OpenRouter for Startups
+    summary: Eligible early-stage startups get up to $5,000 in universal inference credits and 0% processing fees for 12 months across models on OpenRouter.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:25:22.175Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $5,000 in universal inference credits usable across all models on OpenRouter.
+          duration:
+            kind: exact
+            value: P6M
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 500000
+            kind: up-to
+        - applies_to: OpenRouter processing fees
+          benefit_id: ben_02
+          description: 0% processing fees (including platform fees and BYOK fees) for 12 months.
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            basis_points: 10000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.stage
+            kind: predicate
+            operator: eq
+            statement: Pre-Series B stage startup
+            value:
+              type: string
+              value: Pre-Series B
+          - criterion_id: cri_02
+            fact: company.industry
+            kind: predicate
+            operator: contains
+            statement: Building an AI-native product
+            value:
+              type: string
+              value: AI
+          - criterion_id: cri_03
+            kind: manual
+            reason: external-verification
+            statement: Referred by an approved OpenRouter partner
+          - criterion_id: cri_04
+            fact: company.has_public_website
+            kind: predicate
+            operator: eq
+            statement: Have a public company website
+            value:
+              type: boolean
+              value: true
+          - criterion_id: cri_05
+            kind: manual
+            reason: external-verification
+            statement: Apply with a company email address, associated with an OpenRouter account
+          - criterion_id: cri_06
+            fact: company.openrouter_spend_usd
+            kind: predicate
+            operator: lt
+            statement: Have less than $500 in lifetime OpenRouter spend
+            value:
+              type: number
+              value: 500
+          - criterion_id: cri_07
+            kind: manual
+            reason: external-verification
+            statement: Haven't previously received startup credits
+    roles:
+      terms_authority_entity_id: ent_01kyy6rm11txma0afjpbmd0wr7
+      access_operator_entity_id: ent_01kyy6rm11txma0afjpbmd0wr7
+    access:
+      availability: referral
+      method: form
+      url: https://openrouter.ai/startup-program
+    source_ids:
+      - src_4426499e39beb6ef34e0c6908222fc3526896f1dbc2517568a83e65f051fea96

--- a/vendors/ov/ovhcloud-us.yaml
+++ b/vendors/ov/ovhcloud-us.yaml
@@ -1,0 +1,125 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyy6rm11f3azdjg2dn90sz49
+slug: ovhcloud-us
+slug_aliases: []
+name: OVHcloud US
+domains:
+  - value: us.ovhcloud.com
+    role: primary
+    valid_from: 2026-08-01T07:46:23.051Z
+category: hosting-infra
+description: OVHcloud is a global cloud provider delivering hosted private cloud, public cloud, and dedicated server solutions.
+links:
+  site: https://us.ovhcloud.com/startup-program
+sources:
+  - source_id: src_903d24dc7be1a157fecf269fed025f305b10c490ba94c0d6ac491c91dd57e3d7
+    url: https://us.ovhcloud.com/startup-program
+programs:
+  - program_id: prg_01kyy6rm11jz304jdn8r48wajj
+    program_slug: ovhcloud-us-startup-program
+    program_slug_aliases: []
+    title: OVHcloud US Startup Program
+    summary: Provides startups and scaleups with cloud resources, technical expertise, and mentorship to accelerate growth on OVHcloud public cloud solutions.
+    source_ids:
+      - src_903d24dc7be1a157fecf269fed025f305b10c490ba94c0d6ac491c91dd57e3d7
+offers:
+  - offer_id: off_01kyy6rm11xpww455ebgve5tbd
+    program_id: prg_01kyy6rm11jz304jdn8r48wajj
+    offer_slug: ovhcloud-us-startup-program-start-level
+    offer_slug_aliases: []
+    title: OVHcloud US Startup Program - START Level
+    summary: Offers pre-seed and seed startups up to $12,000 in free public cloud credits, 6 hours of 1-on-1 technical support with an engineer, and mentoring over 12 months.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:46:23.051Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $12,000 of OVHcloud free public cloud credits
+          duration:
+            kind: exact
+            value: P1Y
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 1200000
+            kind: up-to
+        - benefit_id: ben_02
+          description: 6 hours of 1-on-1 time with an engineer (free)
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        fact: company.stage
+        kind: predicate
+        operator: in
+        statement: Must be a pre-seed or seed stage startup.
+        value:
+          type: string-set
+          values:
+            - pre-seed
+            - seed
+    roles:
+      terms_authority_entity_id: ent_01kyy6rm11f3azdjg2dn90sz49
+      access_operator_entity_id: ent_01kyy6rm11f3azdjg2dn90sz49
+    access:
+      availability: public
+      method: form
+      url: https://us.ovhcloud.com/startup-program/
+    source_ids:
+      - src_903d24dc7be1a157fecf269fed025f305b10c490ba94c0d6ac491c91dd57e3d7
+  - offer_id: off_01kyy6rm113fsmr0y3r9m40hsr
+    program_id: prg_01kyy6rm11jz304jdn8r48wajj
+    offer_slug: ovhcloud-us-startup-program-scale-level
+    offer_slug_aliases: []
+    title: OVHcloud US Startup Program - SCALE Level
+    summary: Offers series A and above startups up to $120,000 in free public cloud credits, 20 hours of 1-on-1 technical support with an engineer, and mentoring over 12 months.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:46:23.051Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $120,000 of OVHcloud free public cloud credits
+          duration:
+            kind: exact
+            value: P1Y
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 12000000
+            kind: up-to
+        - benefit_id: ben_02
+          description: 20 hours of 1-on-1 time with an engineer (free)
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        fact: company.stage
+        kind: predicate
+        operator: in
+        statement: Must be a series A or above startup.
+        value:
+          type: string-set
+          values:
+            - series-a
+            - series-b
+            - series-c
+            - series-d
+            - series-e
+            - growth
+    roles:
+      terms_authority_entity_id: ent_01kyy6rm11f3azdjg2dn90sz49
+      access_operator_entity_id: ent_01kyy6rm11f3azdjg2dn90sz49
+    access:
+      availability: public
+      method: form
+      url: https://us.ovhcloud.com/startup-program/
+    source_ids:
+      - src_903d24dc7be1a157fecf269fed025f305b10c490ba94c0d6ac491c91dd57e3d7

--- a/vendors/pe/perplexity.yaml
+++ b/vendors/pe/perplexity.yaml
@@ -1,0 +1,98 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyy6rm11ae69evf2r3g632h2
+slug: perplexity
+slug_aliases: []
+name: Perplexity
+domains:
+  - value: perplexity.ai
+    role: primary
+    valid_from: 2026-08-01T07:52:57.012Z
+category: ai-ml
+description: Perplexity provides AI research capabilities and web search APIs including Enterprise Pro and Sonar API.
+links:
+  site: https://www.perplexity.ai
+sources:
+  - source_id: src_a78bd3849b7d3d6ca9f419e200e7674aac987c078d8cd59fe997d213018782eb
+    url: https://www.perplexity.ai/startups
+programs:
+  - program_id: prg_01kyy6rm11dawpz4q5vrsq64kr
+    program_slug: perplexity-for-startups
+    program_slug_aliases: []
+    title: Perplexity for Startups
+    summary: Perplexity for Startups provides eligible early-stage startups with free Enterprise Pro access and Sonar API credits.
+    source_ids:
+      - src_a78bd3849b7d3d6ca9f419e200e7674aac987c078d8cd59fe997d213018782eb
+offers:
+  - offer_id: off_01kyy6rm11h1kf0nkv41d720c9
+    program_id: prg_01kyy6rm11dawpz4q5vrsq64kr
+    offer_slug: perplexity-for-startups-benefit-bundle
+    offer_slug_aliases: []
+    title: Perplexity for Startups Benefit Bundle
+    summary: Eligible startups get 3 months of free Perplexity Enterprise Pro for up to 50 seats, plus $5,000 in API credits for growth.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:52:57.012Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: 3 months of free Perplexity Enterprise Pro for up to 50 seats
+          duration:
+            kind: exact
+            value: P3M
+          kind: free-service
+          service: Perplexity Enterprise Pro (up to 50 seats)
+        - benefit_id: ben_02
+          description: $5,000 in API credits
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 500000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lte
+            statement: Raised no more than $20M in equity funding
+            value:
+              type: number
+              value: 20000000
+          - criterion_id: cri_02
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: Less than 5 years old
+            value:
+              type: number
+              value: 60
+          - criterion_id: cri_03
+            fact: company.partner_memberships
+            kind: predicate
+            operator: contains
+            statement: Associated with one of the approved Startup Partners
+            value:
+              type: string
+              value: approved_startup_partner
+          - criterion_id: cri_04
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: Not an existing Enterprise Pro subscriber
+            value:
+              type: boolean
+              value: false
+    roles:
+      terms_authority_entity_id: ent_01kyy6rm11ae69evf2r3g632h2
+      access_operator_entity_id: ent_01kyy6rm11ae69evf2r3g632h2
+    access:
+      availability: membership
+      method: form
+      url: https://www.perplexity.ai/startups/
+    source_ids:
+      - src_a78bd3849b7d3d6ca9f419e200e7674aac987c078d8cd59fe997d213018782eb

--- a/vendors/pi/pivony.yaml
+++ b/vendors/pi/pivony.yaml
@@ -1,0 +1,53 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyy6rm1156gc8nnj32x880vw
+slug: pivony
+slug_aliases: []
+name: Pivony
+domains:
+  - value: pivony.com
+    role: primary
+    valid_from: 2026-08-01T07:35:34.029Z
+category: data-analytics
+description: Pivony is a new-generation, Agentic AI-powered Voice of Customer (VoC) and Customer Experience (CX) analytics platform operating across Turkey and global markets.
+links:
+  site: https://pivony.com/
+sources:
+  - source_id: src_e1cf6479807e9b0688a5398650ed2217131c5a7250f79d70504944368fe37d3d
+    url: https://pivony.com/startups
+programs: []
+offers:
+  - offer_id: off_01kyy6rm11a6hc0qe8rqwar8bj
+    offer_slug: free-rca-in-48h
+    offer_slug_aliases: []
+    title: Free RCA in 48h
+    summary: Upload data to receive a free Root Cause Analysis (RCA) in 48 hours.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:35:34.029Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Free Root Cause Analysis (RCA) delivered in 48 hours.
+          duration:
+            kind: exact
+            value: P2D
+          kind: free-service
+          service: Free RCA Analysis
+      consideration:
+        description: Upload data
+        kind: variable
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: not-machine-evaluable
+        statement: Upload data for analysis.
+    roles:
+      terms_authority_entity_id: ent_01kyy6rm1156gc8nnj32x880vw
+      access_operator_entity_id: ent_01kyy6rm1156gc8nnj32x880vw
+    access:
+      availability: public
+      method: other
+      url: https://pivony.com/
+    source_ids:
+      - src_e1cf6479807e9b0688a5398650ed2217131c5a7250f79d70504944368fe37d3d

--- a/vendors/re/remote.yaml
+++ b/vendors/re/remote.yaml
@@ -14,7 +14,16 @@ links:
 sources:
   - source_id: src_53cc73a8bcbb3adc5cb83545f0f51aacbd955a1a644b465dc1878aebbe49333e
     url: https://remote.com/global-hr/small-business
-programs: []
+  - source_id: src_5637f24101627f4de80403d0704f41e07d9054bd83948cf0018b653001047fa4
+    url: https://remote.com/global-hr/startups
+programs:
+  - program_id: prg_01kyy6rm11sqz3yrwfb6j21620
+    program_slug: remote-for-startups
+    program_slug_aliases: []
+    title: Remote for Startups
+    summary: Remote for Startups offers eligible early-stage startups promotional pricing and discounts on global HR, payroll, contractor management, EOR, and PEO services.
+    source_ids:
+      - src_5637f24101627f4de80403d0704f41e07d9054bd83948cf0018b653001047fa4
 offers:
   - offer_id: off_01kyh8fpe408k67p925g1km9bt
     offer_slug: remote-startups-discount
@@ -51,3 +60,52 @@ offers:
       public_code: RFS15OFF
     source_ids:
       - src_53cc73a8bcbb3adc5cb83545f0f51aacbd955a1a644b465dc1878aebbe49333e
+  - offer_id: off_01kyy6rm11y74fg69yjhv6dqrm
+    program_id: prg_01kyy6rm11sqz3yrwfb6j21620
+    offer_slug: vc-referral-additional-discount
+    offer_slug_aliases: []
+    title: VC Referral Additional Discount
+    summary: Get an additional 5% discount (up to 20% total) on Remote services by introducing Remote to your venture capital or private equity firm.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:35:57.208Z
+    economics:
+      benefits:
+        - applies_to: Remote services
+          benefit_id: ben_01
+          description: Additional 5% discount (up to 20% total discount)
+          kind: discount
+          percentage:
+            basis_points: 500
+            kind: exact
+      consideration:
+        description: Introduce Remote to your venture capital or private equity firm
+        kind: variable
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.stage
+            kind: predicate
+            operator: in
+            statement: Must have raised pre-seed, seed, or Series A funding from a venture capital firm, accelerator, incubator, or other startup-enabling organisation.
+            value:
+              type: string-set
+              values:
+                - pre-seed
+                - seed
+                - series-a
+          - criterion_id: cri_02
+            kind: manual
+            reason: not-machine-evaluable
+            statement: Introduce your non-partner investor (venture capital or private equity firm) to Remote.
+    roles:
+      terms_authority_entity_id: ent_01kyh8fpe4dkt6qsga03ep38rk
+      access_operator_entity_id: ent_01kyh8fpe4dkt6qsga03ep38rk
+    access:
+      availability: referral
+      method: contact
+      url: https://remote.com/global-hr/startups
+    source_ids:
+      - src_5637f24101627f4de80403d0704f41e07d9054bd83948cf0018b653001047fa4

--- a/vendors/sc/scalingo.yaml
+++ b/vendors/sc/scalingo.yaml
@@ -1,0 +1,64 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyy6rm1109h04rp6g2q31qz2
+slug: scalingo
+slug_aliases: []
+name: Scalingo
+domains:
+  - value: scalingo.com
+    role: primary
+    valid_from: 2026-08-01T07:36:57.844Z
+category: hosting-infra
+description: Scalingo is a European Platform as a Service (PaaS) offering cloud hosting for web applications and databases.
+links:
+  site: https://scalingo.com/
+sources:
+  - source_id: src_c916f732e6f752b46d716b7833b802341ababbdc519dc43530a4d935ac4b2f40
+    url: https://scalingo.com/startup-program
+programs:
+  - program_id: prg_01kyy6rm11nyb13stz3q9apfvh
+    program_slug: scalingo-s-startup-program
+    program_slug_aliases: []
+    title: Scalingo's Startup Program
+    summary: Scalingo's program tailored for startups and incubators to help build, deploy, and scale web applications.
+    source_ids:
+      - src_c916f732e6f752b46d716b7833b802341ababbdc519dc43530a4d935ac4b2f40
+offers:
+  - offer_id: off_01kyy6rm1110hhawrq7k6818zd
+    program_id: prg_01kyy6rm11nyb13stz3q9apfvh
+    offer_slug: scalingo-startup-program
+    offer_slug_aliases: []
+    title: Scalingo Startup Program
+    summary: Eligible startups receive up to 1800€ in free cloud hosting over their first 9 months (up to 200€ per month).
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:36:57.844Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to 1800€ of free cloud hosting over 9 months (up to 200€ per month)
+          duration:
+            kind: exact
+            value: P9M
+          kind: credit
+          value:
+            amount:
+              currency: EUR
+              minor_units: 180000
+            kind: up-to
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: external-verification
+        statement: The program is made for startup and incubators.
+    roles:
+      terms_authority_entity_id: ent_01kyy6rm1109h04rp6g2q31qz2
+      access_operator_entity_id: ent_01kyy6rm1109h04rp6g2q31qz2
+    access:
+      availability: public
+      method: form
+      url: https://scalingo.com/startup-program
+    source_ids:
+      - src_c916f732e6f752b46d716b7833b802341ababbdc519dc43530a4d935ac4b2f40

--- a/vendors/sh/shortcut.yaml
+++ b/vendors/sh/shortcut.yaml
@@ -1,0 +1,98 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyy6rm110xattc8fm7p4z3h4
+slug: shortcut
+slug_aliases: []
+name: Shortcut
+domains:
+  - value: shortcut.com
+    role: primary
+    valid_from: 2026-08-01T07:53:58.333Z
+category: productivity
+description: Fast, powerful project management.
+links:
+  site: https://www.shortcut.com
+sources:
+  - source_id: src_fba28d9e98cf5fd96f29947462623a8a41e819dbd3320f7bf9fcedbadf6952bb
+    url: https://www.shortcut.com/startups
+programs:
+  - program_id: prg_01kyy6rm1199bvxcse3ya91bbb
+    program_slug: shortcut-startup-program
+    program_slug_aliases: []
+    title: Shortcut Startup Program
+    summary: Get 12 months of free access to the Shortcut Business Plan plus SAML SSO for eligible early-stage startups.
+    source_ids:
+      - src_fba28d9e98cf5fd96f29947462623a8a41e819dbd3320f7bf9fcedbadf6952bb
+offers:
+  - offer_id: off_01kyy6rm11cv7shbfhj6jcmwex
+    program_id: prg_01kyy6rm1199bvxcse3ya91bbb
+    offer_slug: shortcut-startup-program
+    offer_slug_aliases: []
+    title: Shortcut Startup Program
+    summary: Eligible early-stage startups get 12 months free on the Shortcut Business Plan, including SAML SSO.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:53:58.333Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: 12 months free access to the Business Plan including unlimited everything plus SAML SSO
+          duration:
+            kind: exact
+            value: P1Y
+          kind: free-service
+          service: Shortcut Business Plan + SAML SSO
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: You're a new Shortcut customer
+            value:
+              type: boolean
+              value: false
+          - criterion_id: cri_02
+            fact: company.employee_count
+            kind: predicate
+            operator: lt
+            statement: You have fewer than 50 employees
+            value:
+              type: number
+              value: 50
+          - criterion_id: cri_03
+            fact: company.industry
+            kind: predicate
+            operator: neq
+            statement: You're not a service provider or consulting agency
+            value:
+              type: string
+              value: service provider or consulting agency
+          - criterion_id: cri_04
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: You have raised less than $10M USD in external funding
+            value:
+              type: number
+              value: 10000000
+          - criterion_id: cri_05
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: You are a business that's less than 5 years old
+            value:
+              type: number
+              value: 60
+    roles:
+      terms_authority_entity_id: ent_01kyy6rm110xattc8fm7p4z3h4
+      access_operator_entity_id: ent_01kyy6rm110xattc8fm7p4z3h4
+    access:
+      availability: public
+      method: form
+      url: https://www.shortcut.com/startups/
+    source_ids:
+      - src_fba28d9e98cf5fd96f29947462623a8a41e819dbd3320f7bf9fcedbadf6952bb

--- a/vendors/sn/snowflake.yaml
+++ b/vendors/sn/snowflake.yaml
@@ -1,0 +1,56 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyy6rm11pm9wrmnakg0t25vh
+slug: snowflake
+slug_aliases: []
+name: Snowflake
+domains:
+  - value: snowflake.com
+    role: primary
+    valid_from: 2026-08-01T07:53:58.007Z
+category: data-analytics
+description: Snowflake powers startups with scalability, native-AI capabilities, and free usage opportunities.
+links:
+  site: https://www.snowflake.com/en/why-snowflake/startup-program
+sources:
+  - source_id: src_9e63740f68ee8a8689d37d925d23723c170ddb7749e52e803a8d7ac28031aab6
+    url: https://www.snowflake.com/en/why-snowflake/startup-program
+programs:
+  - program_id: prg_01kyy6rm117hynccw661eqhyns
+    program_slug: snowflake-for-startups
+    program_slug_aliases: []
+    title: Snowflake for Startups
+    summary: Snowflake for Startups provides eligible startups with access to technical expertise, free usage, go-to-market guidance, and an ecosystem network.
+    source_ids:
+      - src_9e63740f68ee8a8689d37d925d23723c170ddb7749e52e803a8d7ac28031aab6
+offers:
+  - offer_id: off_01kyy6rm11by32ytvdebnjzdma
+    program_id: prg_01kyy6rm117hynccw661eqhyns
+    offer_slug: snowflake-startup-package
+    offer_slug_aliases: []
+    title: Snowflake Startup Package
+    summary: Snowflake offers eligible startups free usage on their first contract to help build their business on Snowflake.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:53:58.007Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Free usage on first Snowflake contract
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: vendor-discretion
+        statement: Startup eligibility verified by Snowflake
+    roles:
+      terms_authority_entity_id: ent_01kyy6rm11pm9wrmnakg0t25vh
+      access_operator_entity_id: ent_01kyy6rm11pm9wrmnakg0t25vh
+    access:
+      availability: public
+      method: form
+      url: https://www.snowflake.com/en/why-snowflake/startup-program
+    source_ids:
+      - src_9e63740f68ee8a8689d37d925d23723c170ddb7749e52e803a8d7ac28031aab6

--- a/vendors/so/solidworks.yaml
+++ b/vendors/so/solidworks.yaml
@@ -14,6 +14,8 @@ links:
 sources:
   - source_id: src_433d56e774807e78fc005d416ccb032dbfbbb0c9b1bb085d12afc14c32023f3c
     url: https://www.solidworks.com/solution/organization-type/entrepreneurs-startups
+  - source_id: src_a92e46f2ccaee87e57cfa15b48adfc6116cc6ba3a6cac24bc15bb1ae6a007284
+    url: https://www.solidworks.com/solution/solidworks-for-startups-program
 programs:
   - program_id: prg_01kyxthgq3a24stg4hc5egbvpc
     program_slug: 3dexperience-works-for-startups
@@ -22,6 +24,7 @@ programs:
     summary: Provides software, training, co-marketing resources, and tiered discounts to early-stage hardware startups.
     source_ids:
       - src_433d56e774807e78fc005d416ccb032dbfbbb0c9b1bb085d12afc14c32023f3c
+      - src_a92e46f2ccaee87e57cfa15b48adfc6116cc6ba3a6cac24bc15bb1ae6a007284
 offers:
   - offer_id: off_01kyxthgq3t3rdpyt22ban6wyv
     program_id: prg_01kyxthgq3a24stg4hc5egbvpc
@@ -106,3 +109,58 @@ offers:
       url: https://www.solidworks.com/solution/organization-type/entrepreneurs-startups
     source_ids:
       - src_433d56e774807e78fc005d416ccb032dbfbbb0c9b1bb085d12afc14c32023f3c
+  - offer_id: off_01kyy6rm11e42frzp0yxx17z9n
+    offer_slug: solidworks-for-startups-scale-up-software-discount
+    offer_slug_aliases: []
+    title: SOLIDWORKS for Startups - Scale-Up Software Discount
+    summary: 70% discount on software for hardware startups with revenue or funding between $1M and $5M.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:56:05.560Z
+    economics:
+      benefits:
+        - applies_to: SOLIDWORKS software
+          benefit_id: ben_01
+          description: 70% discount on software for scale-up hardware startups
+          kind: discount
+          percentage:
+            basis_points: 7000
+            kind: exact
+      consideration:
+        description: Specific discounted purchase terms determined upon application review.
+        kind: unknown
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - kind: all
+            rules:
+              - criterion_id: cri_01
+                fact: company.revenue_usd
+                kind: predicate
+                operator: gte
+                statement: Revenue or funding is at least $1M
+                value:
+                  type: number
+                  value: 1000000
+              - criterion_id: cri_02
+                fact: company.revenue_usd
+                kind: predicate
+                operator: lte
+                statement: Revenue or funding is at most $5M
+                value:
+                  type: number
+                  value: 5000000
+          - criterion_id: cri_03
+            kind: manual
+            reason: vendor-discretion
+            statement: Reserved right to consider company as a Scale-Up and offer 70% discount
+    roles:
+      terms_authority_entity_id: ent_01kyxthgq36x1akfx7cy4k7268
+      access_operator_entity_id: ent_01kyxthgq36x1akfx7cy4k7268
+    access:
+      availability: public
+      method: form
+      url: https://www.solidworks.com/solution/solidworks-for-startups-program
+    source_ids:
+      - src_a92e46f2ccaee87e57cfa15b48adfc6116cc6ba3a6cac24bc15bb1ae6a007284

--- a/vendors/ss/ssojet.yaml
+++ b/vendors/ss/ssojet.yaml
@@ -1,0 +1,101 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyy6rm115469bs2038mts3wv
+slug: ssojet
+slug_aliases: []
+name: SSOJet
+domains:
+  - value: ssojet.com
+    role: primary
+    valid_from: 2026-08-01T07:37:11.016Z
+category: auth-security
+description: SSOJet provides a turnkey solution for B2B SaaS companies to integrate any SSO provider, eliminating complexity and accelerating enterprise customer onboarding.
+links:
+  site: https://ssojet.com
+sources:
+  - source_id: src_c53f8c0d22be1cfbf7b674bb5776bb964996edbc75d41c15cb4cfe5e250187cd
+    url: https://ssojet.com/startup
+programs:
+  - program_id: prg_01kyy6rm115bw54wf0hbzrxv72
+    program_slug: startup-and-non-profit-program
+    program_slug_aliases: []
+    title: Startup & Non-Profit Program
+    summary: Qualified startups and non-profits get 50% off enterprise SSO for 12 months.
+    source_ids:
+      - src_c53f8c0d22be1cfbf7b674bb5776bb964996edbc75d41c15cb4cfe5e250187cd
+offers:
+  - offer_id: off_01kyy6rm11s7thnevckejfz79j
+    program_id: prg_01kyy6rm115bw54wf0hbzrxv72
+    offer_slug: startup-and-non-profit-program-50-off-enterprise-sso
+    offer_slug_aliases: []
+    title: Startup & Non-Profit Program - 50% Off Enterprise SSO
+    summary: Qualified startups and non-profits get 50% off all paid plans for 12 months.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:37:11.016Z
+    economics:
+      benefits:
+        - applies_to: all paid plans
+          benefit_id: ben_01
+          description: 50% discount on all paid plans for 12 months
+          duration:
+            kind: exact
+            value: P12M
+          kind: discount
+          percentage:
+            basis_points: 5000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: any
+        rules:
+          - kind: all
+            rules:
+              - criterion_id: cri_01
+                fact: company.funding_raised_usd
+                kind: predicate
+                operator: lt
+                statement: Less than $5M in total funding OR less than $3M ARR
+                value:
+                  type: number
+                  value: 5000000
+              - criterion_id: cri_02
+                fact: company.age_months
+                kind: predicate
+                operator: lte
+                statement: Founded in the last 5 years
+                value:
+                  type: number
+                  value: 60
+              - criterion_id: cri_03
+                kind: manual
+                reason: not-machine-evaluable
+                statement: B2B SaaS product with enterprise sales motion
+              - criterion_id: cri_04
+                kind: manual
+                reason: not-machine-evaluable
+                statement: Commitment to implementing within 30 days
+          - kind: all
+            rules:
+              - criterion_id: cri_05
+                kind: manual
+                reason: external-verification
+                statement: Registered 501(c)(3) or equivalent non-profit organization
+              - criterion_id: cri_06
+                kind: manual
+                reason: external-verification
+                statement: Valid proof of non-profit status required
+              - criterion_id: cri_07
+                kind: manual
+                reason: not-machine-evaluable
+                statement: Using SSOJet for organizational or mission-driven purposes
+    roles:
+      terms_authority_entity_id: ent_01kyy6rm115469bs2038mts3wv
+      access_operator_entity_id: ent_01kyy6rm115469bs2038mts3wv
+    access:
+      availability: public
+      method: form
+      url: https://ssojet.com/startup/
+    source_ids:
+      - src_c53f8c0d22be1cfbf7b674bb5776bb964996edbc75d41c15cb4cfe5e250187cd

--- a/vendors/st/stream.yaml
+++ b/vendors/st/stream.yaml
@@ -14,6 +14,8 @@ links:
 sources:
   - source_id: src_74aa65916bac8aee9d14b901778840e2d0aee544eebd1ecc0d33baf0bafe6012
     url: https://getstream.io/partners
+  - source_id: src_eaebbb45fbc11438d7174ce8cbdf133c75f0952abcf82795eb9ea09de9b9543c
+    url: https://getstream.io/maker-account
 programs: []
 offers:
   - offer_id: off_01kyy3083w3k33krxmrqx1kr3w
@@ -112,3 +114,73 @@ offers:
     title: Stream x YC Discount (Under $10M Raised)
     source_ids:
       - src_74aa65916bac8aee9d14b901778840e2d0aee544eebd1ecc0d33baf0bafe6012
+  - offer_id: off_01kyy6rm11jmrkybf0xv2dnm3c
+    offer_slug: maker-account
+    offer_slug_aliases: []
+    title: Maker Account
+    summary: Free access to Stream Chat, Activity Feeds, Moderation ($100/mo credit), and Video & Audio for qualifying small teams.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:22:14.798Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Stream Chat modified Start Plan (up to 2,000 MAU and 100 concurrent connections)
+          kind: free-service
+          service: Stream Chat modified Start Plan
+        - benefit_id: ben_02
+          description: Activity Feeds Start Plan
+          kind: free-service
+          service: Activity Feeds Start Plan
+        - benefit_id: ben_03
+          description: AI Moderation Pay-as-You-Go with $100 Monthly Credit
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 10000
+            kind: exact
+        - benefit_id: ben_04
+          description: Video & Audio Build Plan
+          kind: free-service
+          service: Video & Audio Build Plan
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.employee_count
+            kind: predicate
+            operator: lte
+            statement: Five or less team members
+            value:
+              type: number
+              value: 5
+          - criterion_id: cri_02
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: Less than $100k in funding
+            value:
+              type: number
+              value: 100000
+          - criterion_id: cri_03
+            fact: company.monthly_revenue_usd
+            kind: predicate
+            operator: lt
+            statement: Less than $10k/mo revenue
+            value:
+              type: number
+              value: 10000
+    roles:
+      terms_authority_entity_id: ent_01kyy3083w3k33krxmrqx1kr3t
+      access_operator_entity_id: ent_01kyy3083w3k33krxmrqx1kr3t
+    access:
+      availability: public
+      method: form
+      url: https://getstream.io/maker-account/
+    terms_url: https://getstream.io/terms/
+    source_ids:
+      - src_eaebbb45fbc11438d7174ce8cbdf133c75f0952abcf82795eb9ea09de9b9543c

--- a/vendors/ty/typeform.yaml
+++ b/vendors/ty/typeform.yaml
@@ -1,0 +1,85 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyy6rm11pr34gjj52the9v91
+slug: typeform
+slug_aliases: []
+name: Typeform
+domains:
+  - value: typeform.com
+    role: primary
+    valid_from: 2026-08-01T07:22:34.797Z
+category: no-code
+description: Getting started isn’t easy. That’s why we increased our startup discount to help give you a head start and scale with Typeform for a full year.
+links:
+  site: https://www.typeform.com
+sources:
+  - source_id: src_2142b211d7f3a133a55a0454789308aa35b4ea13453a4ade8c56f485a2a0e8a9
+    url: https://help.typeform.com/hc/en-us/articles/360045878891-Startup-discount-at-Typeform
+programs: []
+offers:
+  - offer_id: off_01kyy6rm11g27a3qdqh4bedb2x
+    offer_slug: typeform-startup-discount
+    offer_slug_aliases: []
+    title: Typeform Startup Discount
+    summary: Eligible seed-stage startups can get 75% off Typeform's Business plan for one year when purchasing a yearly plan.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:22:34.797Z
+    economics:
+      benefits:
+        - applies_to: Business plan (yearly)
+          benefit_id: ben_01
+          description: 75% off the Business plan for a year (available on yearly plan)
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            basis_points: 7500
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.stage
+            kind: predicate
+            operator: eq
+            statement: Your startup must be at a seed stage.
+            value:
+              type: string
+              value: seed
+          - criterion_id: cri_02
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: Your startup must have less than $1 million in funding.
+            value:
+              type: number
+              value: 1000000
+          - criterion_id: cri_03
+            fact: company.lifetime_revenue_usd
+            kind: predicate
+            operator: lt
+            statement: Your startup must have less than $1 million in lifetime revenue.
+            value:
+              type: number
+              value: 1000000
+          - criterion_id: cri_04
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: Your startup must not be an existing Typeform customer.
+            value:
+              type: boolean
+              value: false
+    roles:
+      terms_authority_entity_id: ent_01kyy6rm11pr34gjj52the9v91
+      access_operator_entity_id: ent_01kyy6rm11pr34gjj52the9v91
+    access:
+      availability: public
+      method: form
+      url: https://help.typeform.com/hc/en-us/articles/360045878891-Startup-discount-at-Typeform
+    source_ids:
+      - src_2142b211d7f3a133a55a0454789308aa35b4ea13453a4ade8c56f485a2a0e8a9

--- a/vendors/va/vast-ai.yaml
+++ b/vendors/va/vast-ai.yaml
@@ -1,0 +1,57 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyy6rm11ep927174p948h6wx
+slug: vast-ai
+slug_aliases: []
+name: Vast.ai
+domains:
+  - value: vast.ai
+    role: primary
+    valid_from: 2026-08-01T07:46:37.400Z
+category: hosting-infra
+description: AI compute platform connecting developers with high-performance GPU cloud resources.
+links:
+  site: https://vast.ai
+sources:
+  - source_id: src_cb22dbf0d690f481efa2d6b9618252c3d6e9c781448c57b22f31e6893dd82888
+    url: https://vast.ai/article/vast-ai-startup-program
+programs: []
+offers:
+  - offer_id: off_01kyy6rm11p5gpykb3sgc4xd69
+    offer_slug: vast-ai-startup-program
+    offer_slug_aliases: []
+    title: Vast.ai Startup Program
+    summary: Startups can get up to $2,500 in free GPU credits when moving workloads to Vast.ai, along with 24/7 priority support during the credit period.
+    lifecycle:
+      status: active
+      effective_from: 2026-02-06T00:00:00Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $2,500 in free GPU compute credits
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 250000
+            kind: up-to
+        - benefit_id: ben_02
+          description: 24/7 priority support throughout the credit period
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: vendor-discretion
+        statement: Contact the Vast.ai team to share project details and compute needs for approval and finalized credit offer.
+    roles:
+      terms_authority_entity_id: ent_01kyy6rm11ep927174p948h6wx
+      access_operator_entity_id: ent_01kyy6rm11ep927174p948h6wx
+    access:
+      availability: public
+      instructions: Get in touch with the Vast.ai team to share project details and compute needs to finalize the credit offer.
+      method: contact
+      url: https://vast.ai/article/vast-ai-startup-program
+    source_ids:
+      - src_cb22dbf0d690f481efa2d6b9618252c3d6e9c781448c57b22f31e6893dd82888

--- a/vendors/vu/vultr.yaml
+++ b/vendors/vu/vultr.yaml
@@ -1,0 +1,90 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyy6rm11awx10js3n0fnwqpv
+slug: vultr
+slug_aliases: []
+name: Vultr
+domains:
+  - value: vultr.com
+    role: primary
+    valid_from: 2026-08-01T07:21:35.161Z
+category: hosting-infra
+description: Vultr provides high-performance cloud compute, bare metal, and storage infrastructure for startups and digital businesses.
+links:
+  site: https://discover.vultr.com/startup-program
+sources:
+  - source_id: src_9f9528cc7020f1d4183efb65e78f0abb5ea5aa94f1b71d9ba88b9b6cb25add44
+    url: https://discover.vultr.com/startup-program
+programs:
+  - program_id: prg_01kyy6rm11pt717z74bkg8mfms
+    program_slug: vultr-digital-start-up-program
+    program_slug_aliases: []
+    title: Vultr Digital Start-up Program
+    summary: The Vultr Digital Start-up Program provides up to $100K in cloud credits, discounts, and expert support to help startups migrate and scale.
+    source_ids:
+      - src_9f9528cc7020f1d4183efb65e78f0abb5ea5aa94f1b71d9ba88b9b6cb25add44
+offers:
+  - offer_id: off_01kyy6rm11tv21p9aekaqjz3y3
+    program_id: prg_01kyy6rm11pt717z74bkg8mfms
+    offer_slug: vultr-digital-start-up-program
+    offer_slug_aliases: []
+    title: Vultr Digital Start-up Program
+    summary: Eligible high-growth startups with recent Series A–E funding can receive up to $100K in cloud credits, up to 35% long-term discounts, and expert support.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:21:35.161Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $100K in cloud credits
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 10000000
+            kind: up-to
+        - benefit_id: ben_02
+          description: Up to 35% long-term discounts
+          kind: discount
+          percentage:
+            basis_points: 3500
+            kind: up-to
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.stage
+            kind: predicate
+            operator: in
+            statement: Your startup must have secured recent Series A, B, C, D, or E financing to be eligible for the program.
+            value:
+              type: string-set
+              values:
+                - series_a
+                - series_b
+                - series_c
+                - series_d
+                - series_e
+          - criterion_id: cri_02
+            kind: manual
+            reason: not-machine-evaluable
+            statement: Provide the name and contact details of your senior-most technical executive, such as your CTO or equivalent.
+          - criterion_id: cri_03
+            kind: manual
+            reason: not-machine-evaluable
+            statement: Submit the name and contact details of your senior-most technical cloud infrastructure leader.
+          - criterion_id: cri_04
+            kind: manual
+            reason: external-verification
+            statement: Share your last 6 months of cloud compute invoices and agree to be publicly referenceable as a member of the Vultr Digital Start-up Program.
+    roles:
+      terms_authority_entity_id: ent_01kyy6rm11awx10js3n0fnwqpv
+      access_operator_entity_id: ent_01kyy6rm11awx10js3n0fnwqpv
+    access:
+      availability: public
+      method: form
+      url: https://discover.vultr.com/startup-program
+    source_ids:
+      - src_9f9528cc7020f1d4183efb65e78f0abb5ea5aa94f1b71d9ba88b9b6cb25add44

--- a/vendors/wh/whimsical.yaml
+++ b/vendors/wh/whimsical.yaml
@@ -1,0 +1,90 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyy6rm11yjpn8mjszdjk8q8w
+slug: whimsical
+slug_aliases: []
+name: Whimsical
+domains:
+  - value: whimsical.com
+    role: primary
+    valid_from: 2026-08-01T07:46:37.843Z
+category: productivity
+description: Everything your startup needs to think, plan, and build—faster. Free for 12 months in one powerful workspace.
+links:
+  site: https://whimsical.com
+sources:
+  - source_id: src_78464d3ae9df230bf2d7992272072a79cfe3fc5dfeda7050c90ef5cbbcb4324b
+    url: https://whimsical.com/startups
+programs:
+  - program_id: prg_01kyy6rm117jea467a1whsbhvf
+    program_slug: whimsical-startup-program
+    program_slug_aliases: []
+    title: Whimsical Startup Program
+    summary: Whimsical for Startups offers free access to the Whimsical Pro plan for eligible early-stage startups backed by Whimsical partners.
+    source_ids:
+      - src_78464d3ae9df230bf2d7992272072a79cfe3fc5dfeda7050c90ef5cbbcb4324b
+offers:
+  - offer_id: off_01kyy6rm1172yh0y38pfvg5n0t
+    program_id: prg_01kyy6rm117jea467a1whsbhvf
+    offer_slug: whimsical-startup-program-revenue-under-1m
+    offer_slug_aliases: []
+    title: Whimsical Startup Program (Revenue under $1M)
+    summary: Eligible startups backed by a Whimsical partner with under $1M in revenue receive 12 months of Whimsical Pro for free.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:46:37.843Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: 12 months of Whimsical Pro for free
+          duration:
+            kind: exact
+            value: P1Y
+          kind: free-service
+          service: Whimsical Pro
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.partner_memberships
+            kind: predicate
+            operator: contains
+            statement: Startup is backed by a Whimsical partner
+            value:
+              type: string
+              value: whimsical_partner
+          - criterion_id: cri_02
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: New Whimsical customer
+            value:
+              type: boolean
+              value: false
+          - criterion_id: cri_03
+            fact: company.employee_count
+            kind: predicate
+            operator: lt
+            statement: Fewer than 50 employees
+            value:
+              type: number
+              value: 50
+          - criterion_id: cri_04
+            fact: company.annual_revenue_usd
+            kind: predicate
+            operator: lt
+            statement: Revenue under $1M
+            value:
+              type: number
+              value: 1000000
+    roles:
+      terms_authority_entity_id: ent_01kyy6rm11yjpn8mjszdjk8q8w
+      access_operator_entity_id: ent_01kyy6rm11yjpn8mjszdjk8q8w
+    access:
+      availability: membership
+      method: form
+      url: https://whimsical.com/startups
+    source_ids:
+      - src_78464d3ae9df230bf2d7992272072a79cfe3fc5dfeda7050c90ef5cbbcb4324b


### PR DESCRIPTION
Adds 16 reviewed, first-party-sourced startup offers across 15 thin vendor YAML files. The Sourcey admission artifact is bound to source tree `095726161342688a5ba6aa58f277149fa51b6bb8`; merge remains the sole activation event.