### PR TITLE
catalog: add 20 reviewed startup offers

### DIFF
--- a/vendors/ag/agency-cybersecurity.yaml
+++ b/vendors/ag/agency-cybersecurity.yaml
@@ -1,0 +1,49 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyygma82b2qehpp99y8q0619
+slug: agency-cybersecurity
+slug_aliases: []
+name: Agency Cybersecurity
+domains:
+  - value: getagency.com
+    role: primary
+    valid_from: 2026-08-01T07:22:13.711Z
+category: auth-security
+description: All-in SOC 2 readiness for startups — work, audit, pen test, and tooling — from $2,500 to $12,500.
+links:
+  site: https://getagency.com
+sources:
+  - source_id: src_e887a3a0e3a35ad056b4f882cb319a1237f745b50ad97b4fcb61099be7d04902
+    url: https://getagency.com/startups
+programs: []
+offers:
+  - offer_id: off_01kyygma8297z91f07vvvxxf3j
+    offer_slug: agency-for-startup-credits
+    offer_slug_aliases: []
+    title: Agency for Startup Credits
+    summary: All-in SOC 2 readiness package including audit, pen test, tooling discounts, and management for startups at $2,500 to $12,500 depending on stage.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:22:13.711Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: All-in SOC 2 readiness, audit, penetration test, tooling, and stacked partner credits/discounts up to $50,000 applied over 1 to 4 years.
+          kind: other
+      consideration:
+        description: All-in package pricing ranges from $2,500 to $12,500 USD depending on startup funding stage and stack.
+        kind: variable
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: vendor-discretion
+        statement: Pricing and credits depend on startup funding stage and tech stack.
+    roles:
+      terms_authority_entity_id: ent_01kyygma82b2qehpp99y8q0619
+      access_operator_entity_id: ent_01kyygma82b2qehpp99y8q0619
+    access:
+      availability: public
+      method: form
+      url: https://getagency.com/startups
+    source_ids:
+      - src_e887a3a0e3a35ad056b4f882cb319a1237f745b50ad97b4fcb61099be7d04902

--- a/vendors/an/anrok.yaml
+++ b/vendors/an/anrok.yaml
@@ -1,0 +1,62 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyygma818xh1yt3zwbkvnrfe
+slug: anrok
+slug_aliases: []
+name: Anrok
+domains:
+  - value: anrok.com
+    role: primary
+    valid_from: 2026-07-31T23:39:27.108Z
+category: finance-accounting
+description: Anrok eliminates the complexity of sales tax and VAT for early-stage companies.
+links:
+  site: https://www.anrok.com/startups
+sources:
+  - source_id: src_7361e77d7af58f280c8b3a9a26a676b05a9690a24e4a57c4c7b10e8294bd8d7f
+    url: https://www.anrok.com/startups
+programs: []
+offers:
+  - offer_id: off_01kyygma828k05cy7kgwe2xmqy
+    offer_slug: anrok-starter-plan-for-startups
+    offer_slug_aliases: []
+    title: Anrok Starter Plan for Startups
+    summary: Statewide sales tax and VAT compliance for early-stage companies at $100 per market per month.
+    lifecycle:
+      status: active
+      effective_from: 2026-07-31T23:39:27.108Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Statewide tax compliance including global exposure monitoring, real-time tax calculation, filing and remittance, exemption certificate management, and physical nexus tracking.
+          kind: other
+      consideration:
+        amount:
+          currency: USD
+          minor_units: 10000
+        kind: fixed
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.stage
+            kind: predicate
+            operator: eq
+            statement: Applies to startups and early-stage companies.
+            value:
+              type: string
+              value: startup
+          - criterion_id: cri_02
+            kind: manual
+            reason: external-verification
+            statement: Sellers with high transaction volumes may be subject to additional fees as outlined in their contract.
+    roles:
+      terms_authority_entity_id: ent_01kyygma818xh1yt3zwbkvnrfe
+      access_operator_entity_id: ent_01kyygma818xh1yt3zwbkvnrfe
+    access:
+      availability: public
+      method: form
+      url: https://www.anrok.com/startups
+    terms_url: https://www.anrok.com/startups
+    source_ids:
+      - src_7361e77d7af58f280c8b3a9a26a676b05a9690a24e4a57c4c7b10e8294bd8d7f

--- a/vendors/ca/cake-equity.yaml
+++ b/vendors/ca/cake-equity.yaml
@@ -1,0 +1,83 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyygma82q9t8nnvsv35gp4yn
+slug: cake-equity
+slug_aliases: []
+name: Cake Equity
+domains:
+  - value: cakeequity.com
+    role: primary
+    valid_from: 2026-08-01T10:31:07.188Z
+category: finance-accounting
+description: Cake Equity offers cap table management, equity incentives, and 409A valuations for startups.
+links:
+  site: https://www.cakeequity.com
+sources:
+  - source_id: src_0f43bc86113bc41b2b7fcba125fb521723ae4ba190462dd966eb6ef981a307ce
+    url: https://www.cakeequity.com/pricing
+programs: []
+offers:
+  - offer_id: off_01kyygma82p9pqf1kqebddppkd
+    offer_slug: cake-free-plan
+    offer_slug_aliases: []
+    title: Cake Free Plan
+    summary: Free cap table management and equity features for early-stage companies with up to 5 stakeholders.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T10:31:07.188Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Free plan including cap table, stock options, and SAFE notes for up to 5 stakeholders.
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        fact: company.stakeholder_count
+        kind: predicate
+        operator: lte
+        statement: Company has 5 or fewer stakeholders.
+        value:
+          type: number
+          value: 5
+    roles:
+      terms_authority_entity_id: ent_01kyygma82q9t8nnvsv35gp4yn
+      access_operator_entity_id: ent_01kyygma82q9t8nnvsv35gp4yn
+    access:
+      availability: public
+      method: form
+      url: https://www.cakeequity.com/pricing
+    source_ids:
+      - src_0f43bc86113bc41b2b7fcba125fb521723ae4ba190462dd966eb6ef981a307ce
+  - offer_id: off_01kyygma82pfbkmheyj3qe5bnv
+    offer_slug: free-migration-service
+    offer_slug_aliases: []
+    title: Free Migration Service
+    summary: Compliant human-in-the-loop cap table migration to Cake provided at no cost with every plan.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T10:31:07.188Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Free full migration and reconciliation of cap table data from Carta, competing platforms, or spreadsheets.
+          kind: waiver
+          waived_item: Cap table migration fee
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: not-machine-evaluable
+        statement: Customer subscribes to or signs up for a Cake plan and submits cap table data for migration.
+    roles:
+      terms_authority_entity_id: ent_01kyygma82q9t8nnvsv35gp4yn
+      access_operator_entity_id: ent_01kyygma82q9t8nnvsv35gp4yn
+    access:
+      availability: public
+      method: form
+      url: https://www.cakeequity.com/pricing
+    source_ids:
+      - src_0f43bc86113bc41b2b7fcba125fb521723ae4ba190462dd966eb6ef981a307ce

--- a/vendors/ce/cerebras.yaml
+++ b/vendors/ce/cerebras.yaml
@@ -1,0 +1,60 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyygma82bz44sj39nyjey393
+slug: cerebras
+slug_aliases: []
+name: Cerebras
+domains:
+  - value: cerebras.ai
+    role: primary
+    valid_from: 2026-08-01T10:27:09.837Z
+category: ai-ml
+description: Cerebras is the go-to platform for fast and effortless AI training.
+links:
+  site: https://cerebras.ai
+sources:
+  - source_id: src_1f007d1fc9ecf96aa64cd3ce2c190873f30e2ea303557c3ad9019b788775f09a
+    url: https://cerebras.ai/yc-startup-deal
+programs: []
+offers:
+  - offer_id: off_01kyygma82043qa4t5myk78z8c
+    offer_slug: yc-startup-deal
+    offer_slug_aliases: []
+    title: YC Startup Deal
+    summary: YC startups from any batch receive up to $22,500 worth of inference on Cerebras Cloud, along with priority support and co-marketing opportunities.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T10:27:09.837Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Inference on Cerebras Cloud up to $22,500 in value
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 2250000
+            kind: up-to
+        - benefit_id: ben_02
+          description: Priority support and co-marketing opportunities
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        fact: company.partner_memberships
+        kind: predicate
+        operator: contains
+        statement: Company is a YC startup from any batch
+        value:
+          type: string
+          value: y-combinator
+    roles:
+      terms_authority_entity_id: ent_01kyygma82bz44sj39nyjey393
+      access_operator_entity_id: ent_01kyygma82bz44sj39nyjey393
+    access:
+      availability: membership
+      method: form
+      url: https://cerebras.ai/yc-startup-deal
+    source_ids:
+      - src_1f007d1fc9ecf96aa64cd3ce2c190873f30e2ea303557c3ad9019b788775f09a

--- a/vendors/cl/clevertap.yaml
+++ b/vendors/cl/clevertap.yaml
@@ -1,0 +1,56 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyygma82taj75edn8k8jdj6h
+slug: clevertap
+slug_aliases: []
+name: CleverTap
+domains:
+  - value: clevertap.com
+    role: primary
+    valid_from: 2026-08-01T10:20:39.587Z
+category: marketing
+description: All-in-One Customer Engagement Platform providing customer data & analytics, personalization, campaign orchestration, and retention capabilities.
+links:
+  site: https://clevertap.com
+sources:
+  - source_id: src_0fc453e4f6b1de982643df397dbd46b660735ac717f84d78864510b870a77d76
+    url: https://clevertap.com/startup-pricing
+programs: []
+offers:
+  - offer_id: off_01kyygma8266wg2s2zfn9xtepr
+    offer_slug: mid-year-sale-90-off-essentials-for-6-months
+    offer_slug_aliases: []
+    title: Mid-Year Sale - 90% off Essentials for 6 months
+    summary: Get 90% off CleverTap Essentials for 6 months during the Mid-Year Sale 2026.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T10:20:39.587Z
+    economics:
+      benefits:
+        - applies_to: CleverTap Essentials
+          benefit_id: ben_01
+          description: 90% off CleverTap Essentials for 6 months
+          duration:
+            kind: exact
+            value: P6M
+          kind: discount
+          percentage:
+            basis_points: 9000
+            kind: exact
+      consideration:
+        description: Subscription fee following trial or applicable pricing plan
+        kind: unknown
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: not-machine-evaluable
+        statement: Applies to CleverTap Essentials plan under the Mid-Year Sale promotion.
+    roles:
+      terms_authority_entity_id: ent_01kyygma82taj75edn8k8jdj6h
+      access_operator_entity_id: ent_01kyygma82taj75edn8k8jdj6h
+    access:
+      availability: public
+      method: form
+      url: https://clevertap.com/pricing/
+    source_ids:
+      - src_0fc453e4f6b1de982643df397dbd46b660735ac717f84d78864510b870a77d76

--- a/vendors/co/coda.yaml
+++ b/vendors/co/coda.yaml
@@ -1,0 +1,53 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyygma82v52ygt9gw9f3prhb
+slug: coda
+slug_aliases: []
+name: Coda
+domains:
+  - value: coda.io
+    role: primary
+    valid_from: 2026-08-01T10:21:18.818Z
+category: productivity
+description: Coda is an all-in-one flexible doc tool with building blocks, tables, customized views, and integrations to power team, product, and knowledge management.
+links:
+  site: https://coda.io/for/startups
+sources:
+  - source_id: src_5701585bdefc1cf5026883ef2214ba9f3f2d6c4155378e8cfbaaa4a194973432
+    url: https://coda.io/for/startups
+programs: []
+offers:
+  - offer_id: off_01kyygma8278f4c4xbhahf8a2j
+    offer_slug: 1-000-startup-credit
+    offer_slug_aliases: []
+    title: $1,000 startup credit
+    summary: Startups can apply to receive a $1,000 credit to run their business on Coda.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T10:21:18.818Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: $1,000 credit for Coda
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 100000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: vendor-discretion
+        statement: Apply for the startup credit and meet Coda startup eligibility criteria.
+    roles:
+      terms_authority_entity_id: ent_01kyygma82v52ygt9gw9f3prhb
+      access_operator_entity_id: ent_01kyygma82v52ygt9gw9f3prhb
+    access:
+      availability: public
+      method: form
+      url: https://coda.io/for/startups
+    source_ids:
+      - src_5701585bdefc1cf5026883ef2214ba9f3f2d6c4155378e8cfbaaa4a194973432

--- a/vendors/es/esri.yaml
+++ b/vendors/es/esri.yaml
@@ -1,0 +1,82 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyygma82p0jwn11hvnaprqa6
+slug: esri
+slug_aliases: []
+name: Esri
+domains:
+  - value: esri.com
+    role: primary
+    valid_from: 2026-08-01T07:51:50.052Z
+category: data-analytics
+description: Esri provides ArcGIS mapping technology and location intelligence solutions, helping early-stage startups build and scale integrated location products.
+links:
+  site: https://www.esri.com/startups
+sources:
+  - source_id: src_510789beac8838eef08166a9ed9c9014df527a881e964b2e33b6f9eeb987ed5e
+    url: https://www.esri.com/startups
+programs:
+  - program_id: prg_01kyygma82y5n2y18b70j8hz1c
+    program_slug: esri-startup-program
+    program_slug_aliases: []
+    title: Esri Startup Program
+    summary: An exclusive global program that helps early-stage startups build mapping technology and location intelligence into their products using ArcGIS software.
+    source_ids:
+      - src_510789beac8838eef08166a9ed9c9014df527a881e964b2e33b6f9eeb987ed5e
+offers:
+  - offer_id: off_01kyygma8291t9cg8ryve6xrdf
+    program_id: prg_01kyygma82y5n2y18b70j8hz1c
+    offer_slug: esri-startup-program
+    offer_slug_aliases: []
+    title: Esri Startup Program
+    summary: Access Esri ArcGIS software and partnership resources for early-stage software and technology startups founded within the last 5 years with less than $2M in annual revenue.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:51:50.052Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Resources to develop or migrate software, host solutions, or deliver content offerings on Esri ArcGIS technology.
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.industry
+            kind: predicate
+            operator: neq
+            statement: Business must build a software product, host a solution, or deliver content offerings integrated with ArcGIS, and cannot be a consulting or professional services organization.
+            value:
+              type: string
+              value: consulting or professional services
+          - criterion_id: cri_02
+            fact: company.age_months
+            kind: predicate
+            operator: lte
+            statement: Business must be founded within the last five years.
+            value:
+              type: number
+              value: 60
+          - criterion_id: cri_03
+            fact: company.annual_revenue_usd
+            kind: predicate
+            operator: lt
+            statement: Business must generate less than US$2 million annually.
+            value:
+              type: number
+              value: 2000000
+          - criterion_id: cri_04
+            kind: manual
+            reason: vendor-discretion
+            statement: Must be strategically aligned with Esri and ArcGIS, offer a solid go-to-market strategy, and have team commitment to long-term partnership.
+    roles:
+      terms_authority_entity_id: ent_01kyygma82p0jwn11hvnaprqa6
+      access_operator_entity_id: ent_01kyygma82p0jwn11hvnaprqa6
+    access:
+      availability: public
+      method: form
+      url: https://www.esri.com/startups
+    source_ids:
+      - src_510789beac8838eef08166a9ed9c9014df527a881e964b2e33b6f9eeb987ed5e

--- a/vendors/ms/msg91.yaml
+++ b/vendors/ms/msg91.yaml
@@ -1,0 +1,79 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyygma823nzqdmttehnq0v5m
+slug: msg91
+slug_aliases: []
+name: MSG91
+domains:
+  - value: msg91.com
+    role: primary
+    valid_from: 2026-08-01T07:24:20.328Z
+category: communication
+description: Expand your vision with us. Get a complimentary communication API package tailored to meet your needs.
+links:
+  site: https://msg91.com/
+sources:
+  - source_id: src_6d0a1ea568a46600063c63e8e96ce21d7cc292d70ab1bf01915108c9c5275eda
+    url: https://msg91.com/startups
+programs:
+  - program_id: prg_01kyygma825rkqa5hr6srr4p68
+    program_slug: msg91-for-startups
+    program_slug_aliases: []
+    title: MSG91 for Startups
+    summary: Complimentary communication API package and startup balance for startups associated with partner accelerators and incubators.
+    source_ids:
+      - src_6d0a1ea568a46600063c63e8e96ce21d7cc292d70ab1bf01915108c9c5275eda
+offers:
+  - offer_id: off_01kyygma822z14kmscq4q60djz
+    program_id: prg_01kyygma825rkqa5hr6srr4p68
+    offer_slug: msg91-startup-program
+    offer_slug_aliases: []
+    title: MSG91 Startup Program
+    summary: Get a complimentary communication API package with options for SMS credits, emails, WhatsApp sessions, OTP credits, and application access.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:24:20.328Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Startup Balance usable for SMS credits, Emails, WhatsApp Sessions, OTP credits, or application access
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: Must be a new MSG91 user.
+            value:
+              type: boolean
+              value: false
+          - criterion_id: cri_02
+            fact: company.email_domain_type
+            kind: predicate
+            operator: eq
+            statement: Must register with a private domain email ID.
+            value:
+              type: string
+              value: private
+          - criterion_id: cri_03
+            kind: manual
+            reason: external-verification
+            statement: Startup should be associated with one of MSG91's collaborators.
+          - criterion_id: cri_04
+            kind: manual
+            reason: external-verification
+            statement: Startup has to add MSG91's Startup Badge on their website with tagline - Communication Partner.
+    roles:
+      terms_authority_entity_id: ent_01kyygma823nzqdmttehnq0v5m
+      access_operator_entity_id: ent_01kyygma823nzqdmttehnq0v5m
+    access:
+      availability: referral
+      method: form
+      url: https://msg91.com/startups
+    terms_url: https://msg91.com/startups
+    source_ids:
+      - src_6d0a1ea568a46600063c63e8e96ce21d7cc292d70ab1bf01915108c9c5275eda

--- a/vendors/pe/persona.yaml
+++ b/vendors/pe/persona.yaml
@@ -1,0 +1,158 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyygma83pse5k9e9ry0ngfyc
+slug: persona
+slug_aliases: []
+name: Persona
+domains:
+  - value: withpersona.com
+    role: primary
+    valid_from: 2026-08-01T10:20:42.153Z
+category: auth-security
+description: Persona provides identity verification, orchestration, and platform tools to manage Personal Identifiable Information (PII) and stay compliant.
+links:
+  site: https://withpersona.com/
+sources:
+  - source_id: src_99c20c72fefd3c85ac13f2eb7bda59e11bdb736fb57a6bce19cf1083544a783a
+    url: https://withpersona.com/startups
+programs:
+  - program_id: prg_01kyygma83xffge4x55yxjcckx
+    program_slug: persona-startup-program
+    program_slug_aliases: []
+    title: Persona Startup Program
+    summary: Designed to help startups and small businesses grow utilizing Persona's identity verification, orchestration, and platform tools.
+    source_ids:
+      - src_99c20c72fefd3c85ac13f2eb7bda59e11bdb736fb57a6bce19cf1083544a783a
+offers:
+  - offer_id: off_01kyygma83kptje8sqq3jrh629
+    program_id: prg_01kyygma83xffge4x55yxjcckx
+    offer_slug: persona-startup-program-fintech-cohort
+    offer_slug_aliases: []
+    title: Persona Startup Program - Fintech Cohort
+    summary: Up to 12 months free access to Persona's configurable identity platform including 500 free monthly verifications, watchlist screening, and PEP reports.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T10:20:42.153Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to 12 months free access to Persona identity tools with 500 free monthly verifications, watchlists, and PEP reports.
+          duration:
+            kind: up-to
+            value: P1Y
+          kind: free-service
+          service: Persona configurable platform, 500 monthly verifications, watchlists, and PEP reports
+        - benefit_id: ben_02
+          description: Exclusive access to founder events in SF, NYC, and London.
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.industry
+            kind: predicate
+            operator: in
+            statement: For incorporated startups and small businesses in banking, payments, personal finance, lending, or wealth, or partnering with a sponsor bank or carrier
+            value:
+              type: string-set
+              values:
+                - banking
+                - payments
+                - personal finance
+                - lending
+                - wealth
+                - sponsor bank partner
+                - carrier partner
+          - criterion_id: cri_02
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: Current Persona customers are not eligible
+            value:
+              type: boolean
+              value: false
+          - criterion_id: cri_03
+            kind: manual
+            reason: external-verification
+            statement: Falsely misrepresenting eligibility constitutes a breach and may result in termination
+    roles:
+      terms_authority_entity_id: ent_01kyygma83pse5k9e9ry0ngfyc
+      access_operator_entity_id: ent_01kyygma83pse5k9e9ry0ngfyc
+    access:
+      availability: public
+      method: form
+      url: https://withpersona.com/startups/
+    terms_url: https://withpersona.com/startups/
+    source_ids:
+      - src_99c20c72fefd3c85ac13f2eb7bda59e11bdb736fb57a6bce19cf1083544a783a
+  - offer_id: off_01kyygma836yqdmsa4ahzjw8c2
+    program_id: prg_01kyygma83xffge4x55yxjcckx
+    offer_slug: persona-startup-program-general-cohort
+    offer_slug_aliases: []
+    title: Persona Startup Program - General Cohort
+    summary: Up to 12 months free access to Persona's core identity verification tools, including 500 free monthly Government ID (with optional selfie) verifications and $1 pricing thereafter.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T10:20:42.153Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to 12 months free access to Persona's core identity tools with 500 free monthly Government ID verifications.
+          duration:
+            kind: up-to
+            value: P1Y
+          kind: free-service
+          service: Persona core identity tools and 500 monthly Government ID verifications
+        - benefit_id: ben_02
+          description: Exclusive access to founder events in SF, NYC, and London.
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.stage
+            kind: predicate
+            operator: in
+            statement: Operating an incorporated small business or early-stage company
+            value:
+              type: string-set
+              values:
+                - incorporated small business
+                - early-stage
+          - criterion_id: cri_02
+            fact: company.product_status
+            kind: predicate
+            operator: in
+            statement: Product or service that's launched or ready to launch
+            value:
+              type: string-set
+              values:
+                - launched
+                - ready-to-launch
+          - criterion_id: cri_03
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: Current Persona customers are not eligible
+            value:
+              type: boolean
+              value: false
+          - criterion_id: cri_04
+            kind: manual
+            reason: external-verification
+            statement: Falsely misrepresenting eligibility constitutes a breach and may result in termination
+    roles:
+      terms_authority_entity_id: ent_01kyygma83pse5k9e9ry0ngfyc
+      access_operator_entity_id: ent_01kyygma83pse5k9e9ry0ngfyc
+    access:
+      availability: public
+      method: form
+      url: https://withpersona.com/startups/
+    terms_url: https://withpersona.com/startups/
+    source_ids:
+      - src_99c20c72fefd3c85ac13f2eb7bda59e11bdb736fb57a6bce19cf1083544a783a

--- a/vendors/re/recurly.yaml
+++ b/vendors/re/recurly.yaml
@@ -1,0 +1,56 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyygma82ztm6pmnrj8rmgcx9
+slug: recurly
+slug_aliases: []
+name: Recurly
+domains:
+  - value: recurly.com
+    role: primary
+    valid_from: 2026-08-01T10:27:30.674Z
+category: payments-fintech
+description: Recurly is the leading subscription management & billing platform.
+links:
+  site: https://recurly.com/
+sources:
+  - source_id: src_8e771f2e65a895cee88d63fb0da6db1f5a29d3fa51547435adc34998a280705b
+    url: https://recurly.com/plans
+programs: []
+offers:
+  - offer_id: off_01kyygma82b0xvpc6zxzcgnszd
+    offer_slug: starter-plan-90-day-free-trial
+    offer_slug_aliases: []
+    title: Starter Plan 90-Day Free Trial
+    summary: Get a 90-day free trial on the Recurly Starter subscription billing plan.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T10:27:30.674Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: 90-day free trial of Recurly Starter plan
+          duration:
+            kind: exact
+            value: P90D
+          kind: free-service
+          service: Recurly Starter Plan
+        - benefit_id: ben_02
+          description: First $40K of monthly billings included at no charge each month
+          kind: waiver
+          waived_item: Billing volume fee on first $40K per month
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: constant
+        statement: Available to subscription businesses getting started.
+        value: true
+    roles:
+      terms_authority_entity_id: ent_01kyygma82ztm6pmnrj8rmgcx9
+      access_operator_entity_id: ent_01kyygma82ztm6pmnrj8rmgcx9
+    access:
+      availability: public
+      method: automatic
+      url: https://recurly.com/pricing/
+    source_ids:
+      - src_8e771f2e65a895cee88d63fb0da6db1f5a29d3fa51547435adc34998a280705b

--- a/vendors/st/stripe.yaml
+++ b/vendors/st/stripe.yaml
@@ -1,0 +1,65 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyygma830fqh16kvj744sk1c
+slug: stripe
+slug_aliases: []
+name: Stripe
+domains:
+  - value: stripe.com
+    role: primary
+    valid_from: 2026-07-31T23:19:01.190Z
+category: payments-fintech
+description: Stripe provides payments and financial infrastructure to help venture-backed start-ups build, iterate, and scale faster.
+links:
+  site: https://stripe.com/startups
+sources:
+  - source_id: src_4410dda4d44891aad0cc0b21bb409ed3d27032c5bc1852a256708b3df0b1ff45
+    url: https://stripe.com/startups
+programs:
+  - program_id: prg_01kyygma8309wepbqk3a8d21wm
+    program_slug: stripe-startup-programme
+    program_slug_aliases: []
+    title: Stripe Startup Programme
+    summary: Designed to support venture-backed businesses with financial benefits, exclusive discounts, community, and expert resources.
+    source_ids:
+      - src_4410dda4d44891aad0cc0b21bb409ed3d27032c5bc1852a256708b3df0b1ff45
+offers:
+  - offer_id: off_01kyygma8386545a4wn8g6q28y
+    program_id: prg_01kyygma8309wepbqk3a8d21wm
+    offer_slug: stripe-startup-programme
+    offer_slug_aliases: []
+    title: Stripe Startup Programme
+    summary: Provides venture-backed startups with financial benefits including credits to offset Stripe fees and special pricing on Stripe invoices, alongside expert resources and community access.
+    lifecycle:
+      status: active
+      effective_from: 2026-07-31T23:19:01.190Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Credits to offset Stripe fees and special pricing on Stripe invoices
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 0
+            kind: at-least
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        fact: company.stage
+        kind: predicate
+        operator: eq
+        statement: Must be a venture-backed business
+        value:
+          type: string
+          value: venture-backed
+    roles:
+      terms_authority_entity_id: ent_01kyygma830fqh16kvj744sk1c
+      access_operator_entity_id: ent_01kyygma830fqh16kvj744sk1c
+    access:
+      availability: public
+      method: form
+      url: https://stripe.com/au/startups
+    source_ids:
+      - src_4410dda4d44891aad0cc0b21bb409ed3d27032c5bc1852a256708b3df0b1ff45

--- a/vendors/te/teamwork-com.yaml
+++ b/vendors/te/teamwork-com.yaml
@@ -1,0 +1,74 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyygma82z322ysvajabjkvmd
+slug: teamwork-com
+slug_aliases: []
+name: Teamwork.com
+domains:
+  - value: teamwork.com
+    role: primary
+    valid_from: 2026-08-01T10:21:27.104Z
+category: productivity
+description: Teamwork.com provides project management, resource planning, time tracking, and productivity tools for managing client work and business operations.
+links:
+  site: https://www.teamwork.com/startups/
+sources:
+  - source_id: src_ca367cfb37f0a443846d9bb68418aa4c64435f5d92a07641c52d7d1bb87588eb
+    url: https://www.teamwork.com/startups
+programs:
+  - program_id: prg_01kyygma82rtv4gjnchpbjxg9c
+    program_slug: teamwork-for-startups
+    program_slug_aliases: []
+    title: Teamwork for Startups
+    summary: Teamwork for Startups provides eligible early-stage businesses with free access to Teamwork products for one year.
+    source_ids:
+      - src_ca367cfb37f0a443846d9bb68418aa4c64435f5d92a07641c52d7d1bb87588eb
+offers:
+  - offer_id: off_01kyygma83pxvmge0wyrtv3n2g
+    program_id: prg_01kyygma82rtv4gjnchpbjxg9c
+    offer_slug: teamwork-for-startups
+    offer_slug_aliases: []
+    title: Teamwork for Startups
+    summary: Get all Teamwork.com products on the Basics plan or equivalent free for one year, subject to eligibility criteria and a testimonial requirement.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T10:21:27.104Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: All Teamwork.com products (Basics plan or equivalent) free for one year (365 days).
+          duration:
+            kind: exact
+            value: P1Y
+          kind: free-service
+          service: Teamwork.com products (Basics plan or equivalent)
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: vendor-discretion
+            statement: Eligibility is determined based on length of time in business, revenue, and employee numbers.
+          - criterion_id: cri_02
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: The program is not available on accounts where there is already a monthly or annual subscription.
+            value:
+              type: boolean
+              value: false
+          - criterion_id: cri_03
+            kind: manual
+            reason: external-verification
+            statement: The program and its continued use is subject to a testimonial/case study during the course of the program.
+    roles:
+      terms_authority_entity_id: ent_01kyygma82z322ysvajabjkvmd
+      access_operator_entity_id: ent_01kyygma82z322ysvajabjkvmd
+    access:
+      availability: public
+      method: form
+      url: https://www.teamwork.com/startups/
+    source_ids:
+      - src_ca367cfb37f0a443846d9bb68418aa4c64435f5d92a07641c52d7d1bb87588eb

--- a/vendors/te/telnyx.yaml
+++ b/vendors/te/telnyx.yaml
@@ -1,0 +1,69 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyygma83yg4pyars3qr8vcxk
+slug: telnyx
+slug_aliases: []
+name: Telnyx
+domains:
+  - value: telnyx.com
+    role: primary
+    valid_from: 2026-08-01T10:30:06.973Z
+category: communication
+description: Helping startups scale with enterprise-grade communications at no cost. Access up to $20,000 in credits, discounts, and expert support.
+links:
+  site: https://telnyx.com
+sources:
+  - source_id: src_6c264902e4457e7b720d52247fc0c2def700d750d054dc283ec0e89aa9325f71
+    url: https://telnyx.com/resources/ai-accelerator
+programs: []
+offers:
+  - offer_id: off_01kyygma83me3nnpqq68dvf14v
+    offer_slug: telnyx-ai-accelerator
+    offer_slug_aliases: []
+    title: Telnyx AI Accelerator
+    summary: Startups accepted into the program receive up to $20,000 in credits, exclusive discounts, and direct expert support to build their communications stack.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T10:30:06.973Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $20,000 in credits to access enterprise-grade communications.
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 2000000
+            kind: up-to
+        - benefit_id: ben_02
+          description: Exclusive discounts as startups grow.
+          kind: other
+        - benefit_id: ben_03
+          description: Priority and direct access to Telnyx experts.
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.stage
+            kind: predicate
+            operator: eq
+            statement: Must be a startup.
+            value:
+              type: string
+              value: startup
+          - criterion_id: cri_02
+            kind: manual
+            reason: vendor-discretion
+            statement: Application acceptance into the Telnyx AI Accelerator program.
+    roles:
+      terms_authority_entity_id: ent_01kyygma83yg4pyars3qr8vcxk
+      access_operator_entity_id: ent_01kyygma83yg4pyars3qr8vcxk
+    access:
+      availability: public
+      method: contact
+      url: https://telnyx.com/resources/ai-accelerator
+    source_ids:
+      - src_6c264902e4457e7b720d52247fc0c2def700d750d054dc283ec0e89aa9325f71

--- a/vendors/ti/tinybird.yaml
+++ b/vendors/ti/tinybird.yaml
@@ -1,0 +1,97 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyygma8321r4cj67y73vec8q
+slug: tinybird
+slug_aliases: []
+name: Tinybird
+domains:
+  - value: tinybird.co
+    role: primary
+    valid_from: 2026-08-01T07:08:28.136Z
+category: data-analytics
+description: All the infrastructure you need to ship analytics in your app. Capture, store, transform, and serve data without dependencies on external tools or teams.
+links:
+  site: https://www.tinybird.co
+sources:
+  - source_id: src_7fb5b5e82f4a81615b777cc0141b5c340103178a3a81b8e0dbd78a836a23a4eb
+    url: https://www.tinybird.co/open-source-program
+programs:
+  - program_id: prg_01kyygma83qb7mrawtrgzbyekr
+    program_slug: tinybird-open-source-program
+    program_slug_aliases: []
+    title: Tinybird Open Source Program
+    summary: Program providing plan discounts, marketing, engineering support, and swag kits to open source project maintainers.
+    source_ids:
+      - src_7fb5b5e82f4a81615b777cc0141b5c340103178a3a81b8e0dbd78a836a23a4eb
+offers:
+  - offer_id: off_01kyygma832fdhz1axc31cdwy0
+    program_id: prg_01kyygma83qb7mrawtrgzbyekr
+    offer_slug: tinybird-open-source-program
+    offer_slug_aliases: []
+    title: Tinybird Open Source Program
+    summary: Eligible open source projects receive an 80% discount on Tinybird Developer Plans for 6 months, followed by a 20% ongoing discount, along with marketing support, engineering support, and swag.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:08:28.136Z
+    economics:
+      benefits:
+        - applies_to: Tinybird Developer Plan
+          benefit_id: ben_01
+          description: 80% off any Tinybird Developer Plan for the first 6 months
+          duration:
+            kind: exact
+            value: P6M
+          kind: discount
+          percentage:
+            basis_points: 8000
+            kind: exact
+        - applies_to: Tinybird Developer Plan
+          benefit_id: ben_02
+          description: 20% off any Tinybird Developer Plan in continuum for eligible projects
+          kind: discount
+          percentage:
+            basis_points: 2000
+            kind: exact
+        - benefit_id: ben_03
+          description: Featured blog post, founder interview on YouTube, social media highlights, and retweets
+          kind: other
+        - benefit_id: ben_04
+          description: Slack support with Growth Engineers, integration support via code review/contributions, and ClickHouse migration support
+          kind: other
+        - benefit_id: ben_05
+          description: Tinybird Swag Kits (one per founder/maintainer)
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: Source code hosted on a public git provider
+          - criterion_id: cri_02
+            kind: manual
+            reason: external-verification
+            statement: Active contributions within the last 30 days
+          - criterion_id: cri_03
+            fact: company.github_stars
+            kind: predicate
+            operator: gte
+            statement: At least 25 GitHub stars (or equivalent on other providers)
+            value:
+              type: number
+              value: 25
+          - criterion_id: cri_04
+            kind: manual
+            reason: external-verification
+            statement: Commercial or hosted versions must use the same open core code
+    roles:
+      terms_authority_entity_id: ent_01kyygma8321r4cj67y73vec8q
+      access_operator_entity_id: ent_01kyygma8321r4cj67y73vec8q
+    access:
+      availability: public
+      method: form
+      url: https://www.tinybird.co/open-source-program
+    source_ids:
+      - src_7fb5b5e82f4a81615b777cc0141b5c340103178a3a81b8e0dbd78a836a23a4eb

--- a/vendors/tu/turso.yaml
+++ b/vendors/tu/turso.yaml
@@ -1,0 +1,90 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyygma83ghr6dea0nzbdvpa1
+slug: turso
+slug_aliases: []
+name: Turso
+domains:
+  - value: turso.tech
+    role: primary
+    valid_from: 2026-07-31T23:19:17.294Z
+category: databases
+description: Turso offers generous credits, priority technical support, early feature access, and co-marketing opportunities for early-stage venture-backed startups.
+links:
+  site: https://turso.tech
+sources:
+  - source_id: src_0037ff97a23a44d0e1a4dee4b6f47e198d11ea11a8e59da76fa2d1bcd5cdec03
+    url: https://turso.tech/startups
+programs:
+  - program_id: prg_01kyygma83xz5b5aajd3d7h6kg
+    program_slug: turso-for-startups
+    program_slug_aliases: []
+    title: Turso for Startups
+    summary: Turso for Startups provides credits, hands-on technical support, early feature access, and co-marketing opportunities to venture-backed founders.
+    source_ids:
+      - src_0037ff97a23a44d0e1a4dee4b6f47e198d11ea11a8e59da76fa2d1bcd5cdec03
+offers:
+  - offer_id: off_01kyygma83ahsg4w90th99cvs9
+    program_id: prg_01kyygma83xz5b5aajd3d7h6kg
+    offer_slug: turso-for-startups
+    offer_slug_aliases: []
+    title: Turso for Startups
+    summary: Eligible early-stage venture-backed startups receive Turso credits, priority technical support, early access to new features, and co-marketing opportunities.
+    lifecycle:
+      status: active
+      effective_from: 2026-07-31T23:19:17.294Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Generous Turso credits to run databases.
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 1
+            kind: at-least
+        - benefit_id: ben_02
+          description: Priority access to engineering team for onboarding, architecture reviews, and ongoing support.
+          kind: other
+        - benefit_id: ben_03
+          description: Early access to try new features and capabilities before public release.
+          kind: other
+        - benefit_id: ben_04
+          description: Co-marketing opportunities to be featured in blog, case studies, and social channels.
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.funding_rounds_count
+            kind: predicate
+            operator: gte
+            statement: Venture-backed startup with at least one round of funding
+            value:
+              type: number
+              value: 1
+          - criterion_id: cri_02
+            fact: company.stage
+            kind: predicate
+            operator: in
+            statement: Building an early-stage product or actively scaling
+            value:
+              type: string-set
+              values:
+                - early-stage
+                - scaling
+          - criterion_id: cri_03
+            kind: manual
+            reason: external-verification
+            statement: Verifiable funding from recognized investors or accelerators
+    roles:
+      terms_authority_entity_id: ent_01kyygma83ghr6dea0nzbdvpa1
+      access_operator_entity_id: ent_01kyygma83ghr6dea0nzbdvpa1
+    access:
+      availability: public
+      method: form
+      url: https://turso.tech/startups
+    source_ids:
+      - src_0037ff97a23a44d0e1a4dee4b6f47e198d11ea11a8e59da76fa2d1bcd5cdec03

--- a/vendors/up/upstash.yaml
+++ b/vendors/up/upstash.yaml
@@ -1,0 +1,64 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyygma8214q65cdtzx9ssgqe
+slug: upstash
+slug_aliases: []
+name: Upstash
+domains:
+  - value: upstash.com
+    role: primary
+    valid_from: 2026-08-01T10:30:05.504Z
+category: databases
+description: Serverless Redis, Vector and Search databases with low latency and pay-as-you-go pricing.
+links:
+  site: https://upstash.com
+sources:
+  - source_id: src_ed317188c83efebc17cb6618f8c4bf888ff1d2b10d1c035aa616fb56905b5063
+    url: https://upstash.com/open-source
+programs:
+  - program_id: prg_01kyygma8245hc3gn3dffw02k3
+    program_slug: upstash-open-source-program
+    program_slug_aliases: []
+    title: Upstash Open Source Program
+    summary: We support open-source projects building on Upstash with credit grants and exclusive access to support.
+    source_ids:
+      - src_ed317188c83efebc17cb6618f8c4bf888ff1d2b10d1c035aa616fb56905b5063
+offers:
+  - offer_id: off_01kyygma82q19jnfr527sc7wtm
+    program_id: prg_01kyygma8245hc3gn3dffw02k3
+    offer_slug: upstash-open-source-program
+    offer_slug_aliases: []
+    title: Upstash Open Source Program
+    summary: $1,000 monthly credit grant, direct technical support, priority team access, and co-marketing opportunities for open-source projects building on Upstash.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T10:30:05.504Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: $1,000 monthly credit grant covering all Upstash-related costs up to $1,000 per month.
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 100000
+            kind: exact
+        - benefit_id: ben_02
+          description: Direct technical support, priority team access, and co-marketing opportunities.
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: vendor-discretion
+        statement: Must be an open-source project building on Upstash.
+    roles:
+      terms_authority_entity_id: ent_01kyygma8214q65cdtzx9ssgqe
+      access_operator_entity_id: ent_01kyygma8214q65cdtzx9ssgqe
+    access:
+      availability: public
+      method: form
+      url: https://upstash.com/open-source
+    source_ids:
+      - src_ed317188c83efebc17cb6618f8c4bf888ff1d2b10d1c035aa616fb56905b5063

--- a/vendors/wi/wiz.yaml
+++ b/vendors/wi/wiz.yaml
@@ -1,0 +1,49 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyygma836y4jv9n2210zgyq4
+slug: wiz
+slug_aliases: []
+name: Wiz
+domains:
+  - value: wiz.io
+    role: primary
+    valid_from: 2026-08-01T07:56:18.512Z
+category: auth-security
+description: Wiz Go is a complete cloud security bundle for fast-moving teams—offering full visibility, protection, and flexibility with startup-friendly pricing.
+links:
+  site: https://www.wiz.io/lp/startups
+sources:
+  - source_id: src_e10dc2ef42ff4c06dd0e194be3a951c491eb07ca7e75f7102a215bdcd876d430
+    url: https://www.wiz.io/lp/startups
+programs: []
+offers:
+  - offer_id: off_01kyygma830fgn90asc8pctkj3
+    offer_slug: wiz-go-for-startups
+    offer_slug_aliases: []
+    title: Wiz Go for Startups
+    summary: Wiz Go is a tailored cloud security bundle for startups, combining Wiz Code, Wiz Cloud, and Wiz Defend & Runtime Sensor with startup-friendly pricing.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:56:18.512Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Special startup-friendly pricing for Wiz cloud security bundle including Wiz Code, Wiz Cloud, and Wiz Defend & Runtime Sensor.
+          kind: other
+      consideration:
+        description: Startup-friendly pricing is offered, but exact consideration details are not stated in the capture.
+        kind: unknown
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: vendor-discretion
+        statement: Tailored for lean, fast-moving startups.
+    roles:
+      terms_authority_entity_id: ent_01kyygma836y4jv9n2210zgyq4
+      access_operator_entity_id: ent_01kyygma836y4jv9n2210zgyq4
+    access:
+      availability: public
+      method: form
+      url: https://www.wiz.io/lp/startups
+    source_ids:
+      - src_e10dc2ef42ff4c06dd0e194be3a951c491eb07ca7e75f7102a215bdcd876d430

--- a/vendors/wo/workos.yaml
+++ b/vendors/wo/workos.yaml
@@ -1,0 +1,53 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyygma822smsegab8rym0sqk
+slug: workos
+slug_aliases: []
+name: WorkOS
+domains:
+  - value: workos.com
+    role: primary
+    valid_from: 2026-07-31T23:20:01.615Z
+category: auth-security
+description: WorkOS is an enterprise platform for user management, enterprise SSO, directory sync, MFA, RBAC, audit logs, and authentication.
+links:
+  site: https://workos.com
+sources:
+  - source_id: src_8789e905c49e7d05c098a0f21794a9f9de31de90992065d262508e304c3724c3
+    url: https://workos.com/startups
+programs: []
+offers:
+  - offer_id: off_01kyygma82eet0aqhpceg6n1ba
+    offer_slug: workos-user-management-free-tier
+    offer_slug_aliases: []
+    title: WorkOS User Management Free Tier
+    summary: WorkOS provides free user management and auth backend services for up to 1 million monthly active users (MAUs).
+    lifecycle:
+      status: active
+      effective_from: 2026-07-31T23:20:01.615Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Free User Management and auth backend services for up to 1 million monthly active users (MAUs).
+          kind: free-service
+          service: WorkOS User Management for up to 1M MAUs
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        fact: company.monthly_active_users
+        kind: predicate
+        operator: lte
+        statement: Monthly active users count is less than or equal to 1,000,000.
+        value:
+          type: number
+          value: 1000000
+    roles:
+      terms_authority_entity_id: ent_01kyygma822smsegab8rym0sqk
+      access_operator_entity_id: ent_01kyygma822smsegab8rym0sqk
+    access:
+      availability: public
+      method: form
+      url: https://workos.com/startups
+    source_ids:
+      - src_8789e905c49e7d05c098a0f21794a9f9de31de90992065d262508e304c3724c3


### PR DESCRIPTION
Adds 20 reviewed, first-party startup offers across 18 vendor YAML files.

- data-only public projection
- exact evidence authority admitted for Git tree `6be6f6e39b9f3f87d9beec9c8580f52dea8b5794`
- changed-identity validation only
- no catalog code or internal evidence material