### PR TITLE
Add five reviewed startup offers

### DIFF
--- a/vendors/ai/aiven.yaml
+++ b/vendors/ai/aiven.yaml
@@ -1,0 +1,156 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyypqp9x1fgh5rtq71mrtakc
+slug: aiven
+slug_aliases: []
+name: Aiven
+domains:
+  - value: aiven.io
+    role: primary
+    valid_from: 2026-08-01T12:56:21.965Z
+category: databases
+description: Aiven makes setting up and running cloud data infrastructure simple, secure, and fully managed, offering reliable open-source technologies on major cloud platforms.
+links:
+  site: https://aiven.io
+sources:
+  - source_id: src_3228f71d4029385215c61272d11450d0864cb3ff305d1a283b8443e85eaf4492
+    url: https://aiven.io/startups
+programs:
+  - program_id: prg_01kyypqp9x2exr1pg3rheyh3vn
+    program_slug: aiven-for-startups
+    program_slug_aliases: []
+    title: Aiven for Startups
+    summary: Offers data infra support to up and coming startups so they can scale up and grow.
+    source_ids:
+      - src_3228f71d4029385215c61272d11450d0864cb3ff305d1a283b8443e85eaf4492
+offers:
+  - offer_id: off_01kyypqp9xca0ahxwc1hg383cz
+    program_id: prg_01kyypqp9x2exr1pg3rheyh3vn
+    offer_slug: aiven-for-startups
+    offer_slug_aliases: []
+    title: Aiven for Startups
+    summary: Get up to $100,000 in Aiven credits to run fully managed open-source data services for 12 months, plus technical guidance, mentoring, community access, and promotion.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T12:56:21.965Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $100,000 in Aiven credits to run fully managed open-source data services.
+          duration:
+            kind: exact
+            value: P12M
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 10000000
+            kind: up-to
+        - benefit_id: ben_02
+          description: Direct access to technical experts and startup advisors for office hours and 1:1 mentoring.
+          kind: other
+        - benefit_id: ben_03
+          description: Access to Startup Slack for community support and knowledge sharing.
+          kind: other
+        - benefit_id: ben_04
+          description: Opportunities for promotion on Aiven blog, social channels, and events.
+          kind: other
+        - benefit_id: ben_05
+          description: Special virtual events tailored for startups on scaling data infrastructure and product development.
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.age_months
+            kind: predicate
+            operator: lte
+            statement: Startup was founded no more than 7 years ago.
+            value:
+              type: number
+              value: 84
+          - criterion_id: cri_02
+            fact: company.stage
+            kind: predicate
+            operator: in
+            statement: Startup has raised external funding up to Series B.
+            value:
+              type: string-set
+              values:
+                - pre-seed
+                - seed
+                - series-a
+                - series-b
+          - criterion_id: cri_03
+            fact: company.business_email_present
+            kind: predicate
+            operator: eq
+            statement: Startup must apply with a company website and business email address.
+            value:
+              type: boolean
+              value: true
+          - kind: not
+            rule:
+              criterion_id: cri_04
+              fact: company.industry
+              kind: predicate
+              operator: in
+              statement: Agencies, consulting companies, NGOs, or educational institutions are not eligible.
+              value:
+                type: string-set
+                values:
+                  - agency
+                  - consulting
+                  - ngo
+                  - educational-institution
+          - kind: any
+            rules:
+              - criterion_id: cri_05
+                fact: company.partner_memberships
+                kind: predicate
+                operator: contains
+                statement: Proof of affiliation with a VC investor.
+                value:
+                  type: string
+                  value: vc_investor
+              - criterion_id: cri_06
+                fact: company.partner_memberships
+                kind: predicate
+                operator: contains
+                statement: Affiliation with an accelerator, incubator, or co-working space in Aiven's partner network.
+                value:
+                  type: string
+                  value: partner_network
+          - kind: any
+            rules:
+              - criterion_id: cri_07
+                fact: company.is_current_customer
+                kind: predicate
+                operator: eq
+                statement: Not a current paying Aiven customer.
+                value:
+                  type: boolean
+                  value: false
+              - criterion_id: cri_08
+                fact: company.monthly_invoice_usd
+                kind: predicate
+                operator: lt
+                statement: Current paying customer with a monthly invoice under $400.
+                value:
+                  type: number
+                  value: 400
+          - criterion_id: cri_09
+            kind: manual
+            reason: external-verification
+            statement: Applicant has not previously received Startup credits.
+    roles:
+      terms_authority_entity_id: ent_01kyypqp9x1fgh5rtq71mrtakc
+      access_operator_entity_id: ent_01kyypqp9x1fgh5rtq71mrtakc
+    access:
+      availability: public
+      method: form
+      url: https://aiven.io/startups
+    source_ids:
+      - src_3228f71d4029385215c61272d11450d0864cb3ff305d1a283b8443e85eaf4492

--- a/vendors/au/autodesk.yaml
+++ b/vendors/au/autodesk.yaml
@@ -14,6 +14,8 @@ links:
 sources:
   - source_id: src_0cc9c54ff00a1c374e9b96d2ff30d32618f6b18598e44c4bede5d50d754bcfcc
     url: https://www.autodesk.com/products/fusion-360/startups
+  - source_id: src_02aeef534dae2cbac5e9f78db5835e1c4b06595d9e459205ce1e3cbaf197ebf7
+    url: https://www.autodesk.com/sustainability/technology-impact-program
 programs:
   - program_id: prg_01kyxthgprfn3x2yekadhrd83f
     program_slug: fusion-startup-program
@@ -22,6 +24,13 @@ programs:
     summary: Autodesk's program offering qualifying startups and entrepreneurs access to Autodesk Fusion.
     source_ids:
       - src_0cc9c54ff00a1c374e9b96d2ff30d32618f6b18598e44c4bede5d50d754bcfcc
+  - program_id: prg_01kyypqp9wvpk9r9s0qd7ptaew
+    program_slug: technology-impact-program
+    program_slug_aliases: []
+    title: Technology Impact Program
+    summary: Autodesk donates software to nonprofits and startups that are using design for environmental or social good.
+    source_ids:
+      - src_02aeef534dae2cbac5e9f78db5835e1c4b06595d9e459205ce1e3cbaf197ebf7
 offers:
   - offer_id: off_01kyxthgpsbxen55xqbsg5cv6f
     program_id: prg_01kyxthgprfn3x2yekadhrd83f
@@ -125,3 +134,60 @@ offers:
     terms_url: https://www.autodesk.com/company/terms-of-use/en/general-terms
     source_ids:
       - src_0cc9c54ff00a1c374e9b96d2ff30d32618f6b18598e44c4bede5d50d754bcfcc
+  - offer_id: off_01kyypqp9xfg8j49fn9r985pds
+    program_id: prg_01kyypqp9wvpk9r9s0qd7ptaew
+    offer_slug: technology-impact-program-for-startups
+    offer_slug_aliases: []
+    title: Technology Impact Program for Startups
+    summary: Eligible social impact startups receive donated Autodesk software subscriptions for three years.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T11:36:16.812Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Donated 3-year Autodesk software subscriptions for social impact startups.
+          duration:
+            kind: exact
+            value: P3Y
+          kind: free-service
+          service: Autodesk software subscriptions
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: Startup must be less than six years old.
+            value:
+              type: number
+              value: 72
+          - criterion_id: cri_02
+            fact: company.employee_count
+            kind: predicate
+            operator: lte
+            statement: Startup must have 10 or fewer employees.
+            value:
+              type: number
+              value: 10
+          - criterion_id: cri_03
+            kind: manual
+            reason: external-verification
+            statement: Startup must earn annual revenue of less than $1 million USD.
+          - criterion_id: cri_04
+            kind: manual
+            reason: not-machine-evaluable
+            statement: Startup must innovate in a social or environmental impact area.
+    roles:
+      terms_authority_entity_id: ent_01kyxthgpr3a3ds3stc9xvvrgt
+      access_operator_entity_id: ent_01kyxthgpr3a3ds3stc9xvvrgt
+    access:
+      availability: public
+      method: form
+      url: https://autodesk.fluxx.io/apply/technology-impact-program-nonprofit
+    source_ids:
+      - src_02aeef534dae2cbac5e9f78db5835e1c4b06595d9e459205ce1e3cbaf197ebf7

--- a/vendors/fr/freshworks.yaml
+++ b/vendors/fr/freshworks.yaml
@@ -1,0 +1,107 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyypqp9xn8ymms4jtyhc4npw
+slug: freshworks
+slug_aliases: []
+name: Freshworks
+domains:
+  - value: freshworks.com
+    role: primary
+    valid_from: 2026-08-01T12:56:46.088Z
+category: crm-sales
+description: Freshworks provides software tools for sales, marketing, and support including Freshsales, Freshdesk, and Freshchat.
+links:
+  site: https://www.freshworks.com
+sources:
+  - source_id: src_0a52c5f034e4feadb8168735d025d77121e252e5a06bd1e94275e85566ec81f3
+    url: https://www.freshworks.com/company/partners/startup-program
+programs:
+  - program_id: prg_01kyypqp9xcjqgk9xac9rxjzpf
+    program_slug: freshworks-for-startups
+    program_slug_aliases: []
+    title: Freshworks for Startups
+    summary: Freshworks program providing discounts on product suites to startups associated with partner VCs, accelerators, and incubators.
+    source_ids:
+      - src_0a52c5f034e4feadb8168735d025d77121e252e5a06bd1e94275e85566ec81f3
+offers:
+  - offer_id: off_01kyypqp9xgz8mheqg704c62d5
+    program_id: prg_01kyypqp9xcjqgk9xac9rxjzpf
+    offer_slug: freshworks-for-startups-discount-under-4m-raised
+    offer_slug_aliases: []
+    title: Freshworks for Startups Discount (Under $4M Raised)
+    summary: Eligible startups with up to $4 million in funding receive 90% off in their first year, 50% off in year two, and 25% off from year three onwards on Freshworks Pro plans for accounts under 30 agents.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T12:56:46.088Z
+    economics:
+      benefits:
+        - applies_to: Pro plans
+          benefit_id: ben_01
+          description: 90% off Pro plans in the first year
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            basis_points: 9000
+            kind: exact
+        - applies_to: Pro plans
+          benefit_id: ben_02
+          description: 50% off Pro plans in the second year
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            basis_points: 5000
+            kind: exact
+        - applies_to: Pro plans
+          benefit_id: ben_03
+          description: 25% off Pro plans 3rd year onwards
+          kind: discount
+          percentage:
+            basis_points: 2500
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.partner_memberships
+            kind: predicate
+            operator: present
+            statement: Must be associated with a Freshworks partner
+          - criterion_id: cri_02
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lte
+            statement: Total funding received must be less than or equal to USD 4 million
+            value:
+              type: number
+              value: 4000000
+          - criterion_id: cri_03
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: Must be a new customer or on a free plan
+            value:
+              type: boolean
+              value: false
+          - criterion_id: cri_04
+            fact: company.employee_count
+            kind: predicate
+            operator: lt
+            statement: Account must have fewer than 30 agents
+            value:
+              type: number
+              value: 30
+    roles:
+      terms_authority_entity_id: ent_01kyypqp9xn8ymms4jtyhc4npw
+      access_operator_entity_id: ent_01kyypqp9xn8ymms4jtyhc4npw
+    access:
+      availability: referral
+      method: form
+      url: https://www.freshworks.com/company/partners/startup-program/
+    source_ids:
+      - src_0a52c5f034e4feadb8168735d025d77121e252e5a06bd1e94275e85566ec81f3

--- a/vendors/im/imagekit.yaml
+++ b/vendors/im/imagekit.yaml
@@ -1,0 +1,103 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyypqp9xhfg48ahr7mzen3ks
+slug: imagekit
+slug_aliases: []
+name: ImageKit
+domains:
+  - value: imagekit.io
+    role: primary
+    valid_from: 2026-08-01T12:56:03.394Z
+category: hosting-infra
+description: Helping startups streamline image and video delivery and management for the web
+links:
+  site: https://imagekit.io
+sources:
+  - source_id: src_cecce3421b2866fa66624dbeb4abce438ce0a05bf59d1b7058f967f84d795e24
+    url: https://imagekit.io/startup-program
+programs:
+  - program_id: prg_01kyypqp9x1dsvsdfvwa51pt63
+    program_slug: imagekit-startup-program
+    program_slug_aliases: []
+    title: ImageKit Startup Program
+    summary: ImageKit Startup Program offers usage-based discounted pricing and media management tools to eligible VC-, incubator-, and accelerator-backed startups.
+    source_ids:
+      - src_cecce3421b2866fa66624dbeb4abce438ce0a05bf59d1b7058f967f84d795e24
+offers:
+  - offer_id: off_01kyypqp9x66145g8gkwd47xh2
+    program_id: prg_01kyypqp9x1dsvsdfvwa51pt63
+    offer_slug: imagekit-startup-program
+    offer_slug_aliases: []
+    title: ImageKit Startup Program
+    summary: Eligible early-stage startups backed by recognized accelerators, incubators, or VCs get discounted usage-based pricing on media delivery bandwidth, DAM storage, processing units, custom domains, and extra users with no monthly fixed costs.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T12:56:03.394Z
+    economics:
+      benefits:
+        - applies_to: ImageKit media delivery, storage, processing, and usage-based features
+          benefit_id: ben_01
+          description: "Exclusive startup discounts on all billing components: bandwidth ($0.10/GB), storage ($8/100GB), Video Processing Units ($8/10K units), Extension Units ($8/5K units), Custom Domain ($8/month), and additional users ($8 each) with no monthly fixed costs."
+          kind: discount
+          percentage:
+            basis_points: 10000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: Startup must be less than 4 years old.
+            value:
+              type: number
+              value: 48
+          - criterion_id: cri_02
+            kind: manual
+            reason: external-verification
+            statement: Must be associated with an accelerator, incubator, or VC firm mentioned by ImageKit, supported by proof (public announcement, verification email, or partner letter).
+          - criterion_id: cri_03
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lte
+            statement: Must have raised up to $20 million in funding.
+            value:
+              type: number
+              value: 20000000
+          - criterion_id: cri_04
+            fact: company.has_working_website_or_app
+            kind: predicate
+            operator: eq
+            statement: Must have a working company website or app.
+            value:
+              type: boolean
+              value: true
+          - criterion_id: cri_05
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: Must not be an existing paid customer of ImageKit.
+            value:
+              type: boolean
+              value: false
+          - criterion_id: cri_06
+            kind: manual
+            reason: external-verification
+            statement: Must not have received previous ImageKit credits.
+          - criterion_id: cri_07
+            kind: manual
+            reason: external-verification
+            statement: Must sign up using a business email.
+    roles:
+      terms_authority_entity_id: ent_01kyypqp9xhfg48ahr7mzen3ks
+      access_operator_entity_id: ent_01kyypqp9xhfg48ahr7mzen3ks
+    access:
+      availability: public
+      method: form
+      url: https://imagekit.io/startup-program
+    terms_url: https://imagekit.io/startup-program
+    source_ids:
+      - src_cecce3421b2866fa66624dbeb4abce438ce0a05bf59d1b7058f967f84d795e24

--- a/vendors/xe/xero.yaml
+++ b/vendors/xe/xero.yaml
@@ -1,0 +1,54 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyypqp9x4hw483erw4fnzdgy
+slug: xero
+slug_aliases: []
+name: Xero
+domains:
+  - value: xero.com
+    role: primary
+    valid_from: 2026-08-01T12:57:23.902Z
+category: finance-accounting
+description: Intuitive accounting software providing bookkeeping, invoicing, and cash flow tracking.
+links:
+  site: https://www.xero.com
+sources:
+  - source_id: src_9b15185aa771c52c1d89f35b03b4f42245dffe8eae1a7e78c9fa15162a753119
+    url: https://www.xero.com/au/startups
+programs: []
+offers:
+  - offer_id: off_01kyypqp9xt0zcgfjvpyncvejs
+    offer_slug: xero-plans-80-off-first-3-months
+    offer_slug_aliases: []
+    title: Xero Plans 80% Off First 3 Months
+    summary: Get 80% off Xero plans for the first 3 months.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T12:57:23.902Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: 80% discount on plan price for the first 3 months
+          duration:
+            kind: exact
+            value: P3M
+          kind: discount
+          percentage:
+            basis_points: 8000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: constant
+        statement: Available for Xero plan purchases as presented on page
+        value: true
+    roles:
+      terms_authority_entity_id: ent_01kyypqp9x4hw483erw4fnzdgy
+      access_operator_entity_id: ent_01kyypqp9x4hw483erw4fnzdgy
+    access:
+      availability: public
+      method: form
+      url: https://www.xero.com/au/small-businesses/startup/
+    source_ids:
+      - src_9b15185aa771c52c1d89f35b03b4f42245dffe8eae1a7e78c9fa15162a753119


### PR DESCRIPTION
Adds five evidence-reviewed startup offers through the canonical scanner and admission path:

- Aiven for Startups
- Autodesk Technology Impact Program for Startups
- Freshworks for Startups
- ImageKit Startup Program
- Xero 80% startup discount

The contribution remains thin: vendor YAML only. CI validates only the changed vendor files against the immutable admission bound to this exact Git tree.