### PR TITLE
Add Pulley and PerkBook channel offers

### DIFF
--- a/vendors/as/assemblyai.yaml
+++ b/vendors/as/assemblyai.yaml
@@ -14,7 +14,16 @@ links:
 sources:
   - source_id: src_8bca567ba3c14b94f29b44fde3a4786a056238ef6a5feb26cc37d5ae05805a1b
     url: https://www.assemblyai.com/contact/startup-program
-programs: []
+  - source_id: src_6e1f10a8bd9fe0cb207ad9f9671270c4f3b142a71766603fcc20af400bdceafa
+    url: https://perkbook.co/vendor-directory/assemblyai
+programs:
+  - program_id: prg_01kyyr9svgvrbh4bzefjw2yedv
+    program_slug: assemblyai-for-startups
+    program_slug_aliases: []
+    title: AssemblyAI for Startups
+    summary: AssemblyAI for Startups gives qualifying early-stage companies up to $150,000 in Speech AI API credits.
+    source_ids:
+      - src_6e1f10a8bd9fe0cb207ad9f9671270c4f3b142a71766603fcc20af400bdceafa
 offers:
   - offer_id: off_01kyh8fpe19tbgz9qesnr0wd3x
     offer_slug: assemblyai-startup-program
@@ -47,3 +56,43 @@ offers:
       url: https://www.assemblyai.com/contact/startup-program
     source_ids:
       - src_8bca567ba3c14b94f29b44fde3a4786a056238ef6a5feb26cc37d5ae05805a1b
+  - offer_id: off_01kyyr9svghkr1k8pg6k0yed14
+    program_id: prg_01kyyr9svgvrbh4bzefjw2yedv
+    offer_slug: up-to-150-000-in-speech-ai-api-credits-with-assemblyai-for-startups
+    offer_slug_aliases: []
+    title: Up to $150,000 in Speech AI API Credits with AssemblyAI for Startups
+    summary: Qualifying early-stage startups building voice, audio, or speech AI products can receive up to $150,000 in Speech AI API credits.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:12:55.874Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $150,000 USD in Speech AI API credits for transcription, speaker diarisation, sentiment analysis, and audio intelligence.
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 15000000
+            kind: up-to
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        fact: company.stage
+        kind: predicate
+        operator: eq
+        statement: Must be an early-stage startup building voice, audio, or speech AI products.
+        value:
+          type: string
+          value: early-stage
+    roles:
+      terms_authority_entity_id: ent_01kyh8fpe12ppbv2jhh02yn5bx
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: membership
+      method: form
+      url: https://perkbook.co/vendor-directory/assemblyai
+    source_ids:
+      - src_6e1f10a8bd9fe0cb207ad9f9671270c4f3b142a71766603fcc20af400bdceafa

--- a/vendors/cl/clerky.yaml
+++ b/vendors/cl/clerky.yaml
@@ -14,6 +14,8 @@ links:
 sources:
   - source_id: src_1a3df42df562c61d0d616954c394e4c693416a7dcc858d002e1631a86c23c7e8
     url: https://www.clerky.com/pricing
+  - source_id: src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d
+    url: https://pulley.com/perks
 programs: []
 offers:
   - offer_id: off_01kyh8fpe20a14efkpgmx94549
@@ -49,3 +51,36 @@ offers:
       url: https://www.clerky.com/pricing
     source_ids:
       - src_1a3df42df562c61d0d616954c394e4c693416a7dcc858d002e1631a86c23c7e8
+  - offer_id: off_01kyyr9svg05ppfv5js7sj7t9b
+    offer_slug: 100-off-company-lifetime-package
+    offer_slug_aliases: []
+    title: $100 off Company Lifetime Package
+    summary: Get $100 off the Company Lifetime Package from Clerky.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T12:27:57.374Z
+    economics:
+      benefits:
+        - applies_to: Company Lifetime Package
+          benefit_id: ben_01
+          description: $100 off Company Lifetime Package
+          kind: discount
+          percentage:
+            basis_points: 10000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: constant
+        statement: Available to Pulley users.
+        value: true
+    roles:
+      terms_authority_entity_id: ent_01kyh8fpe2y70f5fda2h6nnnfr
+      access_operator_entity_id: ent_01kyyr9svfavvhqt4vy0e0b25k
+    access:
+      availability: membership
+      method: other
+    source_ids:
+      - src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d

--- a/vendors/cl/cloudflare.yaml
+++ b/vendors/cl/cloudflare.yaml
@@ -14,6 +14,8 @@ links:
 sources:
   - source_id: src_149b7d73a9ecaa8fe56a5cfe59571a489f490e14e2f9a3c6ecf8ec48c1c1199c
     url: https://www.cloudflare.com/startups/
+  - source_id: src_6969ed732394ce7e5a91a81dab949751ebcf9db069f27007ca75f3cf8e6db441
+    url: https://perkbook.co/vendor-directory/cloudflare
 programs:
   - program_id: prg_01kyh8jtf667atcvk4kp9spgx9
     program_slug: cloudflare-for-startups
@@ -21,6 +23,7 @@ programs:
     title: Cloudflare for Startups
     source_ids:
       - src_149b7d73a9ecaa8fe56a5cfe59571a489f490e14e2f9a3c6ecf8ec48c1c1199c
+      - src_6969ed732394ce7e5a91a81dab949751ebcf9db069f27007ca75f3cf8e6db441
 offers:
   - offer_id: off_01kyh8jtf6rzp78sqz25kvpe3v
     program_id: prg_01kyh8jtf667atcvk4kp9spgx9
@@ -118,3 +121,67 @@ offers:
       url: https://www.cloudflare.com/startups/
     source_ids:
       - src_149b7d73a9ecaa8fe56a5cfe59571a489f490e14e2f9a3c6ecf8ec48c1c1199c
+  - offer_id: off_01kyyr9svg32mtqwp0bwy6yv8y
+    program_id: prg_01kyh8jtf667atcvk4kp9spgx9
+    offer_slug: free-cloud-credits-with-cloudflare-for-startups-250-000-usd
+    offer_slug_aliases: []
+    title: Free cloud credits with Cloudflare for Startups ($250,000 USD)
+    summary: Cloudflare for Startups provides up to $250,000 in enterprise credits for Workers, CDN, DDoS protection, AI gateway, databases, and more to eligible companies.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:13:34.674Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $250,000 in enterprise credits covering Workers, CDN, DDoS protection, AI gateway, databases, and more.
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 250000000
+            kind: up-to
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.age_months
+            kind: predicate
+            operator: lte
+            statement: Founded in last 5 years
+            value:
+              type: number
+              value: 60
+          - criterion_id: cri_02
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: gte
+            statement: Funded $5M+
+            value:
+              type: number
+              value: 5000000
+          - kind: any
+            rules:
+              - criterion_id: cri_03
+                kind: manual
+                reason: external-verification
+                statement: Tier 1 VC or accelerator partner
+              - criterion_id: cri_04
+                kind: manual
+                reason: not-machine-evaluable
+                statement: High-growth/AI company
+              - criterion_id: cri_05
+                kind: manual
+                reason: external-verification
+                statement: Participating in Workers Launchpad Program
+    roles:
+      terms_authority_entity_id: ent_01kyh8jtf535570d9z2bng6j1t
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: membership
+      method: form
+      url: https://perkbook.co/vendor-directory/cloudflare
+    source_ids:
+      - src_6969ed732394ce7e5a91a81dab949751ebcf9db069f27007ca75f3cf8e6db441

--- a/vendors/co/coda.yaml
+++ b/vendors/co/coda.yaml
@@ -14,7 +14,16 @@ links:
 sources:
   - source_id: src_5701585bdefc1cf5026883ef2214ba9f3f2d6c4155378e8cfbaaa4a194973432
     url: https://coda.io/for/startups
-programs: []
+  - source_id: src_a871822fe0eb911cba69805f8814e91191c235ad3ead82e0c72851983a4e9a2e
+    url: https://perkbook.co/vendor-directory/coda
+programs:
+  - program_id: prg_01kyyr9svgzba5w8b8hnr2wxry
+    program_slug: coda-startup-program
+    program_slug_aliases: []
+    title: Coda Startup Program
+    summary: Coda for Startups provides special perks and free team plan access to eligible early-stage companies.
+    source_ids:
+      - src_a871822fe0eb911cba69805f8814e91191c235ad3ead82e0c72851983a4e9a2e
 offers:
   - offer_id: off_01kyygma8278f4c4xbhahf8a2j
     offer_slug: 1-000-startup-credit
@@ -51,3 +60,72 @@ offers:
       url: https://coda.io/for/startups
     source_ids:
       - src_5701585bdefc1cf5026883ef2214ba9f3f2d6c4155378e8cfbaaa4a194973432
+  - offer_id: off_01kyyr9svgpmay2axw8cj4cawa
+    program_id: prg_01kyyr9svgzba5w8b8hnr2wxry
+    offer_slug: 6-months-free-team-plan-with-coda-for-startups
+    offer_slug_aliases: []
+    title: 6 months free Team Plan with Coda for Startups
+    summary: Qualifying early-stage startups get 6 months free on the Coda Team plan with unlimited AI.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:13:34.666Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: 6 months free on the Coda Team plan with unlimited AI
+          duration:
+            kind: exact
+            value: P6M
+          kind: free-service
+          service: Coda Team plan with unlimited AI
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: Company must be under 5 years old
+            value:
+              type: number
+              value: 60
+          - criterion_id: cri_02
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: Company raised less than $10M
+            value:
+              type: number
+              value: 10000000
+          - criterion_id: cri_03
+            fact: company.employee_count
+            kind: predicate
+            operator: gte
+            statement: Team size must be 2 or more
+            value:
+              type: number
+              value: 2
+          - criterion_id: cri_04
+            kind: manual
+            reason: not-machine-evaluable
+            statement: Must use a business domain email
+          - criterion_id: cri_05
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: Must be new Coda customers
+            value:
+              type: boolean
+              value: false
+    roles:
+      terms_authority_entity_id: ent_01kyygma82v52ygt9gw9f3prhb
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: membership
+      method: form
+      url: https://perkbook.co/vendor-directory/coda
+    source_ids:
+      - src_a871822fe0eb911cba69805f8814e91191c235ad3ead82e0c72851983a4e9a2e

--- a/vendors/de/deel.yaml
+++ b/vendors/de/deel.yaml
@@ -16,6 +16,8 @@ sources:
     url: https://www.deel.com/segments/startups/
   - source_id: src_11482e30b1e1cf00925499a7a256cc5c36accecf3c0d790c06af55f3ccde94c7
     url: https://www.deel.com/segments/startups
+  - source_id: src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d
+    url: https://pulley.com/perks
 programs: []
 offers:
   - offer_id: off_01kyh8fpe2r151y0shvrzcmkwt
@@ -85,3 +87,41 @@ offers:
       url: https://www.deel.com/segments/startups/
     source_ids:
       - src_11482e30b1e1cf00925499a7a256cc5c36accecf3c0d790c06af55f3ccde94c7
+  - offer_id: off_01kyyr9svgyw201n7evr25kcjb
+    offer_slug: up-to-5-000-in-deel-credits-and-free-us-payroll-for-founders
+    offer_slug_aliases: []
+    title: Up to $5,000 in Deel credits and free US Payroll for founders.
+    summary: Get up to $5,000 in Deel credits and free US Payroll.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T12:27:57.374Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $5,000 in Deel credits
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 500000
+            kind: up-to
+        - benefit_id: ben_02
+          description: free US Payroll for founders
+          kind: free-service
+          service: US Payroll
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: constant
+        statement: Available to startup founders using Pulley.
+        value: true
+    roles:
+      terms_authority_entity_id: ent_01kyh8fpe2k0kd5rfqh8es0ccs
+      access_operator_entity_id: ent_01kyyr9svfavvhqt4vy0e0b25k
+    access:
+      availability: membership
+      method: other
+    source_ids:
+      - src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d

--- a/vendors/di/digitalocean.yaml
+++ b/vendors/di/digitalocean.yaml
@@ -14,7 +14,16 @@ links:
 sources:
   - source_id: src_79a5ba0b58a5334728f4b66261d11e87dd01f1b9c98e8c82c9ad5805be0c2327
     url: https://www.digitalocean.com/startups
-programs: []
+  - source_id: src_30a5f4587a36fc6cc338e47bd0185250c99f64a15e057bd464c2248ea16c192c
+    url: https://perkbook.co/vendor-directory/digitalocean
+programs:
+  - program_id: prg_01kyyr9svgytm49k59kkp561mf
+    program_slug: digitalocean-hatch
+    program_slug_aliases: []
+    title: DigitalOcean Hatch
+    summary: DigitalOcean's global startup program to help startups grow and build in the cloud.
+    source_ids:
+      - src_30a5f4587a36fc6cc338e47bd0185250c99f64a15e057bd464c2248ea16c192c
 offers:
   - offer_id: off_01kyh8fpe2dwqnfrbb6nejb5zz
     offer_slug: digitalocean-startups-program
@@ -47,3 +56,158 @@ offers:
       url: https://www.digitalocean.com/startups
     source_ids:
       - src_79a5ba0b58a5334728f4b66261d11e87dd01f1b9c98e8c82c9ad5805be0c2327
+  - offer_id: off_01kyyr9svgr2njarjcjtya6n9q
+    program_id: prg_01kyyr9svgytm49k59kkp561mf
+    offer_slug: 20-000-in-cloud-credits-and-partner-perks-via-digitalocean-hatch-partner-tier
+    offer_slug_aliases: []
+    title: $20,000 in cloud credits and partner perks via DigitalOcean Hatch — partner tier
+    summary: Receive $20,000 in credits over 12 months, 15 months of free Standard support, and extra ecosystem perks when referred by an approved partner.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:14:06.110Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: $20,000 in cloud infrastructure credits
+          duration:
+            kind: exact
+            value: P12M
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 2000000
+            kind: exact
+        - benefit_id: ben_02
+          description: Standard support
+          duration:
+            kind: exact
+            value: P15M
+          kind: free-service
+          service: Standard support
+        - benefit_id: ben_03
+          description: Connections to DO PMs and engineers, plus Segment and HubSpot credits in a welcome kit
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: Affiliated with an approved DigitalOcean Hatch partner (VC/accelerator/incubator)
+          - criterion_id: cri_02
+            kind: manual
+            reason: external-verification
+            statement: New DigitalOcean business account
+          - criterion_id: cri_03
+            kind: manual
+            reason: external-verification
+            statement: Business domain email
+    roles:
+      terms_authority_entity_id: ent_01kyh8fpe29kn3bm05h7kyqyka
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: referral
+      method: other
+      url: https://perkbook.co/vendor-directory/digitalocean
+    source_ids:
+      - src_30a5f4587a36fc6cc338e47bd0185250c99f64a15e057bd464c2248ea16c192c
+  - offer_id: off_01kyyr9svg4h7qprerkpb8pjkj
+    program_id: prg_01kyyr9svgytm49k59kkp561mf
+    offer_slug: up-to-1-000-in-credits-via-digitalocean-hatch-direct-tier
+    offer_slug_aliases: []
+    title: Up to $1,000 in credits via DigitalOcean Hatch — direct tier
+    summary: Get up to $1,000 in cloud infrastructure credits directly through DigitalOcean Hatch for new business accounts.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:14:06.110Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $1,000 of cloud infrastructure credits
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 100000
+            kind: up-to
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: New DigitalOcean business account
+          - criterion_id: cri_02
+            kind: manual
+            reason: external-verification
+            statement: Business domain email
+          - criterion_id: cri_03
+            kind: manual
+            reason: external-verification
+            statement: Team account
+    roles:
+      terms_authority_entity_id: ent_01kyh8fpe29kn3bm05h7kyqyka
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: public
+      method: other
+      url: https://perkbook.co/vendor-directory/digitalocean
+    source_ids:
+      - src_30a5f4587a36fc6cc338e47bd0185250c99f64a15e057bd464c2248ea16c192c
+  - offer_id: off_01kyyr9svgad3pab4t761tkz0y
+    program_id: prg_01kyyr9svgytm49k59kkp561mf
+    offer_slug: up-to-100-000-in-compute-credits-via-digitalocean-hatch-ai-ml-tier
+    offer_slug_aliases: []
+    title: Up to $100,000 in compute credits via DigitalOcean Hatch — AI/ML tier
+    summary: AI-focused startups receive up to $100,000 in compute credits and preferred GPU Droplet pricing at $1.90/hr.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:14:06.110Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $100,000 in compute credits
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 10000000
+            kind: up-to
+        - benefit_id: ben_02
+          description: Preferred GPU Droplet pricing at $1.90/hr
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: AI/ML-focused startup
+          - criterion_id: cri_02
+            kind: manual
+            reason: external-verification
+            statement: Affiliated with an approved DigitalOcean partner
+          - criterion_id: cri_03
+            kind: manual
+            reason: external-verification
+            statement: New DigitalOcean business account
+    roles:
+      terms_authority_entity_id: ent_01kyh8fpe29kn3bm05h7kyqyka
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: referral
+      instructions: Contact hatch@digitalocean.com for AI tier details.
+      method: contact
+      url: https://perkbook.co/vendor-directory/digitalocean
+    source_ids:
+      - src_30a5f4587a36fc6cc338e47bd0185250c99f64a15e057bd464c2248ea16c192c

--- a/vendors/gi/github.yaml
+++ b/vendors/gi/github.yaml
@@ -14,7 +14,16 @@ links:
 sources:
   - source_id: src_16fcc1a7174c8dc0546e3675de9ef1c1a5939b667c4823a242ab6aa0370e06f8
     url: https://github.com/enterprise/startups
-programs: []
+  - source_id: src_66c378883140254b04de6425feae465103e4892f02f421223e5fd8b65f3d9efe
+    url: https://perkbook.co/vendor-directory/github
+programs:
+  - program_id: prg_01kyyr9svgyw0svdrb717nexp9
+    program_slug: github-for-startups
+    program_slug_aliases: []
+    title: GitHub for Startups
+    summary: GitHub for Startups provides eligible early-stage companies with flexible platform credits covering GitHub Enterprise, Copilot, Advanced Security, Actions, and more.
+    source_ids:
+      - src_66c378883140254b04de6425feae465103e4892f02f421223e5fd8b65f3d9efe
 offers:
   - offer_id: off_01kyh8fpe3fe0s7ef65e5fj1p5
     offer_slug: github-for-startups-offer
@@ -47,3 +56,56 @@ offers:
       url: https://github.com/enterprise/startups
     source_ids:
       - src_16fcc1a7174c8dc0546e3675de9ef1c1a5939b667c4823a242ab6aa0370e06f8
+  - offer_id: off_01kyyr9svgd67qdmw6cwerth4p
+    program_id: prg_01kyyr9svgyw0svdrb717nexp9
+    offer_slug: 50-off-with-github-for-startups-year-2
+    offer_slug_aliases: []
+    title: 50% off with GitHub for Startups — Year 2
+    summary: Eligible early-stage startups receive 50% off GitHub for Startups in Year 2.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:14:29.306Z
+    economics:
+      benefits:
+        - applies_to: GitHub for Startups — Year 2
+          benefit_id: ben_01
+          description: 50% off with GitHub for Startups — Year 2
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            basis_points: 5000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: Affiliated with a GitHub for Startups partner (VC/accelerator)
+          - criterion_id: cri_02
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: New GitHub Enterprise customer
+            value:
+              type: boolean
+              value: false
+          - criterion_id: cri_03
+            kind: manual
+            reason: external-verification
+            statement: Company domain email
+    roles:
+      terms_authority_entity_id: ent_01kyh8fpe3xgjjktffez1t34rn
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: referral
+      instructions: Sign Up to Unlock and apply through github.com/enterprise/startups
+      method: other
+      url: https://perkbook.co/vendor-directory/github
+    source_ids:
+      - src_66c378883140254b04de6425feae465103e4892f02f421223e5fd8b65f3d9efe

--- a/vendors/mo/modal.yaml
+++ b/vendors/mo/modal.yaml
@@ -14,7 +14,16 @@ links:
 sources:
   - source_id: src_12f9a93d061e0e5f58df0d8d7ac914e89e2bd620062a3842e3ea4bae69118813
     url: https://modal.com/startups
-programs: []
+  - source_id: src_4eefce2dfc395cad64047bb4aa6d75151f2df72dcaadf1e595c26ed82e1c5d9d
+    url: https://perkbook.co/vendor-directory/modal
+programs:
+  - program_id: prg_01kyyr9svhh7n947rd6m78efaf
+    program_slug: modal-for-startups
+    program_slug_aliases: []
+    title: Modal for Startups
+    summary: Modal for Startups provides compute credits to qualifying early-stage AI companies using Modal's serverless GPU compute platform.
+    source_ids:
+      - src_4eefce2dfc395cad64047bb4aa6d75151f2df72dcaadf1e595c26ed82e1c5d9d
 offers:
   - offer_id: off_01kyh8fpe4fyz5pxzv154ah0y4
     offer_slug: modal-for-startups
@@ -47,3 +56,53 @@ offers:
       url: https://modal.com/startups
     source_ids:
       - src_12f9a93d061e0e5f58df0d8d7ac914e89e2bd620062a3842e3ea4bae69118813
+  - offer_id: off_01kyyr9svhq579q2kgwtr3djcx
+    program_id: prg_01kyyr9svhh7n947rd6m78efaf
+    offer_slug: 25-000-in-modal-compute-credits
+    offer_slug_aliases: []
+    title: $25,000 in Modal compute credits
+    summary: Qualifying early-stage AI startups and new Modal customers receive $25,000 in compute credits on Modal's serverless GPU compute platform.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:15:22.418Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: $25,000 in compute credits for serverless GPU compute
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 2500000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.industry
+            kind: predicate
+            operator: contains
+            statement: Must be an early-stage AI startup building AI applications requiring GPU compute.
+            value:
+              type: string
+              value: AI
+          - criterion_id: cri_02
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: Must be a new Modal customer.
+            value:
+              type: boolean
+              value: false
+    roles:
+      terms_authority_entity_id: ent_01kyh8fpe43gqa08cvashmf19y
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: membership
+      method: form
+      url: https://perkbook.co/vendor-directory/modal
+    source_ids:
+      - src_4eefce2dfc395cad64047bb4aa6d75151f2df72dcaadf1e595c26ed82e1c5d9d

--- a/vendors/op/openai.yaml
+++ b/vendors/op/openai.yaml
@@ -14,7 +14,16 @@ links:
 sources:
   - source_id: src_9223b16ab8e30ece5c495a1ed47b811ce538fbf172483fa3e1bbb3013c5433c8
     url: https://openai.com/business/why-openai/startups/
-programs: []
+  - source_id: src_f0897f1deaf5cdccfab9fda163fcfb40fcd734a1c9adb5e35c96ada602cc65f1
+    url: https://perkbook.co/vendor-directory/openai
+programs:
+  - program_id: prg_01kyyr9svh0pbsy1aaq4gwthwn
+    program_slug: openai-for-startups
+    program_slug_aliases: []
+    title: Openai for Startups
+    summary: OpenAI's startup program provides early-stage companies with API credits to build products powered by GPT-4, DALL-E, Whisper, and other cutting-edge AI models.
+    source_ids:
+      - src_f0897f1deaf5cdccfab9fda163fcfb40fcd734a1c9adb5e35c96ada602cc65f1
 offers:
   - offer_id: off_01kyh8fpe4jecj8crezg4618sc
     offer_slug: openai-startup-credits-and-vc-partner-support
@@ -47,3 +56,49 @@ offers:
       url: https://openai.com/business/why-openai/startups/
     source_ids:
       - src_9223b16ab8e30ece5c495a1ed47b811ce538fbf172483fa3e1bbb3013c5433c8
+  - offer_id: off_01kyyr9svh5zk20r29dskcmpgt
+    program_id: prg_01kyyr9svh0pbsy1aaq4gwthwn
+    offer_slug: free-api-credits-with-openai-for-startups
+    offer_slug_aliases: []
+    title: Free API credits with OpenAI for Startups
+    summary: Early-stage startups can receive $2,500 in OpenAI API credits when applying through partner programs like Ramp, Microsoft for Startups, or approved VC partners.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:15:42.602Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: $2,500 in OpenAI API credits for building products powered by AI models.
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 250000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: Available through partner programs including Ramp, Microsoft for Startups, or approved VC partners
+          - criterion_id: cri_02
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: Must be a new OpenAI API customer
+            value:
+              type: boolean
+              value: false
+    roles:
+      terms_authority_entity_id: ent_01kyh8fpe4qj5yt6msnarsc8kz
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: referral
+      method: form
+      url: https://perkbook.co/vendor-directory/openai
+    source_ids:
+      - src_f0897f1deaf5cdccfab9fda163fcfb40fcd734a1c9adb5e35c96ada602cc65f1

--- a/vendors/pe/perkbook.yaml
+++ b/vendors/pe/perkbook.yaml
@@ -1,0 +1,18 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+slug: perkbook
+slug_aliases: []
+name: PerkBook
+domains:
+  - value: perkbook.co
+    role: primary
+    valid_from: 2026-08-01T13:29:02.000Z
+category: startup
+description: Manage, distribute and discover startup perks in one searchable, branded platform. Built for founders, communities, and vendors.
+links:
+  site: https://perkbook.co
+sources:
+  - source_id: src_0a115e044cfe5af7f2cb5c5d5cc113ccdf327f3c64ce99308ad0055dfcf51d8d
+    url: https://perkbook.co/
+programs: []
+offers: []

--- a/vendors/pi/pilot.yaml
+++ b/vendors/pi/pilot.yaml
@@ -14,6 +14,8 @@ links:
 sources:
   - source_id: src_03280047fb9243ba29a16274b0569d4376e75b97b65e938c2a9045faf5ef21ca
     url: https://pilot.com/pricing
+  - source_id: src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d
+    url: https://pulley.com/perks
 programs: []
 offers:
   - offer_id: off_01kyh8fpe4pawgdejcqq2q04f9
@@ -48,3 +50,56 @@ offers:
       url: https://pilot.com/pricing
     source_ids:
       - src_03280047fb9243ba29a16274b0569d4376e75b97b65e938c2a9045faf5ef21ca
+  - offer_id: off_01kyyr9svgz7xdd7m6ct69rcyw
+    offer_slug: pilot-startup-booster-and-partner-offer
+    offer_slug_aliases: []
+    title: Pilot Startup Booster and Partner Offer
+    summary: Get tax filings and monthly bookkeeping for $750 for young companies, plus 20% off Pilot Core for 6 months and 10% off CFO services.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T12:27:57.374Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Tax filings and monthly bookkeeping for just $750 for companies less than a year old
+          kind: other
+        - applies_to: Pilot Core
+          benefit_id: ben_02
+          description: 20% off Pilot Core for six months
+          duration:
+            kind: exact
+            value: P6M
+          kind: discount
+          percentage:
+            basis_points: 2000
+            kind: exact
+        - applies_to: CFO services
+          benefit_id: ben_03
+          description: 10% off CFO services
+          kind: discount
+          percentage:
+            basis_points: 1000
+            kind: exact
+      consideration:
+        amount:
+          currency: USD
+          minor_units: 75000
+        kind: fixed
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        fact: company.age_months
+        kind: predicate
+        operator: lt
+        statement: Companies that are less than a year old.
+        value:
+          type: number
+          value: 12
+    roles:
+      terms_authority_entity_id: ent_01kyh8fpe4nr3y7st8xcm8gryv
+      access_operator_entity_id: ent_01kyyr9svfavvhqt4vy0e0b25k
+    access:
+      availability: membership
+      method: other
+    source_ids:
+      - src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d

--- a/vendors/pu/pulley.yaml
+++ b/vendors/pu/pulley.yaml
@@ -1,0 +1,60 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyyr9svfavvhqt4vy0e0b25k
+slug: pulley
+slug_aliases: []
+name: Pulley
+domains:
+  - value: pulley.com
+    role: primary
+    valid_from: 2026-08-01T13:29:02.000Z
+category: equity
+description: Pulley has helped thousands of companies manage their cap table and equity. Onboard with us today.
+links:
+  site: https://pulley.com
+sources:
+  - source_id: src_a4659f14a829868c42b77c01a286a3995330172a4358114042c00010c532816c
+    url: https://pulley.com/privacy
+  - source_id: src_ed107b1b269378ea0fa71e20da6f86dd93fb9d9bff167afbf4b60d7c500dcefb
+    url: https://site.pulley.com/techstars
+programs: []
+offers:
+  - offer_id: off_01kyyr9svgh90r2kg9j37jzdaw
+    offer_slug: pulley-for-techstars-1-year-free-cap-table-management
+    offer_slug_aliases: []
+    title: "Pulley for Techstars: 1 Year Free Cap Table Management"
+    summary: Techstars companies can sign up within 1 year of Demo Day to get 1 year free of Pulley's cap table management and equity platform.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T11:05:10.949Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: First year free of Pulley's equity management platform
+          duration:
+            kind: exact
+            value: P1Y
+          kind: free-service
+          service: Pulley cap table and equity management platform
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: Must be affiliated with Techstars (Techstars company).
+          - criterion_id: cri_02
+            kind: manual
+            reason: external-verification
+            statement: Sign up within 1 year of Demo Day.
+    roles:
+      terms_authority_entity_id: ent_01kyyr9svfavvhqt4vy0e0b25k
+      access_operator_entity_id: ent_01kyyr9svfavvhqt4vy0e0b25k
+    access:
+      availability: membership
+      method: form
+      url: https://site.pulley.com/techstars
+    source_ids:
+      - src_ed107b1b269378ea0fa71e20da6f86dd93fb9d9bff167afbf4b60d7c500dcefb

--- a/vendors/ra/ramp.yaml
+++ b/vendors/ra/ramp.yaml
@@ -14,6 +14,8 @@ links:
 sources:
   - source_id: src_d19ab8f87d18dd699257e5a42cd736410ef08227d0e692940cae6deb10f48850
     url: https://ramp.com/startups
+  - source_id: src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d
+    url: https://pulley.com/perks
 programs: []
 offers:
   - offer_id: off_01kyh8fpe4322h35pkyczap998
@@ -47,3 +49,32 @@ offers:
       url: https://ramp.com/startups
     source_ids:
       - src_d19ab8f87d18dd699257e5a42cd736410ef08227d0e692940cae6deb10f48850
+  - offer_id: off_01kyyr9svgg173dw51edxbh53y
+    offer_slug: 500-amazon-gift-card
+    offer_slug_aliases: []
+    title: $500 Amazon Gift card
+    summary: Receive a $500 Amazon Gift Card when signing up for Ramp.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T12:27:57.374Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: $500 Amazon Gift Card
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: constant
+        statement: Available to Pulley users.
+        value: true
+    roles:
+      terms_authority_entity_id: ent_01kyh8fpe4g7kgfr7x2skc0vt3
+      access_operator_entity_id: ent_01kyyr9svfavvhqt4vy0e0b25k
+    access:
+      availability: membership
+      method: other
+    source_ids:
+      - src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d

--- a/vendors/re/remote.yaml
+++ b/vendors/re/remote.yaml
@@ -16,6 +16,8 @@ sources:
     url: https://remote.com/global-hr/small-business
   - source_id: src_5637f24101627f4de80403d0704f41e07d9054bd83948cf0018b653001047fa4
     url: https://remote.com/global-hr/startups
+  - source_id: src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d
+    url: https://pulley.com/perks
 programs:
   - program_id: prg_01kyy6rm11sqz3yrwfb6j21620
     program_slug: remote-for-startups
@@ -109,3 +111,43 @@ offers:
       url: https://remote.com/global-hr/startups
     source_ids:
       - src_5637f24101627f4de80403d0704f41e07d9054bd83948cf0018b653001047fa4
+  - offer_id: off_01kyyr9svgdd81b5ac861syvps
+    offer_slug: 20-off-full-time-hires-20-off-contractor-management
+    offer_slug_aliases: []
+    title: 20% off full time hires + 20% off contractor management
+    summary: Get 20% off full-time hires and 20% off contractor management with Remote.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T12:27:57.374Z
+    economics:
+      benefits:
+        - applies_to: full time hires
+          benefit_id: ben_01
+          description: 20% off full time hires
+          kind: discount
+          percentage:
+            basis_points: 2000
+            kind: exact
+        - applies_to: contractor management
+          benefit_id: ben_02
+          description: 20% off contractor management
+          kind: discount
+          percentage:
+            basis_points: 2000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: constant
+        statement: Available to Pulley users.
+        value: true
+    roles:
+      terms_authority_entity_id: ent_01kyh8fpe4dkt6qsga03ep38rk
+      access_operator_entity_id: ent_01kyyr9svfavvhqt4vy0e0b25k
+    access:
+      availability: membership
+      method: other
+    source_ids:
+      - src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d

--- a/vendors/sa/salesforce.yaml
+++ b/vendors/sa/salesforce.yaml
@@ -14,7 +14,16 @@ links:
 sources:
   - source_id: src_de248238da7faac44fa1bff72d2bcf4525bc36ccdb8b20a93ad9bbedd00f3748
     url: https://www.salesforce.com/launchpad/?bc=OTH
-programs: []
+  - source_id: src_a6d9fdf624ddc31e96c7f991192cf02a9b45373c89aecfc03609393c55e35d69
+    url: https://perkbook.co/vendor-directory/salesforce
+programs:
+  - program_id: prg_01kyyr9svhvjac4av1162f05j1
+    program_slug: salesforce-launchpad
+    program_slug_aliases: []
+    title: Salesforce Launchpad
+    summary: Salesforce Launchpad gives venture-backed startups of all stages free and discounted access to Salesforce products - CRM; Agentforce; Slack; Tableau - plus expert GTM coaching; community; and ecosystem partnerships.
+    source_ids:
+      - src_a6d9fdf624ddc31e96c7f991192cf02a9b45373c89aecfc03609393c55e35d69
 offers:
   - offer_id: off_01kyh8fpe5a27280hssp9jdt7q
     offer_slug: salesforce-launchpad-free-and-discounted-solutions
@@ -47,3 +56,199 @@ offers:
       url: https://www.salesforce.com/launchpad/?bc=OTH
     source_ids:
       - src_de248238da7faac44fa1bff72d2bcf4525bc36ccdb8b20a93ad9bbedd00f3748
+  - offer_id: off_01kyyr9svh98n6tst8agy4n8wv
+    program_id: prg_01kyyr9svhvjac4av1162f05j1
+    offer_slug: 12-months-free-starter-suite-with-salesforce-launchpad
+    offer_slug_aliases: []
+    title: 12 months free Starter Suite with Salesforce Launchpad
+    summary: Venture-backed startups can access 12 months of free Starter Suite through the Salesforce Launchpad program.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:16:59.678Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: 12 months free Starter Suite
+          duration:
+            kind: exact
+            value: P1Y
+          kind: free-service
+          service: Starter Suite
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: not-machine-evaluable
+            statement: Venture-backed or growth-stage startup
+          - criterion_id: cri_02
+            kind: manual
+            reason: external-verification
+            statement: Salesforce Launchpad member
+          - criterion_id: cri_03
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: New Starter Suite customers
+            value:
+              type: boolean
+              value: false
+    roles:
+      terms_authority_entity_id: ent_01kyh8fpe55a2m2njc8y4xs2df
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: membership
+      method: form
+      url: https://perkbook.co/vendor-directory/salesforce
+    source_ids:
+      - src_a6d9fdf624ddc31e96c7f991192cf02a9b45373c89aecfc03609393c55e35d69
+  - offer_id: off_01kyyr9svhk9h0e6bapg0btkt4
+    program_id: prg_01kyyr9svhvjac4av1162f05j1
+    offer_slug: 25-off-slack-pro-or-business-with-salesforce-launchpad
+    offer_slug_aliases: []
+    title: 25% off Slack Pro or Business+ with Salesforce Launchpad
+    summary: Eligible startups with 200 or fewer employees receive 25% off Slack Pro or Business+ through Salesforce Launchpad.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:16:59.678Z
+    economics:
+      benefits:
+        - applies_to: Slack Pro or Business+
+          benefit_id: ben_01
+          description: 25% off Slack Pro or Business+
+          kind: discount
+          percentage:
+            basis_points: 2500
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: not-machine-evaluable
+            statement: Venture-backed or growth-stage startup
+          - criterion_id: cri_02
+            kind: manual
+            reason: external-verification
+            statement: Salesforce Launchpad member
+          - criterion_id: cri_03
+            fact: company.employee_count
+            kind: predicate
+            operator: lte
+            statement: 200 or fewer employees
+            value:
+              type: number
+              value: 200
+          - criterion_id: cri_04
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: New Slack customers
+            value:
+              type: boolean
+              value: false
+    roles:
+      terms_authority_entity_id: ent_01kyh8fpe55a2m2njc8y4xs2df
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: membership
+      method: form
+      url: https://perkbook.co/vendor-directory/salesforce
+    source_ids:
+      - src_a6d9fdf624ddc31e96c7f991192cf02a9b45373c89aecfc03609393c55e35d69
+  - offer_id: off_01kyyr9svh8pman77qjzfxrjzd
+    program_id: prg_01kyyr9svhvjac4av1162f05j1
+    offer_slug: 50-off-pro-suite-with-salesforce-launchpad
+    offer_slug_aliases: []
+    title: 50% off Pro Suite with Salesforce Launchpad
+    summary: New Pro Suite customers who are Salesforce Launchpad members receive 50% off Pro Suite.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:16:59.678Z
+    economics:
+      benefits:
+        - applies_to: Pro Suite
+          benefit_id: ben_01
+          description: 50% off Pro Suite
+          kind: discount
+          percentage:
+            basis_points: 5000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: not-machine-evaluable
+            statement: Venture-backed or growth-stage startup
+          - criterion_id: cri_02
+            kind: manual
+            reason: external-verification
+            statement: Salesforce Launchpad member
+          - criterion_id: cri_03
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: New Pro Suite customers
+            value:
+              type: boolean
+              value: false
+    roles:
+      terms_authority_entity_id: ent_01kyh8fpe55a2m2njc8y4xs2df
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: membership
+      method: form
+      url: https://perkbook.co/vendor-directory/salesforce
+    source_ids:
+      - src_a6d9fdf624ddc31e96c7f991192cf02a9b45373c89aecfc03609393c55e35d69
+  - offer_id: off_01kyyr9svhdgk1rr8v16whzzk7
+    program_id: prg_01kyyr9svhvjac4av1162f05j1
+    offer_slug: 50-off-sales-cloud-enterprise-with-salesforce-launchpad
+    offer_slug_aliases: []
+    title: 50% off Sales Cloud Enterprise with Salesforce Launchpad
+    summary: Venture-backed or growth-stage startups in Salesforce Launchpad get 50% off Sales Cloud Enterprise.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:16:59.678Z
+    economics:
+      benefits:
+        - applies_to: Sales Cloud Enterprise
+          benefit_id: ben_01
+          description: 50% off Sales Cloud Enterprise
+          kind: discount
+          percentage:
+            basis_points: 5000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: not-machine-evaluable
+            statement: Venture-backed or growth-stage startup
+          - criterion_id: cri_02
+            kind: manual
+            reason: external-verification
+            statement: Salesforce Launchpad member
+    roles:
+      terms_authority_entity_id: ent_01kyh8fpe55a2m2njc8y4xs2df
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: membership
+      method: form
+      url: https://perkbook.co/vendor-directory/salesforce
+    source_ids:
+      - src_a6d9fdf624ddc31e96c7f991192cf02a9b45373c89aecfc03609393c55e35d69

--- a/vendors/st/stripe.yaml
+++ b/vendors/st/stripe.yaml
@@ -14,6 +14,8 @@ links:
 sources:
   - source_id: src_4410dda4d44891aad0cc0b21bb409ed3d27032c5bc1852a256708b3df0b1ff45
     url: https://stripe.com/startups
+  - source_id: src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d
+    url: https://pulley.com/perks
 programs:
   - program_id: prg_01kyygma8309wepbqk3a8d21wm
     program_slug: stripe-startup-programme
@@ -63,3 +65,37 @@ offers:
       url: https://stripe.com/au/startups
     source_ids:
       - src_4410dda4d44891aad0cc0b21bb409ed3d27032c5bc1852a256708b3df0b1ff45
+  - offer_id: off_01kyyr9svgdkega07z9phrrjdn
+    offer_slug: 20-000-in-processing-credit
+    offer_slug_aliases: []
+    title: $20,000 in Processing Credit
+    summary: Get $20,000 in payment processing credits for Stripe.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T12:27:57.374Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: $20,000 in payment processing credit
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 2000000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: constant
+        statement: Available to Pulley users.
+        value: true
+    roles:
+      terms_authority_entity_id: ent_01kyygma830fqh16kvj744sk1c
+      access_operator_entity_id: ent_01kyyr9svfavvhqt4vy0e0b25k
+    access:
+      availability: membership
+      method: other
+    source_ids:
+      - src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d

--- a/vendors/va/vanta.yaml
+++ b/vendors/va/vanta.yaml
@@ -14,6 +14,8 @@ links:
 sources:
   - source_id: src_45f3cb169494b2ede38440ee5f20d21796d5bd4c4859976ae3659673b955c52b
     url: https://www.vanta.com/solutions/startup
+  - source_id: src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d
+    url: https://pulley.com/perks
 programs: []
 offers:
   - offer_id: off_01kyh8fpe5gjd9624g0mqdk3mf
@@ -47,3 +49,36 @@ offers:
       url: https://www.vanta.com/solutions/startup
     source_ids:
       - src_45f3cb169494b2ede38440ee5f20d21796d5bd4c4859976ae3659673b955c52b
+  - offer_id: off_01kyyr9svgm4vq06cr78n8p2cr
+    offer_slug: 25-off-vanta
+    offer_slug_aliases: []
+    title: 25% off Vanta
+    summary: Get 25% off Vanta compliance automation platform.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T12:27:57.374Z
+    economics:
+      benefits:
+        - applies_to: Vanta services
+          benefit_id: ben_01
+          description: 25% off Vanta
+          kind: discount
+          percentage:
+            basis_points: 2500
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: constant
+        statement: Available to Pulley users.
+        value: true
+    roles:
+      terms_authority_entity_id: ent_01kyh8fpe5mhzs20zrae013w4h
+      access_operator_entity_id: ent_01kyyr9svfavvhqt4vy0e0b25k
+    access:
+      availability: membership
+      method: other
+    source_ids:
+      - src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d

--- a/vendors/wi/wiz.yaml
+++ b/vendors/wi/wiz.yaml
@@ -14,7 +14,16 @@ links:
 sources:
   - source_id: src_e10dc2ef42ff4c06dd0e194be3a951c491eb07ca7e75f7102a215bdcd876d430
     url: https://www.wiz.io/lp/startups
-programs: []
+  - source_id: src_07e5e123c86af5b6cb52741d997ba3110a476c45d724c585f666ab756f328b3d
+    url: https://perkbook.co/vendor-directory/wiz
+programs:
+  - program_id: prg_01kyyr9svh6aeder74q5j4rcn2
+    program_slug: wiz-startup-program
+    program_slug_aliases: []
+    title: Wiz Startup Program
+    summary: Wiz for Startups offers and perks
+    source_ids:
+      - src_07e5e123c86af5b6cb52741d997ba3110a476c45d724c585f666ab756f328b3d
 offers:
   - offer_id: off_01kyygma830fgn90asc8pctkj3
     offer_slug: wiz-go-for-startups
@@ -47,3 +56,48 @@ offers:
       url: https://www.wiz.io/lp/startups
     source_ids:
       - src_e10dc2ef42ff4c06dd0e194be3a951c491eb07ca7e75f7102a215bdcd876d430
+  - offer_id: off_01kyyr9svh48zzn71mrw9zpapf
+    program_id: prg_01kyyr9svh6aeder74q5j4rcn2
+    offer_slug: 50-off-cloud-security-bundle-with-wiz-go
+    offer_slug_aliases: []
+    title: 50% off cloud security bundle with Wiz Go
+    summary: Qualifying early-stage startups get 50% off the Wiz Go cloud security bundle covering cloud, code, runtime, and AI environments.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:17:55.660Z
+    economics:
+      benefits:
+        - applies_to: Wiz Go cloud security bundle
+          benefit_id: ben_01
+          description: 50% off the Wiz cloud security bundle via Wiz Go
+          kind: discount
+          percentage:
+            basis_points: 5000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: vendor-discretion
+            statement: Must be an early-stage startup
+          - criterion_id: cri_02
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: Must be a new Wiz customer
+            value:
+              type: boolean
+              value: false
+    roles:
+      terms_authority_entity_id: ent_01kyygma836y4jv9n2210zgyq4
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: membership
+      method: form
+      url: https://perkbook.co/vendor-directory/wiz
+    source_ids:
+      - src_07e5e123c86af5b6cb52741d997ba3110a476c45d724c585f666ab756f328b3d

--- a/vendors/wo/workos.yaml
+++ b/vendors/wo/workos.yaml
@@ -14,7 +14,16 @@ links:
 sources:
   - source_id: src_8789e905c49e7d05c098a0f21794a9f9de31de90992065d262508e304c3724c3
     url: https://workos.com/startups
-programs: []
+  - source_id: src_f63ef498edf3919e150a78446108e6dcd05ec3188b6e00af4eee6a863cecaa85
+    url: https://perkbook.co/vendor-directory/workos
+programs:
+  - program_id: prg_01kyyr9svhkdh4hjkb04cxee7z
+    program_slug: workos-startup-program
+    program_slug_aliases: []
+    title: Workos Startup Program
+    summary: Workos Startup Program / Workos for Startups provides startup offers and perks for qualifying early-stage startups.
+    source_ids:
+      - src_f63ef498edf3919e150a78446108e6dcd05ec3188b6e00af4eee6a863cecaa85
 offers:
   - offer_id: off_01kyygma82eet0aqhpceg6n1ba
     offer_slug: workos-user-management-free-tier
@@ -51,3 +60,39 @@ offers:
       url: https://workos.com/startups
     source_ids:
       - src_8789e905c49e7d05c098a0f21794a9f9de31de90992065d262508e304c3724c3
+  - offer_id: off_01kyyr9svhd38hwdr5k9xsxp9h
+    program_id: prg_01kyyr9svhkdh4hjkb04cxee7z
+    offer_slug: 12-months-free-with-workos-for-startups
+    offer_slug_aliases: []
+    title: 12 months free with WorkOS for Startups
+    summary: Qualifying early-stage startups receive up to 12 months of free access to WorkOS's enterprise-ready auth platform.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:17:55.659Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to 12 months free access to WorkOS's enterprise-ready auth platform including SSO, SCIM directory sync, and fine-grained authorization.
+          duration:
+            kind: up-to
+            value: P1Y
+          kind: free-service
+          service: WorkOS enterprise-ready auth platform
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: vendor-discretion
+        statement: Available to qualifying early-stage startups
+    roles:
+      terms_authority_entity_id: ent_01kyygma822smsegab8rym0sqk
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: membership
+      instructions: Sign Up to Unlock
+      method: form
+      url: https://perkbook.co/vendor-directory/workos
+    source_ids:
+      - src_f63ef498edf3919e150a78446108e6dcd05ec3188b6e00af4eee6a863cecaa85

--- a/vendors/xe/xero.yaml
+++ b/vendors/xe/xero.yaml
@@ -14,7 +14,16 @@ links:
 sources:
   - source_id: src_9b15185aa771c52c1d89f35b03b4f42245dffe8eae1a7e78c9fa15162a753119
     url: https://www.xero.com/au/startups
-programs: []
+  - source_id: src_44b6d6f584535a273533712965405c509c56178a6c49055805fcbbf7524128a2
+    url: https://perkbook.co/vendor-directory/xero
+programs:
+  - program_id: prg_01kyyr9svhy3sy9mek6jrdnx43
+    program_slug: xero-for-startups
+    program_slug_aliases: []
+    title: Xero for Startups
+    summary: Xero for Startups program offers discounts on cloud accounting software for qualifying early-stage startups.
+    source_ids:
+      - src_44b6d6f584535a273533712965405c509c56178a6c49055805fcbbf7524128a2
 offers:
   - offer_id: off_01kyypqp9xt0zcgfjvpyncvejs
     offer_slug: xero-plans-80-off-first-3-months
@@ -52,3 +61,51 @@ offers:
       url: https://www.xero.com/au/small-businesses/startup/
     source_ids:
       - src_9b15185aa771c52c1d89f35b03b4f42245dffe8eae1a7e78c9fa15162a753119
+  - offer_id: off_01kyyr9svh3rrj9axka2qr0r66
+    program_id: prg_01kyyr9svhy3sy9mek6jrdnx43
+    offer_slug: 90-off-for-6-months-with-xero-for-startups
+    offer_slug_aliases: []
+    title: 90% off for 6 months with Xero for Startups
+    summary: Qualifying early-stage startups receive a 90% discount on Xero subscription plans for 6 months.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:17:55.653Z
+    economics:
+      benefits:
+        - applies_to: subscription
+          benefit_id: ben_01
+          description: 90% off subscription for 6 months
+          duration:
+            kind: exact
+            value: P6M
+          kind: discount
+          percentage:
+            basis_points: 9000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: New Xero customers only
+            value:
+              type: boolean
+              value: false
+          - criterion_id: cri_02
+            kind: manual
+            reason: not-machine-evaluable
+            statement: Any early-stage startup
+    roles:
+      terms_authority_entity_id: ent_01kyypqp9x4hw483erw4fnzdgy
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: public
+      instructions: Apply via Startup Grind partner link or directly at xero.com/startups
+      method: other
+    source_ids:
+      - src_44b6d6f584535a273533712965405c509c56178a6c49055805fcbbf7524128a2

--- a/vendors/ze/zendesk.yaml
+++ b/vendors/ze/zendesk.yaml
@@ -14,7 +14,16 @@ links:
 sources:
   - source_id: src_25b42ddd48289d24850b1e411340687bbfcd4a3cb063113c80d9e6911decd797
     url: https://www.zendesk.com/au/business/startups/
-programs: []
+  - source_id: src_75b5dc555370733d4846f2bb1b618e8cff662b28039d2e1096456ccc5356451e
+    url: https://perkbook.co/vendor-directory/zendesk
+programs:
+  - program_id: prg_01kyyr9svh3m46vmwgnbrpwagr
+    program_slug: zendesk-startup-program
+    program_slug_aliases: []
+    title: Zendesk Startup Program
+    summary: Zendesk for Startups offers and perks
+    source_ids:
+      - src_75b5dc555370733d4846f2bb1b618e8cff662b28039d2e1096456ccc5356451e
 offers:
   - offer_id: off_01kyh8fpe6brkee6gvymyykky4
     offer_slug: zendesk-for-startups-programme
@@ -48,3 +57,64 @@ offers:
       url: https://www.zendesk.com/au/business/startups/
     source_ids:
       - src_25b42ddd48289d24850b1e411340687bbfcd4a3cb063113c80d9e6911decd797
+  - offer_id: off_01kyyr9svh9qj0hc652gxtp53a
+    program_id: prg_01kyyr9svh3m46vmwgnbrpwagr
+    offer_slug: 30-off-first-year-with-zendesk-for-startups-50-to-250-employees
+    offer_slug_aliases: []
+    title: 30% off first year with Zendesk for Startups — 50 to 250 employees
+    summary: Get 30% off the first year of Zendesk for new customers with 50 to 250 employees.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:18:11.942Z
+    economics:
+      benefits:
+        - applies_to: Zendesk
+          benefit_id: ben_01
+          description: 30% off first year
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            basis_points: 3000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: New Zendesk customer
+            value:
+              type: boolean
+              value: false
+          - criterion_id: cri_02
+            fact: company.employee_count
+            kind: predicate
+            operator: gte
+            statement: Between 50 and 250 employees
+            value:
+              type: number
+              value: 50
+          - criterion_id: cri_03
+            fact: company.employee_count
+            kind: predicate
+            operator: lte
+            statement: Between 50 and 250 employees
+            value:
+              type: number
+              value: 250
+    roles:
+      terms_authority_entity_id: ent_01kyh8fpe6eqd854n10kf92e5b
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: membership
+      instructions: Sign Up to Unlock
+      method: other
+      url: https://perkbook.co/vendor-directory/zendesk
+    source_ids:
+      - src_75b5dc555370733d4846f2bb1b618e8cff662b28039d2e1096456ccc5356451e

--- a/vendors/zo/zoho.yaml
+++ b/vendors/zo/zoho.yaml
@@ -14,7 +14,16 @@ links:
 sources:
   - source_id: src_7eed286a8512fe0123f70f0b88d01a0a88efa496fa5f6a89703157515c5e3a8f
     url: https://www.zoho.com/startups/
-programs: []
+  - source_id: src_d181b341f71716f956f85b611c4672f4e815220a59b4187735d63c9fa6db74c9
+    url: https://perkbook.co/vendor-directory/zoho
+programs:
+  - program_id: prg_01kyyr9svhbyevgq9sjgvgyngg
+    program_slug: zoho-startup-program
+    program_slug_aliases: []
+    title: Zoho Startup Program
+    summary: Zoho for Startups offers and perks
+    source_ids:
+      - src_d181b341f71716f956f85b611c4672f4e815220a59b4187735d63c9fa6db74c9
 offers:
   - offer_id: off_01kyh8fpe6qasefesj77p6h5ww
     offer_slug: zoho-for-startups
@@ -47,3 +56,69 @@ offers:
       url: https://www.zoho.com/startups/
     source_ids:
       - src_7eed286a8512fe0123f70f0b88d01a0a88efa496fa5f6a89703157515c5e3a8f
+  - offer_id: off_01kyyr9svhgqm3k63p9p99dbrf
+    program_id: prg_01kyyr9svhbyevgq9sjgvgyngg
+    offer_slug: free-wallet-credits-with-zoho-startup-program-standard-tier
+    offer_slug_aliases: []
+    title: Free wallet credits with Zoho Startup Program — standard tier
+    summary: Qualifying early-stage startups receive up to A$6,000 in Zoho Wallet Credits usable across Zoho's suite of 55+ business apps.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:18:11.945Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to A$6,000 in Zoho Wallet Credits usable across Zoho's suite of 55+ integrated business apps.
+          kind: credit
+          value:
+            amount:
+              currency: AUD
+              minor_units: 600000
+            kind: up-to
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.stage
+            kind: predicate
+            operator: eq
+            statement: Early-stage startups
+            value:
+              type: string
+              value: early-stage
+          - criterion_id: cri_02
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: Under $5M raised
+            value:
+              type: number
+              value: 5000000
+          - criterion_id: cri_03
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: Under 3 years old
+            value:
+              type: number
+              value: 36
+          - criterion_id: cri_04
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: New Zoho customers
+            value:
+              type: boolean
+              value: false
+    roles:
+      terms_authority_entity_id: ent_01kyh8fpe6n1xs5jjkcz991h2x
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: membership
+      method: form
+      url: https://perkbook.co/vendor-directory/zoho
+    source_ids:
+      - src_d181b341f71716f956f85b611c4672f4e815220a59b4187735d63c9fa6db74c9


### PR DESCRIPTION
Adds 26 net-new, concrete startup offers through two explicit access operators:

- Pulley: 7 vendor-authorized channel offers plus Pulley for Techstars
- PerkBook: 18 materially distinct channel offers
- Pulley and PerkBook are first-party-proven canonical Entities
- 12 new Programs are modeled adjacently only where the source defines one

The contribution remains data-only YAML. Every changed identity closure is covered by the exact reviewed admission for source tree `5dc58cec6a0ad85b6fb0376ed13ef7f4baf08e92`.

Live target after automatic promotion: 239 offers.