### PR TITLE
catalog: add eight reviewed startup offers

### DIFF
--- a/vendors/aw/aws.yaml
+++ b/vendors/aw/aws.yaml
@@ -14,7 +14,16 @@ links:
 sources:
   - source_id: src_76d24dd13896e7193963f92a4af2a17cf151c8909a0598a41567c53d2b202d97
     url: https://aws.amazon.com/startups/
-programs: []
+  - source_id: src_e7804e1c8a7ac1fff655584c226c25f4be1e67fee3e9e2659ff6f336ffe95894
+    url: https://aws.amazon.com/startups
+programs:
+  - program_id: prg_01kyyjpn03angf9erfjwke4c42
+    program_slug: aws-activate
+    program_slug_aliases: []
+    title: AWS Activate
+    summary: AWS Activate provides credits, technical guidance, and resources to help startups test, build, and scale.
+    source_ids:
+      - src_e7804e1c8a7ac1fff655584c226c25f4be1e67fee3e9e2659ff6f336ffe95894
 offers:
   - offer_id: off_01kyh8fpe12z6fgn1ywg2ykth8
     offer_slug: aws-activate-credits
@@ -47,3 +56,39 @@ offers:
       url: https://aws.amazon.com/startups/join?destination=/credits/apply
     source_ids:
       - src_76d24dd13896e7193963f92a4af2a17cf151c8909a0598a41567c53d2b202d97
+  - offer_id: off_01kyyjpn04w8sm169c7ybetjs9
+    program_id: prg_01kyyjpn03angf9erfjwke4c42
+    offer_slug: aws-activate-credits-2
+    offer_slug_aliases: []
+    title: AWS Activate Credits
+    summary: Get up to $200,000 in AWS Activate Credits to offset costs on infrastructure, data services, and AI/ML models, including models on Amazon Bedrock.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T11:36:14.695Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: AWS Activate Credits to offset costs on infrastructure, data services, and AI/ML models
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 20000000
+            kind: up-to
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: vendor-discretion
+        statement: Apply for AWS Activate Credits as a startup
+    roles:
+      terms_authority_entity_id: ent_01kyh8fpe10b164tj935t8k5zb
+      access_operator_entity_id: ent_01kyh8fpe10b164tj935t8k5zb
+    access:
+      availability: public
+      method: form
+      url: https://aws.amazon.com/startups/join?destination=/credits/apply
+    source_ids:
+      - src_e7804e1c8a7ac1fff655584c226c25f4be1e67fee3e9e2659ff6f336ffe95894

--- a/vendors/ba/baseten.yaml
+++ b/vendors/ba/baseten.yaml
@@ -14,7 +14,16 @@ links:
 sources:
   - source_id: src_fbaa9953817b55dee9141c07a6dcbec03e39a4046c2eaeadc56db0100b7cfde9
     url: https://www.baseten.co/startup-program/
-programs: []
+  - source_id: src_94770c0c3d8587aa4dc037f613e2c7e1e71342e57a34363ec2f14d60ecb6527b
+    url: https://www.baseten.co/startup-program
+programs:
+  - program_id: prg_01kyyjpn044rdyrt2q8afs6kcs
+    program_slug: ai-startup-program
+    program_slug_aliases: []
+    title: AI Startup Program
+    summary: Baseten's program for early-stage AI startups offering platform credits for inference, model APIs, training, and technical support.
+    source_ids:
+      - src_94770c0c3d8587aa4dc037f613e2c7e1e71342e57a34363ec2f14d60ecb6527b
 offers:
   - offer_id: off_01kyh8fpe11y56961zxm7q6sd4
     offer_slug: baseten-ai-startup-program
@@ -47,3 +56,78 @@ offers:
       url: https://www.baseten.co/startup-program/
     source_ids:
       - src_fbaa9953817b55dee9141c07a6dcbec03e39a4046c2eaeadc56db0100b7cfde9
+  - offer_id: off_01kyyjpn04x1cdycrwbq4t7r08
+    program_id: prg_01kyyjpn044rdyrt2q8afs6kcs
+    offer_slug: ai-startup-program
+    offer_slug_aliases: []
+    title: AI Startup Program
+    summary: Eligible early-stage AI startups can receive up to $25,000 in credits for Dedicated Inference or Training and up to $2,500 in credits for Model APIs, along with technical support and GTM assistance.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T11:36:14.423Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $25,000 in credits for Dedicated Inference or Training
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 2500000
+            kind: up-to
+        - benefit_id: ben_02
+          description: Up to $2,500 in credits for Model APIs
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 250000
+            kind: up-to
+        - benefit_id: ben_03
+          description: Support with response times within a few business hours, shared slack channels, zoom calls, networking, and GTM support
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: vendor-discretion
+            statement: Artificial intelligence must be core to primary products or solutions.
+          - criterion_id: cri_02
+            fact: company.stage
+            kind: predicate
+            operator: in
+            statement: Funding stage should be Seed to Series A.
+            value:
+              type: string-set
+              values:
+                - Seed
+                - Series A
+          - criterion_id: cri_03
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: Started less than 5 years ago.
+            value:
+              type: number
+              value: 60
+          - criterion_id: cri_04
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: Must be net new customers who have never received any credits from Baseten before.
+            value:
+              type: boolean
+              value: false
+    roles:
+      terms_authority_entity_id: ent_01kyh8fpe1r4t2ewb8ym69qbre
+      access_operator_entity_id: ent_01kyh8fpe1r4t2ewb8ym69qbre
+    access:
+      availability: public
+      method: form
+      url: https://www.baseten.co/startup-program/
+    source_ids:
+      - src_94770c0c3d8587aa4dc037f613e2c7e1e71342e57a34363ec2f14d60ecb6527b

--- a/vendors/ch/chartmogul.yaml
+++ b/vendors/ch/chartmogul.yaml
@@ -1,0 +1,82 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyyjpn0420xj7qn72b7jrrav
+slug: chartmogul
+slug_aliases: []
+name: ChartMogul
+domains:
+  - value: chartmogul.com
+    role: primary
+    valid_from: 2026-08-01T11:46:24.335Z
+category: data-analytics
+description: Subscription analytics product for measuring, understanding and growing your business.
+links:
+  site: https://chartmogul.com
+sources:
+  - source_id: src_846d9d24054f38c9b1d19b2a051cc3e2905238a9d8bb54f2b572932193329a99
+    url: https://chartmogul.com/startups
+programs:
+  - program_id: prg_01kyyjpn04rg0w2ym0gyqhktcm
+    program_slug: chartmogul-startup-program
+    program_slug_aliases: []
+    title: ChartMogul Startup Program
+    summary: Discounted access to ChartMogul subscription analytics plans for early-stage startups.
+    source_ids:
+      - src_846d9d24054f38c9b1d19b2a051cc3e2905238a9d8bb54f2b572932193329a99
+offers:
+  - offer_id: off_01kyyjpn042c17aqg7f0bjn5kp
+    program_id: prg_01kyyjpn04rg0w2ym0gyqhktcm
+    offer_slug: chartmogul-startup-program-50-month-discount
+    offer_slug_aliases: []
+    title: ChartMogul Startup Program $50/month Discount
+    summary: Get a $50 per month discount on any ChartMogul plan for 12 months for startups associated with a supported accelerator program.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T11:46:24.335Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: $50 per month discount on any ChartMogul plan for 12 months (total value $600)
+          duration:
+            kind: exact
+            value: P1Y
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 5000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: Must be a new ChartMogul customer.
+            value:
+              type: boolean
+              value: false
+          - criterion_id: cri_02
+            fact: company.partner_memberships
+            kind: predicate
+            operator: contains
+            statement: Must be part of a supported accelerator program.
+            value:
+              type: string
+              value: supported accelerator program
+          - criterion_id: cri_03
+            kind: manual
+            reason: vendor-discretion
+            statement: ChartMogul reserves the right to reject applications at its sole discretion.
+    roles:
+      terms_authority_entity_id: ent_01kyyjpn0420xj7qn72b7jrrav
+      access_operator_entity_id: ent_01kyyjpn0420xj7qn72b7jrrav
+    access:
+      availability: membership
+      method: form
+      url: https://chartmogul.com/startups/
+    source_ids:
+      - src_846d9d24054f38c9b1d19b2a051cc3e2905238a9d8bb54f2b572932193329a99

--- a/vendors/ok/okta-inc.yaml
+++ b/vendors/ok/okta-inc.yaml
@@ -1,0 +1,60 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyyjpn04p2nymzqhm9m613vw
+slug: okta-inc
+slug_aliases: []
+name: Okta, Inc.
+domains:
+  - value: okta.com
+    role: primary
+    valid_from: 2026-08-01T11:36:40.331Z
+category: auth-security
+description: Okta provides identity tools through the Okta Identity Cloud, including single sign-on, automated provisioning/deprovisioning, and basic MFA.
+links:
+  site: https://www.okta.com/
+sources:
+  - source_id: src_23e0231418d15c7e75a1147e3164033cc6627bef8f6aa4c93c6b35cd480fa5eb
+    url: https://www.okta.com/contact-sales-okta-for-startups
+programs:
+  - program_id: prg_01kyyjpn04m57mpvca9fhx305m
+    program_slug: okta-for-startups
+    program_slug_aliases: []
+    title: Okta for Startups
+    summary: Okta for Startups allows young companies to use Okta’s identity tools for up to 25 employees, contractors and partners through the Okta Identity Cloud for free.
+    source_ids:
+      - src_23e0231418d15c7e75a1147e3164033cc6627bef8f6aa4c93c6b35cd480fa5eb
+offers:
+  - offer_id: off_01kyyjpn04pdy11tg3as9srb0x
+    program_id: prg_01kyyjpn04m57mpvca9fhx305m
+    offer_slug: okta-for-startups
+    offer_slug_aliases: []
+    title: Okta for Startups
+    summary: Eligible startups receive one year of free access for up to 25 users with Okta IT Products, including standard support.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T11:36:40.331Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: One year of free access for up to 25 users with Okta IT Products, including single sign-on, automated provisioning / deprovisioning, basic MFA, and standard support.
+          duration:
+            kind: exact
+            value: P1Y
+          kind: free-service
+          service: Okta IT Products and standard support for up to 25 users
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: vendor-discretion
+        statement: Eligibility determination by contacting the Okta team.
+    roles:
+      terms_authority_entity_id: ent_01kyyjpn04p2nymzqhm9m613vw
+      access_operator_entity_id: ent_01kyyjpn04p2nymzqhm9m613vw
+    access:
+      availability: public
+      method: form
+      url: https://www.okta.com/contact-sales-okta-for-startups
+    source_ids:
+      - src_23e0231418d15c7e75a1147e3164033cc6627bef8f6aa4c93c6b35cd480fa5eb

--- a/vendors/pr/prisma.yaml
+++ b/vendors/pr/prisma.yaml
@@ -1,0 +1,125 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyyjpn046y6zh8fhwt58gg1w
+slug: prisma
+slug_aliases: []
+name: Prisma
+domains:
+  - value: prisma.io
+    role: primary
+    valid_from: 2026-08-01T11:46:59.053Z
+category: databases
+description: "Prisma gives TypeScript and Node.js teams Prisma ORM, Prisma Postgres, and Prisma Compute: a type-safe ORM, managed Postgres, and Compute for deploying TypeScript apps, from schema to deployed app."
+links:
+  site: https://www.prisma.io
+sources:
+  - source_id: src_d8a0b75a1444b4bc9a893805524d0cc9922872402e132eccfbd4f41a6785e57f
+    url: https://www.prisma.io/startups
+programs:
+  - program_id: prg_01kyyjpn0481vjewfjfd887h11
+    program_slug: prisma-startup-program
+    program_slug_aliases: []
+    title: Prisma Startup Program
+    summary: The Prisma Startup Program provides early-stage startups with database credits and technical support.
+    source_ids:
+      - src_d8a0b75a1444b4bc9a893805524d0cc9922872402e132eccfbd4f41a6785e57f
+offers:
+  - offer_id: off_01kyyjpn04f08bxqpf2cezbd87
+    program_id: prg_01kyyjpn0481vjewfjfd887h11
+    offer_slug: prisma-startup-program
+    offer_slug_aliases: []
+    title: Prisma Startup Program
+    summary: Eligible early-stage startups get up to $10,000 in database credits for one year along with 1:1 guidance from Prisma database experts and direct Slack support.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T11:46:59.053Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $10,000 in credits covering your database bill for a year
+          duration:
+            kind: exact
+            value: P1Y
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 1000000
+            kind: up-to
+        - benefit_id: ben_02
+          description: 1:1 guidance from Prisma's database experts
+          kind: other
+        - benefit_id: ben_03
+          description: Direct support in Slack
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.business_model
+            kind: predicate
+            operator: eq
+            statement: Building a software product or service with an active website
+            value:
+              type: string
+              value: software product or service with active website
+          - kind: any
+            rules:
+              - kind: all
+                rules:
+                  - criterion_id: cri_02
+                    fact: company.stage
+                    kind: predicate
+                    operator: in
+                    statement: Pre-seed, seed, or series-A stage
+                    value:
+                      type: string-set
+                      values:
+                        - pre-seed
+                        - seed
+                        - series-a
+                  - criterion_id: cri_03
+                    fact: company.last_funding_round_months_ago
+                    kind: predicate
+                    operator: lte
+                    statement: Raised venture funding in the last 12 months
+                    value:
+                      type: number
+                      value: 12
+                  - criterion_id: cri_04
+                    fact: company.age_months
+                    kind: predicate
+                    operator: lte
+                    statement: Founded in the last 5 years
+                    value:
+                      type: number
+                      value: 60
+              - kind: all
+                rules:
+                  - criterion_id: cri_05
+                    fact: company.mrr_usd
+                    kind: predicate
+                    operator: gte
+                    statement: At least 5k MRR for the last 6 months
+                    value:
+                      type: number
+                      value: 5000
+                  - criterion_id: cri_06
+                    fact: company.employee_count
+                    kind: predicate
+                    operator: gte
+                    statement: Two full-time team members
+                    value:
+                      type: number
+                      value: 2
+    roles:
+      terms_authority_entity_id: ent_01kyyjpn046y6zh8fhwt58gg1w
+      access_operator_entity_id: ent_01kyyjpn046y6zh8fhwt58gg1w
+    access:
+      availability: public
+      method: form
+      url: https://www.prisma.io/startups
+    source_ids:
+      - src_d8a0b75a1444b4bc9a893805524d0cc9922872402e132eccfbd4f41a6785e57f

--- a/vendors/ro/roboflow.yaml
+++ b/vendors/ro/roboflow.yaml
@@ -1,0 +1,71 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyyjpn04wzrm50s4m4p2w6p4
+slug: roboflow
+slug_aliases: []
+name: Roboflow
+domains:
+  - value: roboflow.com
+    role: primary
+    valid_from: 2026-08-01T11:46:22.538Z
+category: ai-ml
+description: End-to-End Computer Vision Platform to train and deploy state-of-the-art models.
+links:
+  site: https://roboflow.com
+sources:
+  - source_id: src_3cc962408d7eefc1591ee05f8af8096b75b08a174a77ad7544799895d7a13513
+    url: https://startups.roboflow.com/
+programs: []
+offers:
+  - offer_id: off_01kyyjpn0433vgweswcfb0nkmg
+    offer_slug: 1-free-year-on-core-plan
+    offer_slug_aliases: []
+    title: 1 Free Year on Core Plan
+    summary: Eligible startups in partner startup programs receive 1 free year of Roboflow Core Plan ($948 value) including platform credits, 20 private projects, and 3 user seats.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T11:46:22.538Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: 1 Free Year on Core Plan ($948 value)
+          duration:
+            kind: exact
+            value: P1Y
+          kind: free-service
+          service: Roboflow Core Plan
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.partner_memberships
+            kind: predicate
+            operator: present
+            statement: Startup must be part of a partner accelerator, VC, or startup program.
+          - criterion_id: cri_02
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: Startup must have raised less than $5 million in funding.
+            value:
+              type: number
+              value: 5000000
+          - criterion_id: cri_03
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: Must be a new Roboflow customer.
+            value:
+              type: boolean
+              value: false
+    roles:
+      terms_authority_entity_id: ent_01kyyjpn04wzrm50s4m4p2w6p4
+      access_operator_entity_id: ent_01kyyjpn04wzrm50s4m4p2w6p4
+    access:
+      availability: membership
+      instructions: Email your program manager or visit your program's perks & discounts list, or contact startups@roboflow.com to connect your program manager.
+      method: contact
+    source_ids:
+      - src_3cc962408d7eefc1591ee05f8af8096b75b08a174a77ad7544799895d7a13513

--- a/vendors/sp/speechmatics.yaml
+++ b/vendors/sp/speechmatics.yaml
@@ -1,0 +1,95 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyyjpn045qy3g8mdxf4x2f4f
+slug: speechmatics
+slug_aliases: []
+name: Speechmatics
+domains:
+  - value: speechmatics.com
+    role: primary
+    valid_from: 2026-08-01T11:46:59.310Z
+category: ai-ml
+description: Speechmatics provides speech technology and Voice AI for enterprises, offering Speech-to-Text, Text-to-Speech, and Voice Agent solutions.
+links:
+  site: https://www.speechmatics.com
+sources:
+  - source_id: src_41fa42e7769d0bbd5c71ab3e752ce7062e72173848c71152f31ed6182a56d84e
+    url: https://www.speechmatics.com/startup-program
+programs:
+  - program_id: prg_01kyyjpn04hb9m9aneqvx96pyh
+    program_slug: speechmatics-startup-program
+    program_slug_aliases: []
+    title: Speechmatics Startup Program
+    summary: Speechmatics Startup Program offers credits and engineering support for early-stage startups building with voice AI.
+    source_ids:
+      - src_41fa42e7769d0bbd5c71ab3e752ce7062e72173848c71152f31ed6182a56d84e
+offers:
+  - offer_id: off_01kyyjpn042c4p32er1bb0atgy
+    program_id: prg_01kyyjpn04hb9m9aneqvx96pyh
+    offer_slug: speechmatics-startup-program
+    offer_slug_aliases: []
+    title: Speechmatics Startup Program
+    summary: Eligible early-stage startups receive up to $50,000 in Speechmatics usage credits along with technical support and co-marketing opportunities.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T11:46:59.310Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $50,000 in Speechmatics usage credits across real-time, batch, text-to-speech, and on-prem APIs.
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 5000000
+            kind: up-to
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: Company has raised less than $10 million total funding.
+            value:
+              type: number
+              value: 10000000
+          - criterion_id: cri_02
+            fact: company.stage
+            kind: predicate
+            operator: in
+            statement: Company has a functional MVP in production or a committed launch within 1-2 months.
+            value:
+              type: string-set
+              values:
+                - mvp_in_production
+                - launch_within_1_2_months
+          - kind: not
+            rule:
+              criterion_id: cri_03
+              fact: company.is_current_paid_enterprise_customer
+              kind: predicate
+              operator: eq
+              statement: Company is currently on a paid Speechmatics enterprise plan.
+              value:
+                type: boolean
+                value: true
+          - criterion_id: cri_04
+            kind: manual
+            reason: external-verification
+            statement: Company has an active development team and defined ASR use case.
+          - criterion_id: cri_05
+            kind: manual
+            reason: external-verification
+            statement: Company completes a 30-minute call with the Speechmatics team to discuss use case and mission prior to approval.
+    roles:
+      terms_authority_entity_id: ent_01kyyjpn045qy3g8mdxf4x2f4f
+      access_operator_entity_id: ent_01kyyjpn045qy3g8mdxf4x2f4f
+    access:
+      availability: public
+      method: form
+      url: https://www.speechmatics.com/startup-program
+    source_ids:
+      - src_41fa42e7769d0bbd5c71ab3e752ce7062e72173848c71152f31ed6182a56d84e

--- a/vendors/sv/svix.yaml
+++ b/vendors/sv/svix.yaml
@@ -1,0 +1,73 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyyjpn04s63h40x2bw6snymy
+slug: svix
+slug_aliases: []
+name: Svix
+domains:
+  - value: svix.com
+    role: primary
+    valid_from: 2026-08-01T11:46:59.243Z
+category: devtools-other
+description: Svix is the enterprise ready webhook service.
+links:
+  site: https://www.svix.com
+sources:
+  - source_id: src_303b8048f9094ad5c9b8820bd5bdd79824ae7bef300d9aa4af9ba938d4de31db
+    url: https://www.svix.com/startups
+programs: []
+offers:
+  - offer_id: off_01kyyjpn04rad383jhbbe2x3ca
+    offer_slug: svix-for-startups
+    offer_slug_aliases: []
+    title: Svix for Startups
+    summary: Eligible startups get $12,000 of free Svix credits valid for 12 months ($1,000 per month) plus concierge onboarding.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T11:46:59.243Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: $12,000 of free credits valid for 12 months ($1k / month)
+          duration:
+            kind: exact
+            value: P1Y
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 1200000
+            kind: exact
+        - benefit_id: ben_02
+          description: Concierge Onboarding to connect with the Svix team
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.age_months
+            kind: predicate
+            operator: lte
+            statement: Incorporated in the last 3 years
+            value:
+              type: number
+              value: 36
+          - criterion_id: cri_02
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lte
+            statement: Raised no more than $7MM in total funding
+            value:
+              type: number
+              value: 7000000
+    roles:
+      terms_authority_entity_id: ent_01kyyjpn04s63h40x2bw6snymy
+      access_operator_entity_id: ent_01kyyjpn04s63h40x2bw6snymy
+    access:
+      availability: public
+      method: form
+      url: https://www.svix.com/startups/
+    source_ids:
+      - src_303b8048f9094ad5c9b8820bd5bdd79824ae7bef300d9aa4af9ba938d4de31db


### PR DESCRIPTION
Adds eight reviewed, first-party startup offers across eight vendor YAML files.

- data-only public projection
- exact evidence authority admitted for Git tree f109539ccebc34e30a4dc079fc0ae250136cc539
- changed-identity validation only
- no catalog code or internal evidence material