### PR TITLE
Catalog: add final 67 startup offers

### DIFF
--- a/vendors/1p/1password.yaml
+++ b/vendors/1p/1password.yaml
@@ -1,0 +1,54 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyyts97sefa85ypnwqp8dvq0
+slug: 1password
+slug_aliases: []
+name: 1Password
+domains:
+  - value: 1password.com
+    role: primary
+    valid_from: 2026-08-01T13:50:00.000Z
+category: security
+description: Read 1Password's privacy policy to learn about the company's commitment to preserving the security of your data, your privacy, and your rights to your data.
+links:
+  site: https://1password.com
+sources:
+  - source_id: src_a17e37535e2f46151efab7f0f76115603518a2e51dd56a1f139c34adbf79ba01
+    url: https://1password.com/legal/privacy
+  - source_id: src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d
+    url: https://pulley.com/perks
+programs: []
+offers:
+  - offer_id: off_01kyyts97vgnfkafpjda0g4fr1
+    offer_slug: 100-credit-for-team-account
+    offer_slug_aliases: []
+    title: $100 credit for Team account
+    summary: Get a $100 credit toward a 1Password Team account.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T12:27:57.374Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: $100 credit for Team account
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 10000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: constant
+        statement: Available to Pulley users.
+        value: true
+    roles:
+      terms_authority_entity_id: ent_01kyyts97sefa85ypnwqp8dvq0
+      access_operator_entity_id: ent_01kyyr9svfavvhqt4vy0e0b25k
+    access:
+      availability: membership
+      method: other
+    source_ids:
+      - src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d

--- a/vendors/ai/airtable.yaml
+++ b/vendors/ai/airtable.yaml
@@ -1,0 +1,63 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyyts97sxvjdbwprq8swyxw5
+slug: airtable
+slug_aliases: []
+name: Airtable
+domains:
+  - value: airtable.com
+    role: primary
+    valid_from: 2026-08-01T13:50:00.000Z
+category: no-code
+description: 500,000+ brands use Airtable to enable real-time collaboration, automate repetitive tasks & manual work, and streamline business processes in minutes. Join them.
+links:
+  site: https://airtable.com
+sources:
+  - source_id: src_78242d8f3ebfd297f184895df2c4cb1f76fe53ad45f507c83d9cda105e3df0ac
+    url: https://www.airtable.com/
+  - source_id: src_0d80b5da8d1a72d20ebec39d42c6c6fc8f1de4ab9fd6c35a145b8e0627511c98
+    url: https://perkbook.co/vendor-directory/airtable
+programs:
+  - program_id: prg_01kyyts97v37whhvf9sn8xqmrg
+    program_slug: airtable-for-startups
+    program_slug_aliases: []
+    title: Airtable for Startups
+    summary: Airtable startup program providing perks and offers for qualifying early-stage startups.
+    source_ids:
+      - src_0d80b5da8d1a72d20ebec39d42c6c6fc8f1de4ab9fd6c35a145b8e0627511c98
+offers:
+  - offer_id: off_01kyyts97vs94cvvf5e20s7xg0
+    program_id: prg_01kyyts97v37whhvf9sn8xqmrg
+    offer_slug: airtable-for-startups-500-credit
+    offer_slug_aliases: []
+    title: Airtable for Startups $500 Credit
+    summary: Qualifying early-stage startups receive $500 in free credit to build custom databases, workflows, and internal tools on Airtable.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:12:36.105Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: $500 in free Airtable credit
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 50000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: external-verification
+        statement: Available to qualifying early-stage startups
+    roles:
+      terms_authority_entity_id: ent_01kyyts97sxvjdbwprq8swyxw5
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: membership
+      method: form
+      url: https://perkbook.co/vendor-directory/airtable
+    source_ids:
+      - src_0d80b5da8d1a72d20ebec39d42c6c6fc8f1de4ab9fd6c35a145b8e0627511c98

--- a/vendors/al/alibaba-cloud.yaml
+++ b/vendors/al/alibaba-cloud.yaml
@@ -1,0 +1,75 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyyts97sh2v27g7w2234k40n
+slug: alibaba-cloud
+slug_aliases: []
+name: Alibaba Cloud
+domains:
+  - value: alibabacloud.com
+    role: primary
+    valid_from: 2026-08-01T13:50:00.000Z
+category: cloud
+description: How we handle your personal data and your rights - Alibaba Cloud International Website Privacy Policy - Alibaba Cloud,Legal:This Privacy Policy applies to the access and use of the Alibaba Cloud
+links:
+  site: https://alibabacloud.com
+sources:
+  - source_id: src_6dfc3454e3e1e7f8e76cd7aa7717a19369892f21bab576b4c3f9eb08adef5f29
+    url: https://www.alibabacloud.com/help/en/legal/latest/alibaba-cloud-international-website-privacy-policy
+  - source_id: src_6ea68ff4421d90263af103c2b04e93e4d76dc469550f4a4068e2f28a1018d4a8
+    url: https://perkbook.co/vendor-directory/alibabacloud
+programs:
+  - program_id: prg_01kyyts97vwa3818s00v9apxng
+    program_slug: alibaba-cloud-startup-program
+    program_slug_aliases: []
+    title: Alibaba Cloud Startup Program
+    summary: Alibaba Cloud gives qualifying early-stage startups cloud credits, technical support, co-marketing opportunities, and access to Alibaba global investor and partner networks.
+    source_ids:
+      - src_6ea68ff4421d90263af103c2b04e93e4d76dc469550f4a4068e2f28a1018d4a8
+offers:
+  - offer_id: off_01kyyts97vpzkvqbvpxyp0w6dm
+    program_id: prg_01kyyts97vwa3818s00v9apxng
+    offer_slug: alibaba-cloud-startup-program
+    offer_slug_aliases: []
+    title: Alibaba Cloud Startup Program
+    summary: Get up to $50,000 USD in cloud credits, technical support, co-marketing opportunities, and network access for qualifying early-stage startups.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:12:36.099Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $50,000 USD in cloud credits
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 5000000
+            kind: up-to
+        - benefit_id: ben_02
+          description: Technical support
+          kind: other
+        - benefit_id: ben_03
+          description: Co-marketing opportunities
+          kind: other
+        - benefit_id: ben_04
+          description: Access to Alibaba global investor and partner networks
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: vendor-discretion
+            statement: Early-stage startups globally; assessed by stage and use case
+    roles:
+      terms_authority_entity_id: ent_01kyyts97sh2v27g7w2234k40n
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: membership
+      instructions: Sign Up to Unlock
+      method: other
+      url: https://perkbook.co/vendor-directory/alibabacloud
+    source_ids:
+      - src_6ea68ff4421d90263af103c2b04e93e4d76dc469550f4a4068e2f28a1018d4a8

--- a/vendors/ar/archbee.yaml
+++ b/vendors/ar/archbee.yaml
@@ -66,3 +66,38 @@ offers:
     title: Archbee Startup Program
     source_ids:
       - src_f282545a7eecaddec966984fc10e581a19f30b641e7058bf7efccc309ac7738a
+  - offer_id: off_01kyyts97v87hhqz5e0xhsx516
+    offer_slug: free-growing-plan-for-open-source-software
+    offer_slug_aliases: []
+    title: Free Growing Plan for Open Source Software
+    summary: Free Growing plan available for open source software projects.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:03:40.270Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Free Growing plan
+          kind: waiver
+          waived_item: Growing plan subscription fee
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        fact: company.is_open_source
+        kind: predicate
+        operator: eq
+        statement: Must be an open source software project
+        value:
+          type: boolean
+          value: true
+    roles:
+      terms_authority_entity_id: ent_01kyy3083w3k33krxmrqx1kr43
+      access_operator_entity_id: ent_01kyy3083w3k33krxmrqx1kr43
+    access:
+      availability: public
+      method: contact
+      url: https://www.archbee.com/pricing
+    source_ids:
+      - src_f282545a7eecaddec966984fc10e581a19f30b641e7058bf7efccc309ac7738a

--- a/vendors/as/ashby.yaml
+++ b/vendors/as/ashby.yaml
@@ -1,0 +1,56 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyyts97sza9n1ez4b19p3104
+slug: ashby
+slug_aliases: []
+name: Ashby
+domains:
+  - value: ashbyhq.com
+    role: primary
+    valid_from: 2026-08-01T13:50:00.000Z
+category: people
+description: Ashby’s all-in-one recruiting software consolidates your ATS, Analytics, Scheduling, and CRM
+links:
+  site: https://ashbyhq.com
+sources:
+  - source_id: src_60e39384ef94c75cda597aa0dbc8ec842cc5be073244332be0836ca629e23893
+    url: https://www.ashbyhq.com/
+  - source_id: src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d
+    url: https://pulley.com/perks
+programs: []
+offers:
+  - offer_id: off_01kyyts97w8akha9e3gmshpmwv
+    offer_slug: get-20-off-your-first-year-with-ashby
+    offer_slug_aliases: []
+    title: Get 20% off your first year with Ashby
+    summary: Get 20% off your first year on Ashby's recruiting platform.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T12:27:57.374Z
+    economics:
+      benefits:
+        - applies_to: Ashby recruiting platform
+          benefit_id: ben_01
+          description: 20% off first year with Ashby
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            basis_points: 2000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: constant
+        statement: Available to Pulley users.
+        value: true
+    roles:
+      terms_authority_entity_id: ent_01kyyts97sza9n1ez4b19p3104
+      access_operator_entity_id: ent_01kyyr9svfavvhqt4vy0e0b25k
+    access:
+      availability: membership
+      method: other
+    source_ids:
+      - src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d

--- a/vendors/au/auth0.yaml
+++ b/vendors/au/auth0.yaml
@@ -14,7 +14,16 @@ links:
 sources:
   - source_id: src_eff2a2761c28380060aff060d1ded39584133534a4efdfd00c06bdf343be6509
     url: https://auth0.com/pricing
-programs: []
+  - source_id: src_d156267470a665ea8499168361817d8f0640966eaa65a8f8fa81a83aa33c63ce
+    url: https://auth0.com/startups
+programs:
+  - program_id: prg_01kyyts97t4myy46bkav6fwyds
+    program_slug: auth0-for-startups
+    program_slug_aliases: []
+    title: Auth0 for Startups
+    summary: The Auth0 for Startups program offers eligible early-stage companies one year of the B2B Professional plan for free.
+    source_ids:
+      - src_d156267470a665ea8499168361817d8f0640966eaa65a8f8fa81a83aa33c63ce
 offers:
   - offer_id: off_01kyh8fpe1wf99w38mgbaz7mzp
     offer_slug: auth0-for-startups
@@ -48,3 +57,74 @@ offers:
       url: https://auth0.com/pricing
     source_ids:
       - src_eff2a2761c28380060aff060d1ded39584133534a4efdfd00c06bdf343be6509
+  - offer_id: off_01kyyts97tenfzgyxkvvcgyy15
+    program_id: prg_01kyyts97t4myy46bkav6fwyds
+    offer_slug: auth0-for-startups-plan
+    offer_slug_aliases: []
+    title: Auth0 for Startups Plan
+    summary: Eligible early-stage startups receive one free year of Auth0's B2B Professional plan capabilities, including up to 100k Monthly Active Users (MAUs).
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:17:32.617Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: One year free of Auth0's B2B Professional plan capabilities (including up to 100k MAUs, Enterprise MFA, Unlimited Organizations, 3 Third-Party APIs, Inbound SCIM, 5 Enterprise Connections, and Token Vault)
+          duration:
+            kind: exact
+            value: P1Y
+          kind: free-service
+          service: Auth0 B2B Professional plan
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: Venture-backed with less than $5M in funding
+            value:
+              type: number
+              value: 5000000
+          - criterion_id: cri_02
+            fact: company.annual_recurring_revenue_usd
+            kind: predicate
+            operator: lt
+            statement: Less than $1M in annual recurring revenue
+            value:
+              type: number
+              value: 1000000
+          - criterion_id: cri_03
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: Less than two years from the date of incorporation
+            value:
+              type: number
+              value: 24
+          - kind: not
+            rule:
+              criterion_id: cri_04
+              fact: company.is_current_customer
+              kind: predicate
+              operator: eq
+              statement: Existing paid Auth0/Okta customers
+              value:
+                type: boolean
+                value: true
+          - criterion_id: cri_05
+            kind: manual
+            reason: external-verification
+            statement: Startups that have previously been members of the Auth0 for Startups program
+    roles:
+      terms_authority_entity_id: ent_01kyh8fpe1tcv01nxjfked7v1g
+      access_operator_entity_id: ent_01kyh8fpe1tcv01nxjfked7v1g
+    access:
+      availability: public
+      method: form
+      url: https://auth0.com/startups
+    source_ids:
+      - src_d156267470a665ea8499168361817d8f0640966eaa65a8f8fa81a83aa33c63ce

--- a/vendors/br/brex.yaml
+++ b/vendors/br/brex.yaml
@@ -1,0 +1,95 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyyts97rczvy7tt3n9gd0y3n
+slug: brex
+slug_aliases: []
+name: Brex
+domains:
+  - value: brex.com
+    role: primary
+    valid_from: 2026-08-01T13:50:00.000Z
+category: banking
+description: Simplify expense management with Brex's finance platform. From company cards to banking, Brex helps you drive growth, automate processes, & earn more.
+links:
+  site: https://brex.com
+sources:
+  - source_id: src_00130686bd808622092b40ba7497fdabb93c0b4c96254703bafb2de1cb7db73e
+    url: https://www.brex.com/
+  - source_id: src_450a31a18e797b943952f91dccda6d8e21cc9c15b2cc9a67afc33bedb13c184e
+    url: https://www.brex.com/startups
+  - source_id: src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d
+    url: https://pulley.com/perks
+programs: []
+offers:
+  - offer_id: off_01kyyts97v83smhzwvc8gkb5k5
+    offer_slug: brex-saas-and-ai-partner-discounts
+    offer_slug_aliases: []
+    title: Brex SaaS and AI Partner Discounts
+    summary: Access over $350K in discounts and credits on AI and SaaS software through Brex for startups.
+    lifecycle:
+      status: active
+      effective_from: 2026-07-31T23:22:39.535Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Over $350K in discounts and credits on AI and SaaS
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 35000000
+            kind: at-least
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: vendor-discretion
+        statement: Available to Brex startup account holders.
+    roles:
+      terms_authority_entity_id: ent_01kyyts97rczvy7tt3n9gd0y3n
+      access_operator_entity_id: ent_01kyyts97rczvy7tt3n9gd0y3n
+    access:
+      availability: membership
+      method: form
+      url: https://www.brex.com/startups
+    source_ids:
+      - src_450a31a18e797b943952f91dccda6d8e21cc9c15b2cc9a67afc33bedb13c184e
+  - offer_id: off_01kyyts97wb2srnvwkqykxtep7
+    offer_slug: up-to-100-000-brex-bonus-points
+    offer_slug_aliases: []
+    title: Up to 100,000 Brex bonus points
+    summary: Get a 50,000 point bonus after depositing $100,000 into Brex and an additional 50,000 points after spending $10,000 on Brex cards.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T12:27:57.374Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: 50,000 point sign up bonus after depositing $100,000 into a Brex business account
+          kind: other
+        - benefit_id: ben_02
+          description: additional 50,000 point sign up bonus after spending $10,000 on Brex card(s)
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: Deposit $100,000 into a Brex business account for first 50,000 points.
+          - criterion_id: cri_02
+            kind: manual
+            reason: external-verification
+            statement: Spend $10,000 on Brex card(s) for second 50,000 points.
+    roles:
+      terms_authority_entity_id: ent_01kyyts97rczvy7tt3n9gd0y3n
+      access_operator_entity_id: ent_01kyyr9svfavvhqt4vy0e0b25k
+    access:
+      availability: referral
+      method: other
+    source_ids:
+      - src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d

--- a/vendors/cl/clerk.yaml
+++ b/vendors/cl/clerk.yaml
@@ -47,3 +47,51 @@ offers:
       url: https://clerk.com/startups
     source_ids:
       - src_636c918f86d4037ce06c2b193a4e6a37c74bc41a2c188ddbcfb8ae35014ee456
+  - offer_id: off_01kyyts97v4fkdpj9tswbveqxc
+    offer_slug: clerk-pro-discount-for-startups
+    offer_slug_aliases: []
+    title: Clerk Pro Discount for Startups
+    summary: Eligible early-stage startups receive Clerk Pro features at a discount.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T06:41:08.884Z
+    economics:
+      benefits:
+        - applies_to: Clerk Pro features
+          benefit_id: ben_01
+          description: Discount on Clerk Pro features
+          kind: discount
+          percentage:
+            basis_points: 1
+            kind: at-least
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.age_months
+            kind: predicate
+            operator: lte
+            statement: Company launch was up to 1 year ago
+            value:
+              type: number
+              value: 12
+          - criterion_id: cri_02
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lte
+            statement: Company has up to $5 million in venture funding
+            value:
+              type: number
+              value: 5000000
+    roles:
+      terms_authority_entity_id: ent_01kyh8fpe1p3qgn8mxp3ev5328
+      access_operator_entity_id: ent_01kyh8fpe1p3qgn8mxp3ev5328
+    access:
+      availability: public
+      method: form
+      url: https://clerk.com/startups
+    source_ids:
+      - src_636c918f86d4037ce06c2b193a4e6a37c74bc41a2c188ddbcfb8ae35014ee456

--- a/vendors/cl/clevertap.yaml
+++ b/vendors/cl/clevertap.yaml
@@ -14,6 +14,8 @@ links:
 sources:
   - source_id: src_0fc453e4f6b1de982643df397dbd46b660735ac717f84d78864510b870a77d76
     url: https://clevertap.com/startup-pricing
+  - source_id: src_3397aa0b845d66a1d4036debf67e9b0ff478c50a9268fd8ad361d78cb040ec7a
+    url: https://clevertap.com/startups
 programs: []
 offers:
   - offer_id: off_01kyygma8266wg2s2zfn9xtepr
@@ -54,3 +56,40 @@ offers:
       url: https://clevertap.com/pricing/
     source_ids:
       - src_0fc453e4f6b1de982643df397dbd46b660735ac717f84d78864510b870a77d76
+  - offer_id: off_01kyyts97tj62hzzk02kaags0m
+    offer_slug: clevertap-essentials-mid-year-sale
+    offer_slug_aliases: []
+    title: CleverTap Essentials Mid Year Sale
+    summary: Get 90% off CleverTap Essentials plan for 6 months.
+    lifecycle:
+      status: active
+      effective_from: 2026-07-31T23:16:39.223Z
+    economics:
+      benefits:
+        - applies_to: CleverTap Essentials
+          benefit_id: ben_01
+          description: 90% off CleverTap Essentials for 6 months
+          duration:
+            kind: exact
+            value: P6M
+          kind: discount
+          percentage:
+            basis_points: 9000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: constant
+        statement: Offer is presented as Mid-Year Sale for CleverTap Essentials.
+        value: true
+    roles:
+      terms_authority_entity_id: ent_01kyygma82taj75edn8k8jdj6h
+      access_operator_entity_id: ent_01kyygma82taj75edn8k8jdj6h
+    access:
+      availability: public
+      method: form
+      url: https://clevertap.com/pricing/
+    source_ids:
+      - src_3397aa0b845d66a1d4036debf67e9b0ff478c50a9268fd8ad361d78cb040ec7a

--- a/vendors/cl/cloudflare.yaml
+++ b/vendors/cl/cloudflare.yaml
@@ -185,3 +185,115 @@ offers:
       url: https://perkbook.co/vendor-directory/cloudflare
     source_ids:
       - src_6969ed732394ce7e5a91a81dab949751ebcf9db069f27007ca75f3cf8e6db441
+  - offer_id: off_01kyyts97xytgjbbb65n1mm574
+    program_id: prg_01kyh8jtf667atcvk4kp9spgx9
+    offer_slug: free-cloud-credits-with-cloudflare-for-startups-bootstrapped-tier
+    offer_slug_aliases: []
+    title: Free cloud credits with Cloudflare for Startups — bootstrapped tier
+    summary: Get $5,000 in credits for the Cloudflare Developer Platform for bootstrapped and stealth startups.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:13:34.674Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: $5,000 in credits to build on the Cloudflare Developer Platform covering Workers, R2 storage, KV, Durable Objects, Pages, and AI inference.
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 500000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: not-machine-evaluable
+            statement: Bootstrapped startup building a software product
+          - criterion_id: cri_02
+            fact: company.age_months
+            kind: predicate
+            operator: lte
+            statement: Founded in last 5 years
+            value:
+              type: number
+              value: 60
+          - criterion_id: cri_03
+            kind: manual
+            reason: external-verification
+            statement: Valid matching company email
+          - criterion_id: cri_04
+            kind: manual
+            reason: not-machine-evaluable
+            statement: No investor required
+    roles:
+      terms_authority_entity_id: ent_01kyh8jtf535570d9z2bng6j1t
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: membership
+      method: form
+      url: https://perkbook.co/vendor-directory/cloudflare
+    source_ids:
+      - src_6969ed732394ce7e5a91a81dab949751ebcf9db069f27007ca75f3cf8e6db441
+  - offer_id: off_01kyyts97xqa1stjgf3d8bn73q
+    program_id: prg_01kyh8jtf667atcvk4kp9spgx9
+    offer_slug: free-cloud-credits-with-cloudflare-for-startups-early-stage-tier
+    offer_slug_aliases: []
+    title: Free cloud credits with Cloudflare for Startups — early-stage tier
+    summary: Get $25,000 in credits for the Cloudflare Developer Platform for early-stage startups with up to $1M raised.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:13:34.674Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: $25,000 in credits to build on the Cloudflare Developer Platform covering Workers, R2, Durable Objects, Pages, AI inference, and more.
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 2500000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: not-machine-evaluable
+            statement: Building a software product
+          - criterion_id: cri_02
+            fact: company.age_months
+            kind: predicate
+            operator: lte
+            statement: Founded in last 5 years
+            value:
+              type: number
+              value: 60
+          - criterion_id: cri_03
+            kind: manual
+            reason: external-verification
+            statement: Active LinkedIn
+          - criterion_id: cri_04
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lte
+            statement: Funded up to $1M
+            value:
+              type: number
+              value: 1000000
+    roles:
+      terms_authority_entity_id: ent_01kyh8jtf535570d9z2bng6j1t
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: membership
+      method: form
+      url: https://perkbook.co/vendor-directory/cloudflare
+    source_ids:
+      - src_6969ed732394ce7e5a91a81dab949751ebcf9db069f27007ca75f3cf8e6db441

--- a/vendors/da/databricks.yaml
+++ b/vendors/da/databricks.yaml
@@ -14,7 +14,14 @@ links:
 sources:
   - source_id: src_379412354a02bdd589f71378373ca1d9a3e5cd11d7b2b5502d51384938dd7035
     url: https://www.databricks.com/product/startups
-programs: []
+programs:
+  - program_id: prg_01kyyts97vhf5ezsgeeb8xcv4v
+    program_slug: databricks-for-startups-program
+    program_slug_aliases: []
+    title: Databricks for Startups Program
+    summary: Helps startups grow and deliver their data and AI strategy with platform access and startup credits.
+    source_ids:
+      - src_379412354a02bdd589f71378373ca1d9a3e5cd11d7b2b5502d51384938dd7035
 offers:
   - offer_id: off_01kyh8fpe2j3bzhymycrhggghe
     offer_slug: databricks-ai-accelerator-program
@@ -69,6 +76,46 @@ offers:
         criterion_id: cri_requirement_01
         statement: Available to qualifying startups (founders can apply directly or ask their investor).
         reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01kyh8fpe20b7d3zws8zfya66r
+      access_operator_entity_id: ent_01kyh8fpe20b7d3zws8zfya66r
+    access:
+      availability: public
+      method: form
+      url: https://www.databricks.com/product/startups
+    source_ids:
+      - src_379412354a02bdd589f71378373ca1d9a3e5cd11d7b2b5502d51384938dd7035
+  - offer_id: off_01kyyts97v21z78gt9fvpcajr2
+    program_id: prg_01kyyts97vhf5ezsgeeb8xcv4v
+    offer_slug: databricks-for-startups-program
+    offer_slug_aliases: []
+    title: Databricks for Startups Program
+    summary: Qualifying startups can receive up to $200K in credits for Databricks and Neon.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:05:36.101Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Credits for Databricks and Neon
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 20000000
+            kind: up-to
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        fact: company.stage
+        kind: predicate
+        operator: eq
+        statement: Must be a qualifying startup.
+        value:
+          type: string
+          value: startup
     roles:
       terms_authority_entity_id: ent_01kyh8fpe20b7d3zws8zfya66r
       access_operator_entity_id: ent_01kyh8fpe20b7d3zws8zfya66r

--- a/vendors/de/deel.yaml
+++ b/vendors/de/deel.yaml
@@ -18,7 +18,25 @@ sources:
     url: https://www.deel.com/segments/startups
   - source_id: src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d
     url: https://pulley.com/perks
-programs: []
+  - source_id: src_3487831c6727db95f17272a5eb83728fc1bcda1aea4d6e4640ae61ea5b58f60f
+    url: https://www.deel.com/pitch
+  - source_id: src_a154479d2eb92aeaa803c4a05e86083a2ac869c5d378a17823c78219471d026f
+    url: https://perkbook.co/vendor-directory/deel
+programs:
+  - program_id: prg_01kyyts97vhv6dbsc02y0sf1z9
+    program_slug: the-pitch-by-deel
+    program_slug_aliases: []
+    title: The Pitch by Deel
+    summary: Global tournament rewarding startup founders with SAFE funding, travel coverage, networking, and access to a perks marketplace.
+    source_ids:
+      - src_3487831c6727db95f17272a5eb83728fc1bcda1aea4d6e4640ae61ea5b58f60f
+  - program_id: prg_01kyyts97xta5b1pjrq41crq84
+    program_slug: deel-startup-program
+    program_slug_aliases: []
+    title: Deel Startup Program
+    summary: Deel Startup Program provides offers and perks for startups, including platform credits and discounts via partner networks.
+    source_ids:
+      - src_a154479d2eb92aeaa803c4a05e86083a2ac869c5d378a17823c78219471d026f
 offers:
   - offer_id: off_01kyh8fpe2r151y0shvrzcmkwt
     offer_slug: first-5-seats-free-for-life-for-venture-backed-startups
@@ -125,3 +143,131 @@ offers:
       method: other
     source_ids:
       - src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d
+  - offer_id: off_01kyyts97v8wq67b3qqzjfxryq
+    program_id: prg_01kyyts97vhv6dbsc02y0sf1z9
+    offer_slug: the-pitch-2026-startup-competition-and-perks-access
+    offer_slug_aliases: []
+    title: The Pitch 2026 Startup Competition & Perks Access
+    summary: Startups applying to The Pitch 2026 compete for SAFE investments ($50k regional, $1M grand finale), travel coverage, and access to an exclusive perks marketplace and startup community.
+    lifecycle:
+      status: ended
+      effective_from: 2026-08-01T07:51:51.161Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Free access to exclusive marketplace of startup software perks and deals
+          kind: other
+        - benefit_id: ben_02
+          description: Opportunity for up to 100 regional winners to receive a $50,000 SAFE investment
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 5000000
+            kind: exact
+        - benefit_id: ben_03
+          description: Opportunity for up to 10 global champions to win $1,000,000 SAFE investment
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 100000000
+            kind: exact
+        - benefit_id: ben_04
+          description: Travel and accommodation coverage for global finale / regional events as applicable
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: vendor-discretion
+            statement: Must be a startup typically at pre-Seed, Seed, or Series A stage with an MVP
+          - criterion_id: cri_02
+            kind: manual
+            reason: vendor-discretion
+            statement: Must have full-time founders
+          - criterion_id: cri_03
+            kind: manual
+            reason: vendor-discretion
+            statement: Must have a registered legal entity by the time of the competition
+          - criterion_id: cri_04
+            kind: manual
+            reason: vendor-discretion
+            statement: Building a product or service with scaling potential
+    roles:
+      terms_authority_entity_id: ent_01kyh8fpe2k0kd5rfqh8es0ccs
+      access_operator_entity_id: ent_01kyh8fpe2k0kd5rfqh8es0ccs
+    access:
+      availability: public
+      method: form
+      url: https://www.deel.com/pitch
+    terms_url: https://www.deel.com/pitch
+    source_ids:
+      - src_3487831c6727db95f17272a5eb83728fc1bcda1aea4d6e4640ae61ea5b58f60f
+  - offer_id: off_01kyyts97xw6824xjva5gmkmnj
+    program_id: prg_01kyyts97xta5b1pjrq41crq84
+    offer_slug: 50-off-year-1-with-deel-for-startups-via-brex
+    offer_slug_aliases: []
+    title: 50% off year 1 with Deel for Startups — via Brex
+    summary: Brex customers who are new to Deel get up to $5,000 in platform credits or 50% off their first year across global payroll, EOR, contractor management, and Deel IT.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:13:34.673Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $5,000 in platform credits or 50% off the first year for Deel services including global payroll, employer of record (EOR), contractor management, and Deel IT across 150+ countries.
+          duration:
+            kind: exact
+            value: P1Y
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 500000
+            kind: up-to
+        - applies_to: Deel platform services for the first year
+          benefit_id: ben_02
+          description: 50% off the first year for Deel services including global payroll, employer of record (EOR), contractor management, and Deel IT.
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            basis_points: 5000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.partner_memberships
+            kind: predicate
+            operator: contains
+            statement: Must open a Brex account / be a Brex customer.
+            value:
+              type: string
+              value: Brex
+          - criterion_id: cri_02
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: Must be a new Deel customer.
+            value:
+              type: boolean
+              value: false
+    roles:
+      terms_authority_entity_id: ent_01kyh8fpe2k0kd5rfqh8es0ccs
+      access_operator_entity_id: ent_01kyyts97rczvy7tt3n9gd0y3n
+    access:
+      availability: membership
+      method: other
+      url: https://perkbook.co/vendor-directory/deel
+    source_ids:
+      - src_a154479d2eb92aeaa803c4a05e86083a2ac869c5d378a17823c78219471d026f

--- a/vendors/de/deepinfra.yaml
+++ b/vendors/de/deepinfra.yaml
@@ -1,0 +1,68 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyyts97sfrxp00s21jt9b95y
+slug: deepinfra
+slug_aliases: []
+name: DeepInfra
+domains:
+  - value: deepinfra.com
+    role: primary
+    valid_from: 2026-08-01T13:50:00.000Z
+category: ml
+description: DeepInfra offers cost-effective, scalable, easy-to-deploy, and production-ready machine-learning models and infrastructures for deep-learning models.
+links:
+  site: https://deepinfra.com
+sources:
+  - source_id: src_4372169c5433326be66d10fc58f66eaf7c58c84bd90379afee5e9f29e1438bd8
+    url: https://deepinfra.com/
+  - source_id: src_8b0cde8a6977f3aaa2bd936f824af4066338da00472d6e50c6526ae811c4c40c
+    url: https://perkbook.co/vendor-directory/deepinfra
+programs:
+  - program_id: prg_01kyyts97w2qshjx2e2yqz6as2
+    program_slug: deepinfra-deepstart
+    program_slug_aliases: []
+    title: DeepInfra DeepStart
+    summary: DeepInfra DeepStart gives qualifying early-stage AI companies up to 1 billion free inference tokens for running open-source models in production.
+    source_ids:
+      - src_8b0cde8a6977f3aaa2bd936f824af4066338da00472d6e50c6526ae811c4c40c
+offers:
+  - offer_id: off_01kyyts97wx07k6ckfa6np5rd6
+    program_id: prg_01kyyts97w2qshjx2e2yqz6as2
+    offer_slug: free-ai-inference-tokens-with-deepinfra-deepstart
+    offer_slug_aliases: []
+    title: Free AI inference tokens with DeepInfra DeepStart
+    summary: Qualifying early-stage AI startups can receive up to 1 billion free inference tokens to run open-source models on DeepInfra.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:13:34.662Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to 1 billion free inference tokens
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: vendor-discretion
+            statement: Early-stage AI startups building with open-source models
+          - criterion_id: cri_02
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: new DeepInfra customers
+            value:
+              type: boolean
+              value: false
+    roles:
+      terms_authority_entity_id: ent_01kyyts97sfrxp00s21jt9b95y
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: membership
+      method: form
+      url: https://perkbook.co/vendor-directory/deepinfra
+    source_ids:
+      - src_8b0cde8a6977f3aaa2bd936f824af4066338da00472d6e50c6526ae811c4c40c

--- a/vendors/de/deepsource.yaml
+++ b/vendors/de/deepsource.yaml
@@ -1,0 +1,76 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyyts97tr0y197z74vgbm0sw
+slug: deepsource
+slug_aliases: []
+name: DeepSource
+domains:
+  - value: deepsource.io
+    role: primary
+    valid_from: 2026-08-01T13:50:00.000Z
+  - value: deepsource.com
+    role: alias
+    valid_from: 2026-08-01T13:50:00.000Z
+category: code
+description: Your team is writing more code with AI. DeepSource automates code reviews so you ship to production faster — catching security issues, improving code quality, and helping your team write better code.
+links:
+  site: https://deepsource.com
+sources:
+  - source_id: src_5a11621d2c5d34598bd03ebef5aedda31fe39b5aafea8c3ae4c5582112dc4cc3
+    url: https://deepsource.com/
+  - source_id: src_bcd1c7246e1c9cdae35fc3392b1e1381ad70bdd096c9565a9a86c694a70d496e
+    url: https://perkbook.co/vendor-directory/deepsource
+programs:
+  - program_id: prg_01kyyts97yn3x8683d4tn4vt3z
+    program_slug: deepsource-startup-program
+    program_slug_aliases: []
+    title: DeepSource Startup Program
+    summary: DeepSource Startup Program / DeepSource for Startups provides perks and free access to its automated code review and static analysis platform for qualifying early-stage startups.
+    source_ids:
+      - src_bcd1c7246e1c9cdae35fc3392b1e1381ad70bdd096c9565a9a86c694a70d496e
+offers:
+  - offer_id: off_01kyyts97ymbdnevwsgawnkb3x
+    program_id: prg_01kyyts97yn3x8683d4tn4vt3z
+    offer_slug: free-code-quality-and-static-analysis-with-deepsource-for-startups
+    offer_slug_aliases: []
+    title: Free code quality and static analysis with DeepSource for Startups
+    summary: Eligible early-stage startups receive free access to the DeepSource static analysis platform for automated code review.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:13:34.666Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Free access to the DeepSource static analysis platform
+          kind: free-service
+          service: DeepSource static analysis platform
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: vendor-discretion
+            statement: Early-stage startups
+          - criterion_id: cri_02
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: New DeepSource customers
+            value:
+              type: boolean
+              value: false
+          - criterion_id: cri_03
+            kind: manual
+            reason: not-machine-evaluable
+            statement: Engineering teams using GitHub, GitLab, or Bitbucket
+    roles:
+      terms_authority_entity_id: ent_01kyyts97tr0y197z74vgbm0sw
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: membership
+      method: form
+      url: https://perkbook.co/vendor-directory/deepsource
+    source_ids:
+      - src_bcd1c7246e1c9cdae35fc3392b1e1381ad70bdd096c9565a9a86c694a70d496e

--- a/vendors/de/descope.yaml
+++ b/vendors/de/descope.yaml
@@ -1,0 +1,76 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyyts97sdsn61rze854rtsjc
+slug: descope
+slug_aliases: []
+name: Descope
+domains:
+  - value: descope.com
+    role: primary
+    valid_from: 2026-08-01T13:50:00.000Z
+category: security
+description: Build secure, frictionless identity journeys for your users, business customers, partners, AI agents, and MCP servers with the Descope External IAM Platform.
+links:
+  site: https://descope.com
+sources:
+  - source_id: src_ab04b4eaba7fd527dc58484e7f4d00dcffc5fff0c0c632888d14244d107a67d9
+    url: https://www.descope.com/
+  - source_id: src_bf52821693023034ce9171d3206ccbcd7a24ea6bf390c3add220bba84ba4492d
+    url: https://perkbook.co/vendor-directory/descope
+programs:
+  - program_id: prg_01kyyts97wa9d7s999d5d5bas6
+    program_slug: descope-for-startups
+    program_slug_aliases: []
+    title: Descope for Startups
+    summary: Descope for Startups provides early-stage companies access to Descope's authentication platform and perks.
+    source_ids:
+      - src_bf52821693023034ce9171d3206ccbcd7a24ea6bf390c3add220bba84ba4492d
+offers:
+  - offer_id: off_01kyyts97wny98pf77e1dsxaay
+    program_id: prg_01kyyts97wa9d7s999d5d5bas6
+    offer_slug: 12-months-free-authentication-platform-with-descope-for-startups
+    offer_slug_aliases: []
+    title: 12 months free authentication platform with Descope for Startups
+    summary: Qualifying early-stage companies receive 12 months free on the Descope Pro tier through the Descope Hello World Startup Plan.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:14:06.100Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: 12 months free on the Descope Pro tier authentication platform
+          duration:
+            kind: exact
+            value: P1Y
+          kind: free-service
+          service: Descope Pro tier authentication platform
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.age_months
+            kind: predicate
+            operator: lte
+            statement: Founded within last 3 years
+            value:
+              type: number
+              value: 36
+          - criterion_id: cri_02
+            fact: company.annual_recurring_revenue_usd
+            kind: predicate
+            operator: lt
+            statement: Under $1M ARR
+            value:
+              type: number
+              value: 1000000
+    roles:
+      terms_authority_entity_id: ent_01kyyts97sdsn61rze854rtsjc
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: membership
+      method: form
+      url: https://perkbook.co/vendor-directory/descope
+    source_ids:
+      - src_bf52821693023034ce9171d3206ccbcd7a24ea6bf390c3add220bba84ba4492d

--- a/vendors/do/docsend.yaml
+++ b/vendors/do/docsend.yaml
@@ -1,0 +1,226 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyyts97s803mp8w4cmgxa1en
+slug: docsend
+slug_aliases: []
+name: DocSend
+domains:
+  - value: docsend.com
+    role: primary
+    valid_from: 2026-08-01T13:50:00.000Z
+  - value: dropbox.com
+    role: alias
+    valid_from: 2026-08-01T13:50:00.000Z
+category: productivity
+description: Learn how DocSend lets you take control of your business with real-time shared document analytics that unlock data-driven decision making.
+links:
+  site: https://dropbox.com
+sources:
+  - source_id: src_041ab6b6d66f29e0291b59c4b8ada19f54e6a4bb9867fb5ecb8f00b396099d25
+    url: https://www.dropbox.com/docsend
+  - source_id: src_bd9ba13a47d267f4788593e8dc00306da6bdec3415b5ecec62ed9c32acc5c52b
+    url: https://perkbook.co/vendor-directory/docsend
+programs:
+  - program_id: prg_01kyyts97wxmzh9m06kxxcb1h2
+    program_slug: docsend-for-startups
+    program_slug_aliases: []
+    title: DocSend for Startups
+    summary: DocSend for Startups offers discounts on annual DocSend Advanced plans based on startup funding stage.
+    source_ids:
+      - src_bd9ba13a47d267f4788593e8dc00306da6bdec3415b5ecec62ed9c32acc5c52b
+offers:
+  - offer_id: off_01kyyts97w4za5zns8kyebftv1
+    program_id: prg_01kyyts97wxmzh9m06kxxcb1h2
+    offer_slug: 20-off-with-docsend-startup-program-series-b
+    offer_slug_aliases: []
+    title: 20% off with DocSend Startup Program — Series B
+    summary: DocSend for Startups gives Series B companies between $10M and $20M raised 20% off their annual DocSend Advanced plan.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:14:06.095Z
+    economics:
+      benefits:
+        - applies_to: annual DocSend Advanced plan
+          benefit_id: ben_01
+          description: 20% off annual DocSend Advanced plan
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            basis_points: 2000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.stage
+            kind: predicate
+            operator: eq
+            statement: Series B startup
+            value:
+              type: string
+              value: series_b
+          - criterion_id: cri_02
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: gte
+            statement: between $10M and $20M raised
+            value:
+              type: number
+              value: 10000000
+          - criterion_id: cri_03
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lte
+            statement: between $10M and $20M raised
+            value:
+              type: number
+              value: 20000000
+          - criterion_id: cri_04
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: new DocSend customer
+            value:
+              type: boolean
+              value: false
+    roles:
+      terms_authority_entity_id: ent_01kyyts97s803mp8w4cmgxa1en
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: membership
+      instructions: Sign Up to Unlock
+      method: other
+    source_ids:
+      - src_bd9ba13a47d267f4788593e8dc00306da6bdec3415b5ecec62ed9c32acc5c52b
+  - offer_id: off_01kyyts97whz9w3fwh91xpskt6
+    program_id: prg_01kyyts97wxmzh9m06kxxcb1h2
+    offer_slug: 50-off-with-docsend-startup-program-series-a
+    offer_slug_aliases: []
+    title: 50% off with DocSend Startup Program — Series A
+    summary: DocSend for Startups gives Series A companies between $2M and $10M raised 50% off their annual DocSend Advanced plan.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:14:06.095Z
+    economics:
+      benefits:
+        - applies_to: annual DocSend Advanced plan
+          benefit_id: ben_01
+          description: 50% off annual DocSend Advanced plan
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            basis_points: 5000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.stage
+            kind: predicate
+            operator: eq
+            statement: Series A startup
+            value:
+              type: string
+              value: series_a
+          - criterion_id: cri_02
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: gte
+            statement: between $2M and $10M raised
+            value:
+              type: number
+              value: 2000000
+          - criterion_id: cri_03
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lte
+            statement: between $2M and $10M raised
+            value:
+              type: number
+              value: 10000000
+          - criterion_id: cri_04
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: new DocSend customer
+            value:
+              type: boolean
+              value: false
+    roles:
+      terms_authority_entity_id: ent_01kyyts97s803mp8w4cmgxa1en
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: membership
+      instructions: Sign Up to Unlock
+      method: other
+    source_ids:
+      - src_bd9ba13a47d267f4788593e8dc00306da6bdec3415b5ecec62ed9c32acc5c52b
+  - offer_id: off_01kyyts97wf5yq8nvzs4wadhjj
+    program_id: prg_01kyyts97wxmzh9m06kxxcb1h2
+    offer_slug: 90-off-with-docsend-startup-program-seed
+    offer_slug_aliases: []
+    title: 90% off with DocSend Startup Program — Seed
+    summary: DocSend for Startups gives Seed-stage companies under $2M raised 90% off their annual DocSend Advanced plan.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:14:06.095Z
+    economics:
+      benefits:
+        - applies_to: annual DocSend Advanced plan
+          benefit_id: ben_01
+          description: 90% off annual DocSend Advanced plan
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            basis_points: 9000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.stage
+            kind: predicate
+            operator: eq
+            statement: Seed-stage startup
+            value:
+              type: string
+              value: seed
+          - criterion_id: cri_02
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: under $2M raised
+            value:
+              type: number
+              value: 2000000
+          - criterion_id: cri_03
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: new DocSend customer
+            value:
+              type: boolean
+              value: false
+    roles:
+      terms_authority_entity_id: ent_01kyyts97s803mp8w4cmgxa1en
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: membership
+      instructions: Sign Up to Unlock
+      method: other
+    source_ids:
+      - src_bd9ba13a47d267f4788593e8dc00306da6bdec3415b5ecec62ed9c32acc5c52b

--- a/vendors/do/dover.yaml
+++ b/vendors/do/dover.yaml
@@ -1,0 +1,65 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyyts97thnsffv3e7r9m1270
+slug: dover
+slug_aliases: []
+name: Dover
+domains:
+  - value: dover.com
+    role: primary
+    valid_from: 2026-08-01T13:50:00.000Z
+category: people
+description: 2,000+ companies hire with Dover - the best way for startups to find recruiting help. Access a marketplace of top fractional tech recruiters and run your process in our free ATS built for startups.
+links:
+  site: https://dover.com
+sources:
+  - source_id: src_0f4670aab0525145a9ffcb3e35c460d65f8f14b7ccfc1378153dc87448940e47
+    url: https://www.dover.com/
+  - source_id: src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d
+    url: https://pulley.com/perks
+programs: []
+offers:
+  - offer_id: off_01kyyts97w5gemywn56dycqgqw
+    offer_slug: free-access-to-ats-and-33-discount
+    offer_slug_aliases: []
+    title: Free Access to ATS & 33% Discount
+    summary: Get forever-free access to Dover ATS and Sourcing Copilot plus 33% off your first year of Dover Embedded or Sourcing Autopilot for new customers.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T12:27:57.374Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Forever-free access to Dover ATS and Sourcing Copilot
+          kind: free-service
+          service: Dover ATS and Sourcing Copilot
+        - applies_to: Dover Embedded or Sourcing Autopilot
+          benefit_id: ben_02
+          description: 33% discount off first year of Dover Embedded or Sourcing Autopilot
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            basis_points: 3300
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        fact: company.is_current_customer
+        kind: predicate
+        operator: eq
+        statement: New customers only
+        value:
+          type: boolean
+          value: false
+    roles:
+      terms_authority_entity_id: ent_01kyyts97thnsffv3e7r9m1270
+      access_operator_entity_id: ent_01kyyr9svfavvhqt4vy0e0b25k
+    access:
+      availability: membership
+      instructions: Email vip@dover.com and mention Pulley deal to sales rep.
+      method: contact
+    source_ids:
+      - src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d

--- a/vendors/dr/drata.yaml
+++ b/vendors/dr/drata.yaml
@@ -1,0 +1,72 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyyts97tv5vmpzna1nna08rb
+slug: drata
+slug_aliases: []
+name: Drata
+domains:
+  - value: drata.com
+    role: primary
+    valid_from: 2026-08-01T13:50:00.000Z
+  - value: help.drata.com
+    role: alias
+    valid_from: 2026-08-01T13:50:00.000Z
+category: security
+description: Drata Help Center
+links:
+  site: https://drata.com
+sources:
+  - source_id: src_2e7079c3b4306a5cf769d77f11dd9f26f6cb1064857461abdc44797adcbd6693
+    url: https://help.drata.com/en/
+  - source_id: src_67b6b47342f8646ee4596a42c3407f248389fee37d569fb5ca77a0d1190151d5
+    url: https://perkbook.co/vendor-directory/drata
+programs:
+  - program_id: prg_01kyyts97yk1gdq9zb89ht24nf
+    program_slug: drata-for-startups
+    program_slug_aliases: []
+    title: Drata for Startups
+    summary: Drata for Startups offers discounted access to Drata's continuous compliance platform for qualifying early-stage startups.
+    source_ids:
+      - src_67b6b47342f8646ee4596a42c3407f248389fee37d569fb5ca77a0d1190151d5
+offers:
+  - offer_id: off_01kyyts97y4yk035z9vrfwkfwd
+    program_id: prg_01kyyts97yk1gdq9zb89ht24nf
+    offer_slug: startup-discount-on-compliance-automation-with-drata-for-startups
+    offer_slug_aliases: []
+    title: Startup discount on compliance automation with Drata for Startups
+    summary: Qualifying early-stage companies affiliated with an approved Drata investor partner get discounted access to the Drata continuous compliance platform as new customers.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:14:06.104Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Discounted access to the Drata continuous compliance platform.
+          kind: other
+      consideration:
+        description: Specific discounted pricing is not stated in the source text.
+        kind: unknown
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: Affiliated with an approved Drata investor partner
+          - criterion_id: cri_02
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: New Drata customer
+            value:
+              type: boolean
+              value: false
+    roles:
+      terms_authority_entity_id: ent_01kyyts97tv5vmpzna1nna08rb
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: membership
+      method: form
+      url: https://perkbook.co/vendor-directory/drata
+    source_ids:
+      - src_67b6b47342f8646ee4596a42c3407f248389fee37d569fb5ca77a0d1190151d5

--- a/vendors/e2/e2b.yaml
+++ b/vendors/e2/e2b.yaml
@@ -1,0 +1,93 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyyts97s1bxxwa11s6wbm0r2
+slug: e2b
+slug_aliases: []
+name: E2B
+domains:
+  - value: e2b.dev
+    role: primary
+    valid_from: 2026-08-01T13:50:00.000Z
+category: other
+description: E2B Gives AI Agents Secure Computers with Real-World Tools. E2B is Used by 88% of Fortune 100 Companies for Frontier Agentic Workflows.
+links:
+  site: https://e2b.dev
+sources:
+  - source_id: src_0e33303f9e66813d619253e4b5f2b39c6abce3ddad223c01cbe96accd65a8293
+    url: https://e2b.dev/privacy
+  - source_id: src_a534ac470b986affc207b6f52ec5e66f285bf7972ac2f6026137f7d743b0c1e8
+    url: https://e2b.dev/startups
+programs:
+  - program_id: prg_01kyyts97vcfchqrykv2cg0v2e
+    program_slug: e2b-for-startups-program
+    program_slug_aliases: []
+    title: E2B for Startups Program
+    summary: E2B program providing startup credits and Pro Tier plan access to eligible early-stage AI agent startups.
+    source_ids:
+      - src_a534ac470b986affc207b6f52ec5e66f285bf7972ac2f6026137f7d743b0c1e8
+offers:
+  - offer_id: off_01kyyts97vfy9btzmsqx8hp75k
+    program_id: prg_01kyyts97vcfchqrykv2cg0v2e
+    offer_slug: e2b-for-startups-program
+    offer_slug_aliases: []
+    title: E2B for Startups Program
+    summary: Eligible early-stage startups get $20,000 in one-time E2B credits and membership in the E2B Pro Tier plan.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T11:36:15.140Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: $20,000 of usage in credits
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 2000000
+            kind: exact
+        - benefit_id: ben_02
+          description: Membership in E2B Pro Tier plan
+          kind: free-service
+          service: E2B Pro Tier plan
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: Raised less than $5M
+            value:
+              type: number
+              value: 5000000
+          - criterion_id: cri_02
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: Less than 3 years old
+            value:
+              type: number
+              value: 36
+          - criterion_id: cri_03
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: First time E2B users only
+            value:
+              type: boolean
+              value: false
+          - criterion_id: cri_04
+            kind: manual
+            reason: vendor-discretion
+            statement: Early-stage startups working on AI agents or AI-based applications evaluated by E2B
+    roles:
+      terms_authority_entity_id: ent_01kyyts97s1bxxwa11s6wbm0r2
+      access_operator_entity_id: ent_01kyyts97s1bxxwa11s6wbm0r2
+    access:
+      availability: public
+      method: form
+      url: https://e2b.dev/startups
+    source_ids:
+      - src_a534ac470b986affc207b6f52ec5e66f285bf7972ac2f6026137f7d743b0c1e8

--- a/vendors/el/ellis.yaml
+++ b/vendors/el/ellis.yaml
@@ -1,0 +1,54 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyyts97t5rgyrkz36gjyf1jq
+slug: ellis
+slug_aliases: []
+name: Ellis
+domains:
+  - value: ellis.com
+    role: primary
+    valid_from: 2026-08-01T13:50:00.000Z
+category: compliance
+description: Ellis is a business immigration platform helping People teams secure U.S. visas and green cards for skilled talent and improve your immigration program.
+links:
+  site: https://ellis.com
+sources:
+  - source_id: src_b5eaa060dac861bb0afa88ba80cec7aa1d7ff9108164a0b82ce519dc846c418b
+    url: https://www.ellis.com/
+  - source_id: src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d
+    url: https://pulley.com/perks
+programs: []
+offers:
+  - offer_id: off_01kyyts97w3nq0dwxwv14398ed
+    offer_slug: receive-a-1-000-discount-on-your-company-s-first-visa-petition-with-ellis
+    offer_slug_aliases: []
+    title: Receive a $1,000 discount on your company’s first visa petition with Ellis
+    summary: Receive $1,000 off your company's first visa petition with Ellis by mentioning Pulley.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T12:27:57.374Z
+    economics:
+      benefits:
+        - applies_to: first visa petition
+          benefit_id: ben_01
+          description: $1,000 discount on company's first visa petition
+          kind: discount
+          percentage:
+            basis_points: 10000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: constant
+        statement: Mention Pulley during consultation or before engagement letter signing.
+        value: true
+    roles:
+      terms_authority_entity_id: ent_01kyyts97t5rgyrkz36gjyf1jq
+      access_operator_entity_id: ent_01kyyr9svfavvhqt4vy0e0b25k
+    access:
+      availability: membership
+      instructions: To claim the offer, mention Pulley during your consultation or before the engagement letter signing.
+      method: contact
+    source_ids:
+      - src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d

--- a/vendors/ex/expensify.yaml
+++ b/vendors/ex/expensify.yaml
@@ -1,0 +1,73 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyyts97tpafry8ep3g3e85eh
+slug: expensify
+slug_aliases: []
+name: Expensify
+domains:
+  - value: expensify.com
+    role: primary
+    valid_from: 2026-08-01T13:50:00.000Z
+category: accounting
+description: Expensify's spend management software simplifies receipt and expense tracking. Automate reports, control spending, and save time with our easy-to-use platform.
+links:
+  site: https://expensify.com
+sources:
+  - source_id: src_6f3eb4093b3fd13d6eb6eb10c8d81e428751f9c04110757fc1ae6c9175dc1a14
+    url: https://www.expensify.com/
+  - source_id: src_21301fa5c389c204b52dc14f2c399210b3e1e0edcb9dc1e4342f66fe982ee6cf
+    url: https://perkbook.co/vendor-directory/expensify
+programs:
+  - program_id: prg_01kyyts97wxt2z585svpg1z4xf
+    program_slug: expensify-for-startups
+    program_slug_aliases: []
+    title: Expensify for Startups
+    summary: Expensify for Startups gives qualifying early-stage companies access to Expensify's expense management and corporate card platform.
+    source_ids:
+      - src_21301fa5c389c204b52dc14f2c399210b3e1e0edcb9dc1e4342f66fe982ee6cf
+offers:
+  - offer_id: off_01kyyts97w8j859aftbp2sfsk5
+    program_id: prg_01kyyts97wxt2z585svpg1z4xf
+    offer_slug: 3-months-free-with-expensify-for-startups
+    offer_slug_aliases: []
+    title: 3 months free with Expensify for Startups
+    summary: New qualifying early-stage startups get their first 3 months of the Expensify expense management and corporate card platform free.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:14:06.102Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: First 3 months of Expensify free
+          duration:
+            kind: exact
+            value: P3M
+          kind: free-service
+          service: Expensify platform
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: Available to new Expensify customers
+            value:
+              type: boolean
+              value: false
+          - criterion_id: cri_02
+            kind: manual
+            reason: vendor-discretion
+            statement: Early-stage startups
+    roles:
+      terms_authority_entity_id: ent_01kyyts97tpafry8ep3g3e85eh
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: membership
+      instructions: Sign Up to Unlock
+      method: other
+      url: https://perkbook.co/vendor-directory/expensify
+    source_ids:
+      - src_21301fa5c389c204b52dc14f2c399210b3e1e0edcb9dc1e4342f66fe982ee6cf

--- a/vendors/fi/firstbase.yaml
+++ b/vendors/fi/firstbase.yaml
@@ -1,0 +1,53 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyyts97tdzqkfecknpaf5e0p
+slug: firstbase
+slug_aliases: []
+name: Firstbase
+domains:
+  - value: firstbase.io
+    role: primary
+    valid_from: 2026-08-01T13:50:00.000Z
+category: compliance
+description: Firstbase helps anyone to build a US business. Start a company, set up banking, payments, and payroll, and manage a business — online, from anywhere.
+links:
+  site: https://firstbase.io
+sources:
+  - source_id: src_f9fb388f23a3452e9a7bb3ba060e62543325cebe53a99aa55e169c583449092e
+    url: https://www.firstbase.io/
+  - source_id: src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d
+    url: https://pulley.com/perks
+programs: []
+offers:
+  - offer_id: off_01kyyts97wxz856wm49a4m7v1r
+    offer_slug: receive-10-off-standard-pricing-for-u-s-incorporation-services
+    offer_slug_aliases: []
+    title: Receive 10% off standard pricing for U.S. incorporation services
+    summary: Receive 10% off standard pricing for Firstbase U.S. incorporation services.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T12:27:57.374Z
+    economics:
+      benefits:
+        - applies_to: U.S. incorporation services
+          benefit_id: ben_01
+          description: 10% off standard pricing for U.S. incorporation services
+          kind: discount
+          percentage:
+            basis_points: 1000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: constant
+        statement: Available to Pulley users.
+        value: true
+    roles:
+      terms_authority_entity_id: ent_01kyyts97tdzqkfecknpaf5e0p
+      access_operator_entity_id: ent_01kyyr9svfavvhqt4vy0e0b25k
+    access:
+      availability: membership
+      method: other
+    source_ids:
+      - src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d

--- a/vendors/fo/foundersuite.yaml
+++ b/vendors/fo/foundersuite.yaml
@@ -1,0 +1,54 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyyts97tv71kntfsyxy6e3pp
+slug: foundersuite
+slug_aliases: []
+name: foundersuite
+domains:
+  - value: foundersuite.com
+    role: primary
+    valid_from: 2026-08-01T13:50:00.000Z
+category: fundraising
+description: Software for raising venture capital and managing investor relations. Used by startups, investors, accelerators and financial intermediaries
+links:
+  site: https://foundersuite.com
+sources:
+  - source_id: src_fc50644b5ed5275deffd6f7c39aad168cc34ad56f77e0d6a8d1f867a104b4e4e
+    url: https://foundersuite.com/
+  - source_id: src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d
+    url: https://pulley.com/perks
+programs: []
+offers:
+  - offer_id: off_01kyyts97wq93er3t1zrs20n1b
+    offer_slug: get-40-off-any-annual-subscription-using-code-pulley
+    offer_slug_aliases: []
+    title: Get 40% off any Annual Subscription using code “Pulley”
+    summary: Get 40% off any Foundersuite Annual Subscription using coupon code Pulley.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T12:27:57.374Z
+    economics:
+      benefits:
+        - applies_to: Annual Subscription
+          benefit_id: ben_01
+          description: 40% off any Annual Subscription
+          kind: discount
+          percentage:
+            basis_points: 4000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: constant
+        statement: Use code Pulley.
+        value: true
+    roles:
+      terms_authority_entity_id: ent_01kyyts97tv71kntfsyxy6e3pp
+      access_operator_entity_id: ent_01kyyr9svfavvhqt4vy0e0b25k
+    access:
+      availability: public
+      method: code
+      public_code: Pulley
+    source_ids:
+      - src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d

--- a/vendors/go/google-cloud.yaml
+++ b/vendors/go/google-cloud.yaml
@@ -14,6 +14,8 @@ links:
 sources:
   - source_id: src_d4247606b801f684842c4b4a07967eb180fa8d99005a5a5c67247deb0c04d2c8
     url: https://cloud.google.com/startup
+  - source_id: src_1818590e2301ade4655e5d8bf9c89bb4f091f6032c63f17bc3a19f11f3ab0260
+    url: https://perkbook.co/vendor-directory/google
 programs:
   - program_id: prg_01kyh8fpe243m25ep0wtvz068s
     program_slug: google-for-startups-cloud-program
@@ -21,6 +23,13 @@ programs:
     title: Google for Startups Cloud Program
     source_ids:
       - src_d4247606b801f684842c4b4a07967eb180fa8d99005a5a5c67247deb0c04d2c8
+  - program_id: prg_01kyyts97xc8p500ajkf2n1774
+    program_slug: google-cloud-for-startups
+    program_slug_aliases: []
+    title: Google Cloud for Startups
+    summary: Google Cloud program providing startup cloud credits and discounts.
+    source_ids:
+      - src_1818590e2301ade4655e5d8bf9c89bb4f091f6032c63f17bc3a19f11f3ab0260
 offers:
   - offer_id: off_01kyh8fpe243m25ep0wtvz068s
     program_id: prg_01kyh8fpe243m25ep0wtvz068s
@@ -86,3 +95,52 @@ offers:
       url: https://cloud.google.com/startup
     source_ids:
       - src_d4247606b801f684842c4b4a07967eb180fa8d99005a5a5c67247deb0c04d2c8
+  - offer_id: off_01kyyts97x2jp0pmtbzfdervh2
+    program_id: prg_01kyyts97xc8p500ajkf2n1774
+    offer_slug: google-cloud-for-startups-credits-and-usage-coverage
+    offer_slug_aliases: []
+    title: Google Cloud for Startups Credits and Usage Coverage
+    summary: Up to $100,000 in Google Cloud credits during year one, plus 20% usage coverage in year two up to an additional $100,000.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:14:29.305Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $100,000 in credits to use with Google Cloud during your first year
+          duration:
+            kind: exact
+            value: P1Y
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 10000000
+            kind: up-to
+        - applies_to: Google Cloud usage during your second year
+          benefit_id: ben_02
+          description: 20% of your usage covered during your second year, up to an additional $100,000
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            basis_points: 2000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: vendor-discretion
+        statement: Available to all startups
+    roles:
+      terms_authority_entity_id: ent_01kyh8fpe210m3jqn5xgzztgv8
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: membership
+      method: form
+      url: https://perkbook.co/vendor-directory/google
+    source_ids:
+      - src_1818590e2301ade4655e5d8bf9c89bb4f091f6032c63f17bc3a19f11f3ab0260

--- a/vendors/gr/growsurf.yaml
+++ b/vendors/gr/growsurf.yaml
@@ -1,0 +1,53 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyyts97tgx2a9v0rnxxwvjpr
+slug: growsurf
+slug_aliases: []
+name: GrowSurf
+domains:
+  - value: growsurf.com
+    role: primary
+    valid_from: 2026-08-01T13:50:00.000Z
+category: marketing
+description: Referral software for marketing and product teams. Launch customer referral and affiliate programs in days, not weeks, without heavy engineering work.
+links:
+  site: https://growsurf.com
+sources:
+  - source_id: src_9883517dd9c1c1de62856b871636dcf5d0c2719924df9b3b092922b9a0cbc896
+    url: https://growsurf.com/
+  - source_id: src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d
+    url: https://pulley.com/perks
+programs: []
+offers:
+  - offer_id: off_01kyyts97wjy5ssdmvkjbsc7gw
+    offer_slug: 20-off-any-growsurf-plan
+    offer_slug_aliases: []
+    title: 20% off any GrowSurf plan
+    summary: Get 20% off any GrowSurf referral software plan.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T12:27:57.374Z
+    economics:
+      benefits:
+        - applies_to: GrowSurf plan
+          benefit_id: ben_01
+          description: 20% off any GrowSurf plan
+          kind: discount
+          percentage:
+            basis_points: 2000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: constant
+        statement: Available to Pulley users.
+        value: true
+    roles:
+      terms_authority_entity_id: ent_01kyyts97tgx2a9v0rnxxwvjpr
+      access_operator_entity_id: ent_01kyyr9svfavvhqt4vy0e0b25k
+    access:
+      availability: membership
+      method: other
+    source_ids:
+      - src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d

--- a/vendors/he/help-scout.yaml
+++ b/vendors/he/help-scout.yaml
@@ -14,7 +14,16 @@ links:
 sources:
   - source_id: src_05ba8d34222f2831b597e210e029fd69a347b4be2c4b3e658b256d675beca04a
     url: https://www.helpscout.com/startups/
-programs: []
+  - source_id: src_c9dc9cc8fc004b3411c9c32170a3aafe299b3d7fa70088053905208158decd19
+    url: https://www.helpscout.com/startups
+programs:
+  - program_id: prg_01kyyts97td7qwt101xj261h5z
+    program_slug: help-scout-for-startups
+    program_slug_aliases: []
+    title: Help Scout for Startups
+    summary: Help Scout's startup program offering six months of free access to Help Scout Plus for eligible early-stage startups.
+    source_ids:
+      - src_c9dc9cc8fc004b3411c9c32170a3aafe299b3d7fa70088053905208158decd19
 offers:
   - offer_id: off_01kyh8fpe3764vaa0pa94p6myj
     offer_slug: help-scout-for-startups
@@ -48,3 +57,68 @@ offers:
       url: https://www.helpscout.com/startups/
     source_ids:
       - src_05ba8d34222f2831b597e210e029fd69a347b4be2c4b3e658b256d675beca04a
+  - offer_id: off_01kyyts97t6zmpyza6edxsy08b
+    program_id: prg_01kyyts97td7qwt101xj261h5z
+    offer_slug: 6-months-free-help-scout-plus-for-startups
+    offer_slug_aliases: []
+    title: 6 months free Help Scout Plus for Startups
+    summary: Eligible incorporated tech startups under two years old with under $1M in ARR get six months of free access to Help Scout Plus.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:06:11.535Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Six months free on Help Scout Plus plan
+          duration:
+            kind: exact
+            value: P6M
+          kind: free-service
+          service: Help Scout Plus
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: Must be a new Help Scout customer
+            value:
+              type: boolean
+              value: false
+          - criterion_id: cri_02
+            fact: company.industry
+            kind: predicate
+            operator: contains
+            statement: Must be an incorporated tech startup
+            value:
+              type: string
+              value: tech
+          - criterion_id: cri_03
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: Must be less than two years old
+            value:
+              type: number
+              value: 24
+          - criterion_id: cri_04
+            fact: company.arr_usd
+            kind: predicate
+            operator: lt
+            statement: Generating under $1 million in annual recurring revenue (ARR)
+            value:
+              type: number
+              value: 1000000
+    roles:
+      terms_authority_entity_id: ent_01kyh8fpe3c80bycfhyx7m3jym
+      access_operator_entity_id: ent_01kyh8fpe3c80bycfhyx7m3jym
+    access:
+      availability: public
+      method: form
+      url: https://www.helpscout.com/startups/
+    source_ids:
+      - src_c9dc9cc8fc004b3411c9c32170a3aafe299b3d7fa70088053905208158decd19

--- a/vendors/ib/ibm.yaml
+++ b/vendors/ib/ibm.yaml
@@ -1,0 +1,55 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyyts97s6yk21ew7jmrwvj53
+slug: ibm
+slug_aliases: []
+name: IBM
+domains:
+  - value: ibm.com
+    role: primary
+    valid_from: 2026-08-01T13:50:00.000Z
+category: infra
+description: For more than a century, IBM has been a global technology innovator, leading advances in AI, automation and hybrid cloud solutions that help businesses grow.
+links:
+  site: https://ibm.com
+sources:
+  - source_id: src_c5a7735b1035270e2caf8c82c4cf0850e0d521e2d798ad9179e4e5d29040b92a
+    url: https://www.ibm.com/au-en
+  - source_id: src_1e556a4ddf545e3c2ad695bc37512aab8e6d25e5f1964abd75e56c5fc6612b3f
+    url: https://www.ibm.com/cloud/startups
+programs: []
+offers:
+  - offer_id: off_01kyyts97ve9xwf6ccn7j7mj6q
+    offer_slug: ibm-cloud-free-tier
+    offer_slug_aliases: []
+    title: IBM Cloud Free Tier
+    summary: Create a free IBM Cloud account to get access to over 40 always-free products and a $200 credit to use on any product in the IBM Cloud catalog.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:52:32.871Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: USD 200 credit on any product in the IBM Cloud catalog
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 20000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: constant
+        statement: Create your free IBM Cloud account
+        value: true
+    roles:
+      terms_authority_entity_id: ent_01kyyts97s6yk21ew7jmrwvj53
+      access_operator_entity_id: ent_01kyyts97s6yk21ew7jmrwvj53
+    access:
+      availability: public
+      method: form
+      url: https://www.ibm.com/products
+    source_ids:
+      - src_1e556a4ddf545e3c2ad695bc37512aab8e6d25e5f1964abd75e56c5fc6612b3f

--- a/vendors/in/incident-io.yaml
+++ b/vendors/in/incident-io.yaml
@@ -47,3 +47,57 @@ offers:
       url: https://incident.io/industry/startups
     source_ids:
       - src_0c09093713ab461ce2b22ca3fef2c2042b6be1fe35db093c686a5215ea7a9565
+  - offer_id: off_01kyyts97t7narfpd5cet2r8dt
+    offer_slug: incident-io-startup-program-1-500-off-team-plan
+    offer_slug_aliases: []
+    title: incident.io Startup Program - $1,500 off Team plan
+    summary: Eligible startups with under 20 employees can get $1,500 off the incident.io Team plan upon signing up, completing their first payment, and emailing support.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:23:37.441Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: $1,500 off the Team plan
+          duration:
+            kind: exact
+            value: P1Y
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 150000
+            kind: exact
+      consideration:
+        description: Sign up for the Team plan and complete the first payment
+        kind: variable
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: Must be a new incident.io customer
+            value:
+              type: boolean
+              value: false
+          - criterion_id: cri_02
+            fact: company.employee_count
+            kind: predicate
+            operator: lt
+            statement: Must have under 20 employees
+            value:
+              type: number
+              value: 20
+    roles:
+      terms_authority_entity_id: ent_01kyh8fpe322z5v22fkrz422xa
+      access_operator_entity_id: ent_01kyh8fpe322z5v22fkrz422xa
+    access:
+      availability: public
+      instructions: To claim your credits, sign up for the Team plan, complete your first payment, and then email credits@incident.io to have the credits added to your account
+      method: contact
+      url: https://incident.io/industry/startups
+    source_ids:
+      - src_0c09093713ab461ce2b22ca3fef2c2042b6be1fe35db093c686a5215ea7a9565

--- a/vendors/ma/magicbell.yaml
+++ b/vendors/ma/magicbell.yaml
@@ -1,0 +1,55 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyyts97txs24gjrczw3tepqw
+slug: magicbell
+slug_aliases: []
+name: MagicBell
+domains:
+  - value: magicbell.com
+    role: primary
+    valid_from: 2026-08-01T13:50:00.000Z
+category: other
+description: Push notification service for email, mobile push, web push, Slack, and SMS. API & SDKs with built-in user preferences and delivery tracking. Free to start.
+links:
+  site: https://magicbell.com
+sources:
+  - source_id: src_177c983f9979709e2267efd818c466c1c3178b76ae16e43ab366a37ac608acbd
+    url: https://www.magicbell.com/
+  - source_id: src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d
+    url: https://pulley.com/perks
+programs: []
+offers:
+  - offer_id: off_01kyyts97w5pnkr5ewb1pdjh9p
+    offer_slug: 50-off-for-the-first-24-months-1200-value-with-code-pulley1200
+    offer_slug_aliases: []
+    title: $50 off for the first 24 months ($1200 value) with code PULLEY1200
+    summary: Get $50 off per month for the first 24 months ($1,200 value) with promo code PULLEY1200.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T12:27:57.374Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: $50 off for the first 24 months ($1200 value)
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 120000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: constant
+        statement: Use code PULLEY1200.
+        value: true
+    roles:
+      terms_authority_entity_id: ent_01kyyts97txs24gjrczw3tepqw
+      access_operator_entity_id: ent_01kyyr9svfavvhqt4vy0e0b25k
+    access:
+      availability: public
+      method: code
+      public_code: PULLEY1200
+    source_ids:
+      - src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d

--- a/vendors/ma/make.yaml
+++ b/vendors/ma/make.yaml
@@ -14,6 +14,8 @@ links:
 sources:
   - source_id: src_db3296af0447f0e07ac4ca90f90dde3d7df547a077af2257e2b77323c2e912c7
     url: https://f.make.com/startup-program
+  - source_id: src_52c7cfef76238693c49b022554f5d5ebcae3cf0fc5dc5360e48fae867f013be5
+    url: https://perkbook.co/vendor-directory/make
 programs:
   - program_id: prg_01kyxthgpy4wnbhzr8b5hv4nz8
     program_slug: make-startup-program
@@ -22,6 +24,7 @@ programs:
     summary: Make Startup Program offers free access and plan discounts with automation credits to early-stage startups.
     source_ids:
       - src_db3296af0447f0e07ac4ca90f90dde3d7df547a077af2257e2b77323c2e912c7
+      - src_52c7cfef76238693c49b022554f5d5ebcae3cf0fc5dc5360e48fae867f013be5
 offers:
   - offer_id: off_01kyxthgpyakq6wbdhypr9wn51
     program_id: prg_01kyxthgpy4wnbhzr8b5hv4nz8
@@ -92,3 +95,84 @@ offers:
       url: https://f.make.com/startup-program
     source_ids:
       - src_db3296af0447f0e07ac4ca90f90dde3d7df547a077af2257e2b77323c2e912c7
+  - offer_id: off_01kyyts97x7ytcbchydkafk13x
+    program_id: prg_01kyxthgpy4wnbhzr8b5hv4nz8
+    offer_slug: 1-year-free-teams-plan-with-make-for-startups-partner-tier
+    offer_slug_aliases: []
+    title: 1 year free Teams Plan with Make for Startups — partner tier
+    summary: Qualifying partner-affiliated early-stage startups receive 1 year free on the Make Teams plan with up to 480k operations.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:15:22.414Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: 1 year free on the Make Teams plan with 480k operations (worth $1,100+).
+          duration:
+            kind: exact
+            value: P1Y
+          kind: free-service
+          service: Make Teams plan with 480k operations
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: Not a paying Make customer
+            value:
+              type: boolean
+              value: false
+          - criterion_id: cri_02
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: Raised less than $5M
+            value:
+              type: number
+              value: 5000000
+          - criterion_id: cri_03
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: Less than 5 years old
+            value:
+              type: number
+              value: 60
+          - criterion_id: cri_04
+            fact: company.employee_count
+            kind: predicate
+            operator: lt
+            statement: Fewer than 100 employees
+            value:
+              type: number
+              value: 100
+          - criterion_id: cri_05
+            fact: company.industry
+            kind: predicate
+            operator: neq
+            statement: Not providing AI automation as a service
+            value:
+              type: string
+              value: AI automation as a service
+          - criterion_id: cri_06
+            fact: company.partner_memberships
+            kind: predicate
+            operator: contains
+            statement: Affiliated with a Make partner
+            value:
+              type: string
+              value: Make partner
+    roles:
+      terms_authority_entity_id: ent_01kyxthgpy3tfte8bd2eng1ncw
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: membership
+      method: form
+      url: https://perkbook.co/vendor-directory/make
+    source_ids:
+      - src_52c7cfef76238693c49b022554f5d5ebcae3cf0fc5dc5360e48fae867f013be5

--- a/vendors/mi/miro.yaml
+++ b/vendors/mi/miro.yaml
@@ -14,6 +14,8 @@ links:
 sources:
   - source_id: src_cd12d5b849bd137660d1748c1f441203536c41948b97eef4e1122804a2620037
     url: https://miro.com/startups/
+  - source_id: src_eec011578cba1a7a91df90a049196d57b38721f4119f616e91939105a9d5bac4
+    url: https://perkbook.co/vendor-directory/miro
 programs:
   - program_id: prg_01kyh8fpe335dxj6tsyk7tb78w
     program_slug: miro-for-startups
@@ -21,6 +23,13 @@ programs:
     title: Miro for Startups
     source_ids:
       - src_cd12d5b849bd137660d1748c1f441203536c41948b97eef4e1122804a2620037
+  - program_id: prg_01kyyts97xgd034zqh77z1n3r9
+    program_slug: miro-startup-program
+    program_slug_aliases: []
+    title: Miro Startup Program
+    summary: Miro Startup Program offers credits for eligible startups.
+    source_ids:
+      - src_eec011578cba1a7a91df90a049196d57b38721f4119f616e91939105a9d5bac4
 offers:
   - offer_id: off_01kyh8fpe335dxj6tsyk7tb78w
     program_id: prg_01kyh8fpe335dxj6tsyk7tb78w
@@ -89,3 +98,140 @@ offers:
       url: https://miro.com/startups/
     source_ids:
       - src_cd12d5b849bd137660d1748c1f441203536c41948b97eef4e1122804a2620037
+  - offer_id: off_01kyyts97xm14v7h68xprfng2a
+    program_id: prg_01kyyts97xgd034zqh77z1n3r9
+    offer_slug: free-credits-with-miro-startup-program-individual-tier
+    offer_slug_aliases: []
+    title: Free credits with Miro Startup Program — individual tier
+    summary: $500 in Miro credits for individual startups without a Miro partner, accepted on a case-by-case basis.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:15:22.413Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: $500 in Miro credits
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 50000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.partner_memberships
+            kind: predicate
+            operator: absent
+            statement: Not affiliated with a Miro partner
+          - criterion_id: cri_02
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: Not a paying Miro subscriber
+            value:
+              type: boolean
+              value: false
+          - criterion_id: cri_03
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: Under 2 years old
+            value:
+              type: number
+              value: 24
+          - criterion_id: cri_04
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: Under $5M raised
+            value:
+              type: number
+              value: 5000000
+          - criterion_id: cri_05
+            kind: manual
+            reason: external-verification
+            statement: Work/startup domain email
+          - criterion_id: cri_06
+            kind: manual
+            reason: vendor-discretion
+            statement: Accepted on a case-by-case basis
+    roles:
+      terms_authority_entity_id: ent_01kyh8fpe3h966sfgy1aghhjce
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: public
+      method: form
+      url: https://perkbook.co/vendor-directory/miro
+    source_ids:
+      - src_eec011578cba1a7a91df90a049196d57b38721f4119f616e91939105a9d5bac4
+  - offer_id: off_01kyyts97xnz2014phy8xa4m45
+    program_id: prg_01kyyts97xgd034zqh77z1n3r9
+    offer_slug: free-credits-with-miro-startup-program-partner-tier
+    offer_slug_aliases: []
+    title: Free credits with Miro Startup Program — partner tier
+    summary: $1,000 in Miro credits for startups affiliated with an approved Miro Startup Program partner (VC, accelerator, or incubator).
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:15:22.413Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: $1,000 in Miro credits
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 100000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: Affiliated with an approved Miro Startup Program partner (VC, accelerator, or incubator)
+          - criterion_id: cri_02
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: Not a paying Miro subscriber
+            value:
+              type: boolean
+              value: false
+          - criterion_id: cri_03
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: Under 2 years old
+            value:
+              type: number
+              value: 24
+          - criterion_id: cri_04
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: Under $5M raised
+            value:
+              type: number
+              value: 5000000
+          - criterion_id: cri_05
+            kind: manual
+            reason: external-verification
+            statement: Work/startup domain email
+    roles:
+      terms_authority_entity_id: ent_01kyh8fpe3h966sfgy1aghhjce
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: membership
+      method: form
+      url: https://perkbook.co/vendor-directory/miro
+    source_ids:
+      - src_eec011578cba1a7a91df90a049196d57b38721f4119f616e91939105a9d5bac4

--- a/vendors/mi/mixpanel.yaml
+++ b/vendors/mi/mixpanel.yaml
@@ -14,7 +14,16 @@ links:
 sources:
   - source_id: src_ea790be568ceac58032d8f5cfbe5fe7cc82aad0993b883bb8c4fc00d0a39e2ca
     url: https://mixpanel.com/startups
-programs: []
+  - source_id: src_eae408957a688c39055eba95a3015809cfd7c08e400619ecd2a4c76246aab2fb
+    url: https://perkbook.co/vendor-directory/mixpanel
+programs:
+  - program_id: prg_01kyyts97x3wvehfewd8amgdjp
+    program_slug: mixpanel-for-startups
+    program_slug_aliases: []
+    title: Mixpanel for Startups
+    summary: Mixpanel for Startups provides free credits and product analytics tools to help early-stage startups reach product-market fit.
+    source_ids:
+      - src_eae408957a688c39055eba95a3015809cfd7c08e400619ecd2a4c76246aab2fb
 offers:
   - offer_id: off_01kyh8fpe47c34p80tmwstfc3a
     offer_slug: startup-program
@@ -48,3 +57,64 @@ offers:
       url: https://mixpanel.com/startups
     source_ids:
       - src_ea790be568ceac58032d8f5cfbe5fe7cc82aad0993b883bb8c4fc00d0a39e2ca
+  - offer_id: off_01kyyts97xe9g83q0py06y9z7a
+    program_id: prg_01kyyts97x3wvehfewd8amgdjp
+    offer_slug: 1-year-free-startup-plan-with-mixpanel-for-startups
+    offer_slug_aliases: []
+    title: 1 year free Startup Plan with Mixpanel for Startups
+    summary: Eligible early-stage startups receive $50,000 in free credits for Mixpanel's Startup Plan over 1 year.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:15:22.415Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: $50,000 in free credits for the Startup Plan
+          duration:
+            kind: exact
+            value: P1Y
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 5000000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: Company is under 2 years old
+            value:
+              type: number
+              value: 24
+          - criterion_id: cri_02
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: Company has raised less than $5M in total funding
+            value:
+              type: number
+              value: 5000000
+          - criterion_id: cri_03
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: Must be a new Mixpanel customer
+            value:
+              type: boolean
+              value: false
+    roles:
+      terms_authority_entity_id: ent_01kyh8fpe40rzz1tgnr4prd3tr
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: membership
+      method: form
+      url: https://perkbook.co/vendor-directory/mixpanel
+    source_ids:
+      - src_eae408957a688c39055eba95a3015809cfd7c08e400619ecd2a4c76246aab2fb

--- a/vendors/mo/mongodb.yaml
+++ b/vendors/mo/mongodb.yaml
@@ -14,7 +14,16 @@ links:
 sources:
   - source_id: src_87fa40e252a9c0c03f4ac9ffad48bd99a2d2b8e7777d03753698a2b1458074fe
     url: https://www.mongodb.com/solutions/startups
-programs: []
+  - source_id: src_e0bda57ca6e319ab92324c417a2a85c8ebc6df9632a7fa410a23ae14b296fa6e
+    url: https://www.mongodb.com/startups
+programs:
+  - program_id: prg_01kyyts97vc8jaej2hsbpjwt81
+    program_slug: mongodb-for-startups
+    program_slug_aliases: []
+    title: MongoDB for Startups
+    summary: MongoDB for Startups supports early-stage startups with MongoDB Atlas credits, Voyage AI tokens, expert technical advice, and access to partner resources.
+    source_ids:
+      - src_e0bda57ca6e319ab92324c417a2a85c8ebc6df9632a7fa410a23ae14b296fa6e
 offers:
   - offer_id: off_01kyh8fpe4x7t8nptwjhqh6var
     offer_slug: mongodb-for-startups-program
@@ -47,3 +56,75 @@ offers:
       url: https://www.mongodb.com/solutions/startups
     source_ids:
       - src_87fa40e252a9c0c03f4ac9ffad48bd99a2d2b8e7777d03753698a2b1458074fe
+  - offer_id: off_01kyyts97vfba6xyhnp22d9ayx
+    program_id: prg_01kyyts97vc8jaej2hsbpjwt81
+    offer_slug: mongodb-for-startups
+    offer_slug_aliases: []
+    title: MongoDB for Startups
+    summary: Access MongoDB Atlas credits, Voyage AI tokens, technical advice, one-on-one expert guidance, and partner network access for early-stage startups.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T06:51:28.753Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: MongoDB Atlas credits
+          kind: other
+        - benefit_id: ben_02
+          description: Voyage AI tokens for high-performance retrieval and embeddings
+          kind: other
+        - benefit_id: ben_03
+          description: Exclusive access to a one-on-one session with a professional services expert for best practices and startup guidance
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: Startup must be less than 7 years old
+            value:
+              type: number
+              value: 84
+          - criterion_id: cri_02
+            fact: company.stage
+            kind: predicate
+            operator: in
+            statement: Startup funding stage must be Series A or earlier
+            value:
+              type: string-set
+              values:
+                - Bootstrapped
+                - Pre-seed
+                - Seed
+                - Series A
+          - criterion_id: cri_03
+            fact: company.industry
+            kind: predicate
+            operator: neq
+            statement: Startup must be focused on a single software-based product or service
+            value:
+              type: string
+              value: agency_or_dev_shop
+          - criterion_id: cri_04
+            fact: company.is_current_customer
+            kind: predicate
+            operator: absent
+            statement: Must not be a previous participant accepted into MongoDB for Startups
+          - criterion_id: cri_05
+            kind: manual
+            reason: external-verification
+            statement: Must have an active company website and LinkedIn profile
+    roles:
+      terms_authority_entity_id: ent_01kyh8fpe4ys74qx1k4zfcqpjv
+      access_operator_entity_id: ent_01kyh8fpe4ys74qx1k4zfcqpjv
+    access:
+      availability: public
+      method: form
+      url: https://www.mongodb.com/startups
+    source_ids:
+      - src_e0bda57ca6e319ab92324c417a2a85c8ebc6df9632a7fa410a23ae14b296fa6e

--- a/vendors/ne/nebius.yaml
+++ b/vendors/ne/nebius.yaml
@@ -1,0 +1,121 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyyts97t7e1mjd9afe1c2b6k
+slug: nebius
+slug_aliases: []
+name: nebius
+domains:
+  - value: nebius.com
+    role: primary
+    valid_from: 2026-08-01T13:50:00.000Z
+category: infra
+description: Build and scale faster on the purpose-built AI cloud, engineered from silicon to API.
+links:
+  site: https://nebius.com
+sources:
+  - source_id: src_6412a02cb1ef633dc301c4840a8f6f52f6699572e99e3fbd1b206d1eb162f9a2
+    url: https://nebius.com/
+  - source_id: src_e5f8862d901702ee28addc2b5d482e2f4049d47452e2f8dd3b51d83028a5478d
+    url: https://perkbook.co/vendor-directory/nebius
+programs:
+  - program_id: prg_01kyyts97wfw7w8brz2xw4psa6
+    program_slug: nebius-for-startups
+    program_slug_aliases: []
+    title: Nebius for Startups
+    summary: Program providing AI-focused early-stage companies with immediate GPU credits and discounted compute on enterprise-grade H100 infrastructure.
+    source_ids:
+      - src_e5f8862d901702ee28addc2b5d482e2f4049d47452e2f8dd3b51d83028a5478d
+offers:
+  - offer_id: off_01kyyts97wajf01q9g41ztvarp
+    program_id: prg_01kyyts97wfw7w8brz2xw4psa6
+    offer_slug: free-compute-credits-with-nebius-for-startups-base-tier
+    offer_slug_aliases: []
+    title: Free compute credits with Nebius for Startups — base tier
+    summary: Provides $5,000 in immediate GPU credits for early-stage AI startups with under $5M in funding.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:15:42.602Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: $5,000 USD in immediate GPU compute credits
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 500000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: not-machine-evaluable
+            statement: Must be an early-stage AI-focused startup.
+          - criterion_id: cri_02
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: Must be a new Nebius customer.
+            value:
+              type: boolean
+              value: false
+          - criterion_id: cri_03
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: Must have raised under $5M in funding.
+            value:
+              type: number
+              value: 5000000
+    roles:
+      terms_authority_entity_id: ent_01kyyts97t7e1mjd9afe1c2b6k
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: membership
+      method: other
+    source_ids:
+      - src_e5f8862d901702ee28addc2b5d482e2f4049d47452e2f8dd3b51d83028a5478d
+  - offer_id: off_01kyyts97wzz52bdfhxbhhkk41
+    program_id: prg_01kyyts97wfw7w8brz2xw4psa6
+    offer_slug: free-compute-credits-with-nebius-for-startups-high-growth-tier
+    offer_slug_aliases: []
+    title: Free compute credits with Nebius for Startups — high-growth tier
+    summary: Provides $100,000 USD in compute credits for high-growth AI startups with significant compute needs.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:15:42.602Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: $100,000 USD in compute credits
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 10000000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: not-machine-evaluable
+            statement: Must be a high-growth AI startup with significant compute needs.
+          - criterion_id: cri_02
+            kind: manual
+            reason: vendor-discretion
+            statement: Assessed case by case by Nebius.
+    roles:
+      terms_authority_entity_id: ent_01kyyts97t7e1mjd9afe1c2b6k
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: membership
+      method: other
+    source_ids:
+      - src_e5f8862d901702ee28addc2b5d482e2f4049d47452e2f8dd3b51d83028a5478d

--- a/vendors/ne/neo4j.yaml
+++ b/vendors/ne/neo4j.yaml
@@ -14,7 +14,16 @@ links:
 sources:
   - source_id: src_69ffb8925d5967c3d95dc1708b78eea0ec83de27d1a390b28c4e5a1ccf716811
     url: https://neo4j.com/startup-program/
-programs: []
+  - source_id: src_fca2323e44d4a96f3541993271951a026fef1b4043106ee184efddf0a05b2184
+    url: https://neo4j.com/startup-program
+programs:
+  - program_id: prg_01kyyts97t489dn9xs9cnyy2zv
+    program_slug: neo4j-startup-program
+    program_slug_aliases: []
+    title: Neo4j startup program
+    summary: Neo4j startup program provides early-stage startups with Aura credits, expert guidance, and co-marketing opportunities.
+    source_ids:
+      - src_fca2323e44d4a96f3541993271951a026fef1b4043106ee184efddf0a05b2184
 offers:
   - offer_id: off_01kyh8fpe481pd2jnjrc9fr9qr
     offer_slug: neo4j-startup-program
@@ -47,3 +56,67 @@ offers:
       url: https://neo4j.com/startup-program/
     source_ids:
       - src_69ffb8925d5967c3d95dc1708b78eea0ec83de27d1a390b28c4e5a1ccf716811
+  - offer_id: off_01kyyts97vrwvjk2hzser10zjz
+    program_id: prg_01kyyts97t489dn9xs9cnyy2zv
+    offer_slug: up-to-16k-in-aura-credits
+    offer_slug_aliases: []
+    title: Up to $16K in Aura credits
+    summary: Eligible early-stage startups at Series B or earlier receive up to $16,000 in Aura credits to build and scale on Neo4j's production-ready graph database.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T06:42:55.540Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $16,000 in Neo4j Aura credits
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 1600000
+            kind: up-to
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.stage
+            kind: predicate
+            operator: in
+            statement: Startup must be at Series B or earlier.
+            value:
+              type: string-set
+              values:
+                - Pre-Seed
+                - Seed
+                - Series A
+                - Series B
+          - criterion_id: cri_02
+            fact: company.business_model
+            kind: predicate
+            operator: neq
+            statement: Startup must build a single product for many customers, not a custom product for individual customers.
+            value:
+              type: string
+              value: agency_or_consulting
+          - criterion_id: cri_03
+            fact: company.website_url
+            kind: predicate
+            operator: present
+            statement: Startup must have a live, functioning website.
+          - criterion_id: cri_04
+            fact: company.linkedin_profile
+            kind: predicate
+            operator: present
+            statement: Startup must have a valid company profile on LinkedIn and a direct association with the person who is applying.
+    roles:
+      terms_authority_entity_id: ent_01kyh8fpe4m8296zng9ncsnbqs
+      access_operator_entity_id: ent_01kyh8fpe4m8296zng9ncsnbqs
+    access:
+      availability: public
+      method: form
+      url: https://neo4j.com/startup-program/
+    source_ids:
+      - src_fca2323e44d4a96f3541993271951a026fef1b4043106ee184efddf0a05b2184

--- a/vendors/ne/neon.yaml
+++ b/vendors/ne/neon.yaml
@@ -21,6 +21,13 @@ programs:
     title: Neon Startup Program
     source_ids:
       - src_65083022096f10c52db27a04aa8e3bba73fd9c0d619c10d1027fceec3d80cf19
+  - program_id: prg_01kyyts97vnde5z7v1mc0fcxjf
+    program_slug: databricks-startup-program
+    program_slug_aliases: []
+    title: Databricks Startup Program
+    summary: Credits and support for qualifying self-funded and venture-backed startups.
+    source_ids:
+      - src_65083022096f10c52db27a04aa8e3bba73fd9c0d619c10d1027fceec3d80cf19
 offers:
   - offer_id: off_01kyh8fpe4n0a9h3p60g60ppdj
     program_id: prg_01kyh8fpe4n0a9h3p60g60ppdj
@@ -77,6 +84,136 @@ offers:
         criterion_id: cri_requirement_01
         statement: VC-backed startups with at least $1M in funding or participating in recognized accelerators like Y Combinator, building an early-stage product or MVP.
         reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01kyh8fpe42ws3zbxkkaybx2ea
+      access_operator_entity_id: ent_01kyh8fpe42ws3zbxkkaybx2ea
+    access:
+      availability: public
+      method: form
+      url: https://neon.com/startups
+    source_ids:
+      - src_65083022096f10c52db27a04aa8e3bba73fd9c0d619c10d1027fceec3d80cf19
+  - offer_id: off_01kyyts97v9xesen17q0yd2ge9
+    program_id: prg_01kyyts97vnde5z7v1mc0fcxjf
+    offer_slug: databricks-startup-program-self-funded
+    offer_slug_aliases: []
+    title: Databricks Startup Program - Self-Funded
+    summary: Up to $1,000 in Neon credits, onboarding support, and early access to features for early-stage self-funded startups with less than $1M in funding.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T06:43:53.496Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $1,000 in Neon credits valid for 12 months.
+          duration:
+            kind: exact
+            value: P1Y
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 100000
+            kind: up-to
+        - benefit_id: ben_02
+          description: Onboarding support from the Neon product team.
+          kind: other
+        - benefit_id: ben_03
+          description: Early access to new Neon features.
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: Company has raised less than $1,000,000 in funding.
+            value:
+              type: number
+              value: 1000000
+          - criterion_id: cri_02
+            fact: company.stage
+            kind: predicate
+            operator: eq
+            statement: Company stage is early-stage, self-funded startup building an early-stage product or MVP.
+            value:
+              type: string
+              value: early-stage
+    roles:
+      terms_authority_entity_id: ent_01kyh8fpe42ws3zbxkkaybx2ea
+      access_operator_entity_id: ent_01kyh8fpe42ws3zbxkkaybx2ea
+    access:
+      availability: public
+      method: form
+      url: https://neon.com/startups
+    source_ids:
+      - src_65083022096f10c52db27a04aa8e3bba73fd9c0d619c10d1027fceec3d80cf19
+  - offer_id: off_01kyyts97v1nqhyspc5vgs7yt9
+    program_id: prg_01kyyts97vnde5z7v1mc0fcxjf
+    offer_slug: databricks-startup-program-venture-backed
+    offer_slug_aliases: []
+    title: Databricks Startup Program - Venture-Backed
+    summary: Up to $200K in Neon and Databricks credits, onboarding support, feature access, and co-marketing opportunities for VC-backed or accelerator startups.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T06:43:53.496Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $200,000 in Neon and Databricks credits valid for 12 months.
+          duration:
+            kind: exact
+            value: P1Y
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 20000000
+            kind: up-to
+        - benefit_id: ben_02
+          description: Onboarding support from the Neon product team.
+          kind: other
+        - benefit_id: ben_03
+          description: Early access to new Neon features.
+          kind: other
+        - benefit_id: ben_04
+          description: Speaking opportunities at Neon developer events.
+          kind: other
+        - benefit_id: ben_05
+          description: Co-marketing opportunities and visibility with Neon.
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.stage
+            kind: predicate
+            operator: eq
+            statement: Company stage is early-stage building an early-stage product or MVP.
+            value:
+              type: string
+              value: early-stage
+          - kind: any
+            rules:
+              - criterion_id: cri_02
+                fact: company.funding_raised_usd
+                kind: predicate
+                operator: gte
+                statement: Company has raised at least $1,000,000 in VC funding.
+                value:
+                  type: number
+                  value: 1000000
+              - criterion_id: cri_03
+                kind: manual
+                reason: external-verification
+                statement: Participant in a recognized startup accelerator (e.g. Y Combinator).
     roles:
       terms_authority_entity_id: ent_01kyh8fpe42ws3zbxkkaybx2ea
       access_operator_entity_id: ent_01kyh8fpe42ws3zbxkkaybx2ea

--- a/vendors/no/notion.yaml
+++ b/vendors/no/notion.yaml
@@ -1,0 +1,155 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyyts97tbppvx69rh3v86sk2
+slug: notion
+slug_aliases: []
+name: notion
+domains:
+  - value: notion.so
+    role: primary
+    valid_from: 2026-08-01T13:50:00.000Z
+  - value: notion.com
+    role: alias
+    valid_from: 2026-08-01T13:50:00.000Z
+category: workspace
+description: Build Custom Agents, search across all your apps, and automate busywork. The AI workspace where teams get more done, faster.
+links:
+  site: https://notion.com
+sources:
+  - source_id: src_b04d19f21678295e26b2d736b5d339ff79eaee87563c1ff74c62f102bdd9d843
+    url: https://www.notion.com/
+  - source_id: src_68fcbed34628a5c136b481682c292d79387f0a2a8fe60cb165f9f176c5f82fac
+    url: https://perkbook.co/vendor-directory/notion
+programs:
+  - program_id: prg_01kyyts97wr01a0f3as5qcgatc
+    program_slug: notion-for-startups
+    program_slug_aliases: []
+    title: Notion for Startups
+    summary: Startup discounts and credits programs offered by Notion.
+    source_ids:
+      - src_68fcbed34628a5c136b481682c292d79387f0a2a8fe60cb165f9f176c5f82fac
+offers:
+  - offer_id: off_01kyyts97ws635fv7kpb4ce6qh
+    program_id: prg_01kyyts97wr01a0f3as5qcgatc
+    offer_slug: 6-months-free-with-notion-for-startups-partner-tier
+    offer_slug_aliases: []
+    title: 6 months free with Notion for Startups — partner tier
+    summary: Get 6 months free of Notion for eligible startups affiliated with an approved partner network.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:15:42.602Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: 6 months free of Notion workspace
+          duration:
+            kind: exact
+            value: P6M
+          kind: free-service
+          service: Notion connected workspace
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: Not a paying Notion customer
+            value:
+              type: boolean
+              value: false
+          - criterion_id: cri_02
+            fact: company.employee_count
+            kind: predicate
+            operator: lt
+            statement: Fewer than 100 employees
+            value:
+              type: number
+              value: 100
+          - criterion_id: cri_03
+            fact: company.partner_memberships
+            kind: predicate
+            operator: present
+            statement: Affiliated with an approved Notion Startup Program partner (VC; accelerator; or tech platform)
+          - criterion_id: cri_04
+            kind: manual
+            reason: external-verification
+            statement: Valid company email
+    roles:
+      terms_authority_entity_id: ent_01kyyts97tbppvx69rh3v86sk2
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: membership
+      method: form
+      url: https://perkbook.co/vendor-directory/notion
+    source_ids:
+      - src_68fcbed34628a5c136b481682c292d79387f0a2a8fe60cb165f9f176c5f82fac
+  - offer_id: off_01kyyts97wjtcep1n3c9hwkrr1
+    program_id: prg_01kyyts97wr01a0f3as5qcgatc
+    offer_slug: free-credits-with-notion-for-startups-direct-apply
+    offer_slug_aliases: []
+    title: Free credits with Notion for Startups — direct apply
+    summary: Get $500 in Notion credits for eligible early-stage startups applying directly without a partner affiliation.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:15:42.602Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: $500 in Notion credits
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 50000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.partner_memberships
+            kind: predicate
+            operator: absent
+            statement: Not affiliated with a Notion startup partner
+          - criterion_id: cri_02
+            fact: company.plan_tier
+            kind: predicate
+            operator: eq
+            statement: Currently on a free Notion plan
+            value:
+              type: string
+              value: free
+          - criterion_id: cri_03
+            fact: company.stage
+            kind: predicate
+            operator: eq
+            statement: Must be an early-stage startup
+            value:
+              type: string
+              value: early-stage
+          - criterion_id: cri_04
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: Must be a new Notion customer
+            value:
+              type: boolean
+              value: false
+          - criterion_id: cri_05
+            kind: manual
+            reason: vendor-discretion
+            statement: Accepted on a case-by-case basis
+    roles:
+      terms_authority_entity_id: ent_01kyyts97tbppvx69rh3v86sk2
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: public
+      method: form
+      url: https://perkbook.co/vendor-directory/notion
+    source_ids:
+      - src_68fcbed34628a5c136b481682c292d79387f0a2a8fe60cb165f9f176c5f82fac

--- a/vendors/pa/pave.yaml
+++ b/vendors/pa/pave.yaml
@@ -1,0 +1,50 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyyts97tvcvr85cjbh5f7rsf
+slug: pave
+slug_aliases: []
+name: Pave
+domains:
+  - value: pave.com
+    role: primary
+    valid_from: 2026-08-01T13:50:00.000Z
+category: people
+description: View Pave's privacy policy.
+links:
+  site: https://pave.com
+sources:
+  - source_id: src_a474861d4940b546e1a67bc160f0698c22101701704fbb702ee9c055cbe5621e
+    url: https://www.pave.com/company/legal/privacy-policy
+  - source_id: src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d
+    url: https://pulley.com/perks
+programs: []
+offers:
+  - offer_id: off_01kyyts97wvqj3eqwn9xwszrc5
+    offer_slug: free-real-time-global-cash-and-equity-compensation-market-data-through-pave-mark
+    offer_slug_aliases: []
+    title: Free, real-time global cash and equity compensation market data through Pave Market Data Lite
+    summary: Unlock free benchmarks by connecting your HRIS and Pulley account to Pave Market Data Lite.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T12:27:57.374Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Free, real-time global cash and equity compensation market data through Pave Market Data Lite
+          kind: free-service
+          service: Pave Market Data Lite
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: constant
+        statement: Simply connect your HRIS and Pulley account in minutes and instantly unlock free benchmarks.
+        value: true
+    roles:
+      terms_authority_entity_id: ent_01kyyts97tvcvr85cjbh5f7rsf
+      access_operator_entity_id: ent_01kyyr9svfavvhqt4vy0e0b25k
+    access:
+      availability: membership
+      method: other
+    source_ids:
+      - src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d

--- a/vendors/pi/pilot.yaml
+++ b/vendors/pi/pilot.yaml
@@ -103,3 +103,38 @@ offers:
       method: other
     source_ids:
       - src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d
+  - offer_id: off_01kyyts97v3m4t28cc4zgp3eza
+    offer_slug: pre-revenue-tax-discount
+    offer_slug_aliases: []
+    title: Pre-revenue Tax Discount
+    summary: Exclusive tax filing discounts for pre-revenue businesses.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T06:43:53.069Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Exclusive discount on tax filing services.
+          kind: other
+      consideration:
+        description: Discounted fee for tax filing services.
+        kind: unknown
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        fact: company.is_pre_revenue
+        kind: predicate
+        operator: eq
+        statement: Business must be pre-revenue.
+        value:
+          type: boolean
+          value: true
+    roles:
+      terms_authority_entity_id: ent_01kyh8fpe4nr3y7st8xcm8gryv
+      access_operator_entity_id: ent_01kyh8fpe4nr3y7st8xcm8gryv
+    access:
+      availability: public
+      method: contact
+      url: https://pilot.com/pricing
+    source_ids:
+      - src_03280047fb9243ba29a16274b0569d4376e75b97b65e938c2a9045faf5ef21ca

--- a/vendors/pu/puzzle.yaml
+++ b/vendors/pu/puzzle.yaml
@@ -1,0 +1,93 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyyts97s1w9c31cbzyjwye2h
+slug: puzzle
+slug_aliases: []
+name: Puzzle
+domains:
+  - value: puzzle.io
+    role: primary
+    valid_from: 2026-08-01T13:50:00.000Z
+category: accounting
+description: Automate your bookkeeping with Puzzle’s AI-native accounting software. Get real-time financial insights, seamless integrations (Stripe, Brex, Gusto), and tax-ready financials instantly.
+links:
+  site: https://puzzle.io
+sources:
+  - source_id: src_71c84f48edff421fd0d325aadd1afb668a81affea8256b629118e70d8aa18f2f
+    url: https://puzzle.io/
+  - source_id: src_1218c0e1006047b76dbdb4f12f087fce02bb36ebbd981ba5508a74f39c0432b0
+    url: https://puzzle.io/pricing
+  - source_id: src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d
+    url: https://pulley.com/perks
+programs: []
+offers:
+  - offer_id: off_01kyyts97vew8dq1f25mejswen
+    offer_slug: starter-plan-2-months-free
+    offer_slug_aliases: []
+    title: Starter Plan - 2 Months Free
+    summary: Get 100% off for 2 months on Puzzle's Starter plan for early-stage accounting.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T06:44:14.430Z
+    economics:
+      benefits:
+        - applies_to: Puzzle Starter plan
+          benefit_id: ben_01
+          description: 100% off the Starter plan for 2 months.
+          duration:
+            kind: exact
+            value: P2M
+          kind: discount
+          percentage:
+            basis_points: 10000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: constant
+        statement: Available to users signing up for the Starter plan.
+        value: true
+    roles:
+      terms_authority_entity_id: ent_01kyyts97s1w9c31cbzyjwye2h
+      access_operator_entity_id: ent_01kyyts97s1w9c31cbzyjwye2h
+    access:
+      availability: public
+      method: form
+      url: https://puzzle.io/pricing
+    source_ids:
+      - src_1218c0e1006047b76dbdb4f12f087fce02bb36ebbd981ba5508a74f39c0432b0
+  - offer_id: off_01kyyts97wvcdryhjrw1sbmz4g
+    offer_slug: mention-pulley-during-onboarding-and-get-6-months-free
+    offer_slug_aliases: []
+    title: Mention Pulley during onboarding and get 6 months free
+    summary: Get 6 months of Puzzle financial accounting software free when mentioning Pulley during onboarding.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T12:27:57.374Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: 6 months free Puzzle accounting software
+          duration:
+            kind: exact
+            value: P6M
+          kind: free-service
+          service: Puzzle platform
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: constant
+        statement: Mention Pulley during onboarding.
+        value: true
+    roles:
+      terms_authority_entity_id: ent_01kyyts97s1w9c31cbzyjwye2h
+      access_operator_entity_id: ent_01kyyr9svfavvhqt4vy0e0b25k
+    access:
+      availability: membership
+      instructions: Mention Pulley during onboarding.
+      method: contact
+    source_ids:
+      - src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d

--- a/vendors/ra/ramp.yaml
+++ b/vendors/ra/ramp.yaml
@@ -78,3 +78,38 @@ offers:
       method: other
     source_ids:
       - src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d
+  - offer_id: off_01kyyts97v7ft9qtyzmn3zf227
+    offer_slug: ramp-business-account-interest
+    offer_slug_aliases: []
+    title: Ramp Business Account Interest
+    summary: Earn up to 2% APY on operating cash held in a Ramp business account.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:35:57.122Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Earn up to 2% APY on business account operating cash.
+          kind: cashback
+          value:
+            kind: percentage
+            value:
+              basis_points: 200
+              kind: up-to
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: external-verification
+        statement: Application review and approval by Ramp and partner bank.
+    roles:
+      terms_authority_entity_id: ent_01kyh8fpe4g7kgfr7x2skc0vt3
+      access_operator_entity_id: ent_01kyh8fpe4g7kgfr7x2skc0vt3
+    access:
+      availability: public
+      method: form
+      url: https://ramp.com/startups
+    source_ids:
+      - src_d19ab8f87d18dd699257e5a42cd736410ef08227d0e692940cae6deb10f48850

--- a/vendors/re/redis.yaml
+++ b/vendors/re/redis.yaml
@@ -14,7 +14,16 @@ links:
 sources:
   - source_id: src_c1f2a9f31452ef5949b6e57fa22689e15e08347e9aac2371969f2c38c0cbbd89
     url: https://redis.io/startups/
-programs: []
+  - source_id: src_cfad910dd54bf9485e7124063448a4ab2b3d59660d3338e89c9355a69ff8efbe
+    url: https://redis.io/startups
+programs:
+  - program_id: prg_01kyyts97vc4p2yndr23a0nyt4
+    program_slug: redis-startup-program
+    program_slug_aliases: []
+    title: Redis Startup Program
+    summary: The Redis startup program offers growing businesses free Redis for 6 months, support, and go-to-market opportunities to build fast apps fast.
+    source_ids:
+      - src_cfad910dd54bf9485e7124063448a4ab2b3d59660d3338e89c9355a69ff8efbe
 offers:
   - offer_id: off_01kyh8fpe41sm83gbe300tdt1m
     offer_slug: free-redis-for-qualifying-startups
@@ -48,3 +57,47 @@ offers:
       url: https://redis.io/startups/
     source_ids:
       - src_c1f2a9f31452ef5949b6e57fa22689e15e08347e9aac2371969f2c38c0cbbd89
+  - offer_id: off_01kyyts97vf8dj3p88aahvj5vj
+    program_id: prg_01kyyts97vc4p2yndr23a0nyt4
+    offer_slug: redis-startup-program
+    offer_slug_aliases: []
+    title: Redis Startup Program
+    summary: Free Redis for 6 months with usage limits, early access to features, dedicated customer support, monthly office hours, basic support, and co-marketing opportunities for qualifying startups.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T06:44:43.244Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Free Redis for 6 months (usage limits apply)
+          duration:
+            kind: exact
+            value: P6M
+          kind: free-service
+          service: Redis
+        - benefit_id: ben_02
+          description: Early access to new Redis features and products
+          kind: other
+        - benefit_id: ben_03
+          description: Dedicated customer support, including monthly office hours and a basic support plan
+          kind: other
+        - benefit_id: ben_04
+          description: Access co-marketing opportunities and lead generation programs
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: vendor-discretion
+        statement: Qualifying startups
+    roles:
+      terms_authority_entity_id: ent_01kyh8fpe4zndzypt528e2ntzg
+      access_operator_entity_id: ent_01kyh8fpe4zndzypt528e2ntzg
+    access:
+      availability: public
+      method: form
+      url: https://redis.io/startups/
+    source_ids:
+      - src_cfad910dd54bf9485e7124063448a4ab2b3d59660d3338e89c9355a69ff8efbe

--- a/vendors/ri/rippling.yaml
+++ b/vendors/ri/rippling.yaml
@@ -1,0 +1,53 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyyts97t9540w53gq2fq5cwg
+slug: rippling
+slug_aliases: []
+name: Rippling
+domains:
+  - value: rippling.com
+    role: primary
+    valid_from: 2026-08-01T13:50:00.000Z
+category: people
+description: Rippling eliminates the friction from running a business, combining HR, IT, and Finance apps on a unified data platform.
+links:
+  site: https://rippling.com
+sources:
+  - source_id: src_49f89780293baa1f31c4eefecc5684f1d6b8e769e132db4e9bd44b877a86f2aa
+    url: https://www.rippling.com/
+  - source_id: src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d
+    url: https://pulley.com/perks
+programs: []
+offers:
+  - offer_id: off_01kyyts97wz7abt05wxcc73qk4
+    offer_slug: 6-months-free
+    offer_slug_aliases: []
+    title: 6 months free
+    summary: Get 6 months free on Rippling's employee management platform.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T12:27:57.374Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: 6 months free
+          duration:
+            kind: exact
+            value: P6M
+          kind: free-service
+          service: Rippling platform
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: constant
+        statement: Available to Pulley users.
+        value: true
+    roles:
+      terms_authority_entity_id: ent_01kyyts97t9540w53gq2fq5cwg
+      access_operator_entity_id: ent_01kyyr9svfavvhqt4vy0e0b25k
+    access:
+      availability: membership
+      method: other
+    source_ids:
+      - src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d

--- a/vendors/ri/rise.yaml
+++ b/vendors/ri/rise.yaml
@@ -1,0 +1,54 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyyts97ty4y9cavw4wr3kcz3
+slug: rise
+slug_aliases: []
+name: Rise
+domains:
+  - value: rise.com
+    role: primary
+    valid_from: 2026-08-01T13:50:00.000Z
+category: training
+description: Rise is the online training system your employees will love. Easily create, share, and manage interactive training, performance support content, guides, and online courses that work perfectly on any
+links:
+  site: https://rise.com
+sources:
+  - source_id: src_6c5f48ae73b928b5fcb0efdfd68e0ea5719ecd9c654bc2abdf25ff6e189004f2
+    url: https://rise.com/
+  - source_id: src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d
+    url: https://pulley.com/perks
+programs: []
+offers:
+  - offer_id: off_01kyyts97x9m5c492x4m8ygvys
+    offer_slug: get-10-off-when-you-mention-pulley-in-your-message
+    offer_slug_aliases: []
+    title: Get 10% off when you mention Pulley in your message
+    summary: Get 10% off Rise hybrid payroll platform when mentioning Pulley.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T12:27:57.374Z
+    economics:
+      benefits:
+        - applies_to: Rise services
+          benefit_id: ben_01
+          description: 10% off Rise services
+          kind: discount
+          percentage:
+            basis_points: 1000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: constant
+        statement: Mention Pulley in your message.
+        value: true
+    roles:
+      terms_authority_entity_id: ent_01kyyts97ty4y9cavw4wr3kcz3
+      access_operator_entity_id: ent_01kyyr9svfavvhqt4vy0e0b25k
+    access:
+      availability: membership
+      instructions: Mention Pulley in your message.
+      method: contact
+    source_ids:
+      - src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d

--- a/vendors/si/simpleclosure.yaml
+++ b/vendors/si/simpleclosure.yaml
@@ -1,0 +1,53 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyyts97t8ebaxn89bv0d6qm6
+slug: simpleclosure
+slug_aliases: []
+name: SimpleClosure
+domains:
+  - value: simpleclosure.com
+    role: primary
+    valid_from: 2026-08-01T13:50:00.000Z
+category: compliance
+description: The shutdown standard for founders and business owners. Clarity, structure, and expert handling from the first step to the final filing.
+links:
+  site: https://simpleclosure.com
+sources:
+  - source_id: src_939c69516fd213b9aed69456f29226eec4c5653f2ddd9154770fc870f7032f23
+    url: https://simpleclosure.com/
+  - source_id: src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d
+    url: https://pulley.com/perks
+programs: []
+offers:
+  - offer_id: off_01kyyts97xzmdvdpgfw3nsmr63
+    offer_slug: get-10-off-visit-to-redeem
+    offer_slug_aliases: []
+    title: Get 10% off. Visit to redeem
+    summary: Get 10% off SimpleClosure shutdown and legal filing services.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T12:27:57.374Z
+    economics:
+      benefits:
+        - applies_to: SimpleClosure services
+          benefit_id: ben_01
+          description: 10% off SimpleClosure services
+          kind: discount
+          percentage:
+            basis_points: 1000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: constant
+        statement: Available to Pulley users.
+        value: true
+    roles:
+      terms_authority_entity_id: ent_01kyyts97t8ebaxn89bv0d6qm6
+      access_operator_entity_id: ent_01kyyr9svfavvhqt4vy0e0b25k
+    access:
+      availability: membership
+      method: other
+    source_ids:
+      - src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d

--- a/vendors/sl/slack.yaml
+++ b/vendors/sl/slack.yaml
@@ -1,0 +1,83 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyyts97tdz1rtzzt919cthny
+slug: slack
+slug_aliases: []
+name: Slack
+domains:
+  - value: slack.com
+    role: primary
+    valid_from: 2026-08-01T13:50:00.000Z
+category: communication
+description: We care about your privacy. Our privacy policy will help you understand what information is collected, how it’s used and what choices you have.
+links:
+  site: https://slack.com
+sources:
+  - source_id: src_a5703a08dde126a8dceb545480be5629e0d825b2850010d50a47e9bdfb86b1f0
+    url: https://slack.com/intl/en-au/trust/privacy/privacy-policy
+  - source_id: src_aa37358989ed750304cec4c78e160fdf97b853f7a730ba6c39a35dea038dc117
+    url: https://perkbook.co/vendor-directory/slack
+programs:
+  - program_id: prg_01kyyts97x1wsbyazz8cez8dwd
+    program_slug: salesforce-launchpad
+    program_slug_aliases: []
+    title: Salesforce Launchpad
+    summary: Salesforce Launchpad provides perks for enrolled startups.
+    source_ids:
+      - src_aa37358989ed750304cec4c78e160fdf97b853f7a730ba6c39a35dea038dc117
+offers:
+  - offer_id: off_01kyyts97x6wp1yp57apfrmyz1
+    program_id: prg_01kyyts97x1wsbyazz8cez8dwd
+    offer_slug: 25-off-pro-and-business-with-slack-via-salesforce-launchpad
+    offer_slug_aliases: []
+    title: 25% off Pro and Business+ with Slack — via Salesforce Launchpad
+    summary: Startups enrolled in Salesforce Launchpad receive 25% off Slack Pro or Business+ plans.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:16:59.668Z
+    economics:
+      benefits:
+        - applies_to: Slack Pro or Business+ plans
+          benefit_id: ben_01
+          description: 25% off Slack Pro or Business+ plans
+          kind: discount
+          percentage:
+            basis_points: 2500
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.partner_memberships
+            kind: predicate
+            operator: contains
+            statement: Enrolled in Salesforce Launchpad
+            value:
+              type: string
+              value: Salesforce Launchpad
+          - kind: any
+            rules:
+              - criterion_id: cri_02
+                fact: company.is_current_customer
+                kind: predicate
+                operator: eq
+                statement: New Slack customer
+                value:
+                  type: boolean
+                  value: false
+              - criterion_id: cri_03
+                kind: manual
+                reason: external-verification
+                statement: Upgrading from free plan
+    roles:
+      terms_authority_entity_id: ent_01kyyts97tdz1rtzzt919cthny
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: membership
+      instructions: Sign Up to Unlock
+      method: other
+      url: https://perkbook.co/vendor-directory/slack
+    source_ids:
+      - src_aa37358989ed750304cec4c78e160fdf97b853f7a730ba6c39a35dea038dc117

--- a/vendors/sn/snyk.yaml
+++ b/vendors/sn/snyk.yaml
@@ -1,0 +1,63 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyyts97t571ppq7npwnk7j73
+slug: snyk
+slug_aliases: []
+name: Snyk
+domains:
+  - value: snyk.io
+    role: primary
+    valid_from: 2026-08-01T13:50:00.000Z
+category: security
+description: Snyk is the AI Security Fabric — the independent validator that makes AI-generated code, AI agents, and AI-native applications trustworthy. Unleash AI innovation securely.
+links:
+  site: https://snyk.io
+sources:
+  - source_id: src_17babe7f787baa5cf68240f15ac676878012927f58631cad5c60f380e16f28f3
+    url: https://snyk.io/
+  - source_id: src_ace9e61070087cfb13fabaa60cfd08d89c747f7381b73793b2f86b234099101f
+    url: https://perkbook.co/vendor-directory/snyk
+programs:
+  - program_id: prg_01kyyts97ypct4sqe3wg0vy5ra
+    program_slug: snyk-for-startups
+    program_slug_aliases: []
+    title: Snyk for Startups
+    summary: Snyk for Startups provides early-stage software companies free access to the Snyk developer security platform.
+    source_ids:
+      - src_ace9e61070087cfb13fabaa60cfd08d89c747f7381b73793b2f86b234099101f
+offers:
+  - offer_id: off_01kyyts97y1q5x1acb2rqa4tqp
+    program_id: prg_01kyyts97ypct4sqe3wg0vy5ra
+    offer_slug: free-developer-security-with-snyk-for-startups
+    offer_slug_aliases: []
+    title: Free developer security with Snyk for Startups
+    summary: Early-stage software companies get free access to the Snyk developer security platform to scan code, containers, open-source dependencies, and IaC for vulnerabilities.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:16:59.675Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Free access to the Snyk developer security platform
+          kind: free-service
+          service: Snyk developer security platform
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        fact: company.stage
+        kind: predicate
+        operator: eq
+        statement: Available to early-stage startups
+        value:
+          type: string
+          value: early-stage
+    roles:
+      terms_authority_entity_id: ent_01kyyts97t571ppq7npwnk7j73
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: membership
+      method: form
+      url: https://perkbook.co/vendor-directory/snyk
+    source_ids:
+      - src_ace9e61070087cfb13fabaa60cfd08d89c747f7381b73793b2f86b234099101f

--- a/vendors/st/stytch.yaml
+++ b/vendors/st/stytch.yaml
@@ -1,0 +1,84 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyyts97t86xxhk66xc34bjvs
+slug: stytch
+slug_aliases: []
+name: Stytch
+domains:
+  - value: stytch.com
+    role: primary
+    valid_from: 2026-08-01T13:50:00.000Z
+category: security
+description: APIs and SDKs to integrate authentication and security into your app.
+links:
+  site: https://stytch.com
+sources:
+  - source_id: src_57b4079771e2b0b3f248e940d92e2833f727ff5f362c909241183a21e3b09c76
+    url: https://stytch.com/
+  - source_id: src_1d28545b15b0f85210fb42564078baece3e558a8f4fe4e95250f680f9abce844
+    url: https://perkbook.co/vendor-directory/stytch
+programs:
+  - program_id: prg_01kyyts97y0k39nb4pa1hhays8
+    program_slug: stytch-for-startups
+    program_slug_aliases: []
+    title: Stytch for Startups
+    summary: Stytch for Startups gives qualifying early-stage companies free access to the Stytch authentication platform.
+    source_ids:
+      - src_1d28545b15b0f85210fb42564078baece3e558a8f4fe4e95250f680f9abce844
+offers:
+  - offer_id: off_01kyyts97yaqe3dscp7brf8t2r
+    program_id: prg_01kyyts97y0k39nb4pa1hhays8
+    offer_slug: free-authentication-platform-with-stytch-for-startups
+    offer_slug_aliases: []
+    title: Free authentication platform with Stytch for Startups
+    summary: Qualifying early-stage startups get free access to the Stytch auth and fraud prevention platform.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:17:26.920Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Free access to the Stytch authentication platform
+          kind: free-service
+          service: Stytch authentication platform
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: Must have raised under $10M
+            value:
+              type: number
+              value: 10000000
+          - criterion_id: cri_02
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: Must be new Stytch customers
+            value:
+              type: boolean
+              value: false
+          - criterion_id: cri_03
+            fact: company.industry
+            kind: predicate
+            operator: in
+            statement: Must be B2B SaaS, fintech, or e-commerce startups
+            value:
+              type: string-set
+              values:
+                - B2B SaaS
+                - fintech
+                - e-commerce
+    roles:
+      terms_authority_entity_id: ent_01kyyts97t86xxhk66xc34bjvs
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: membership
+      method: form
+      url: https://perkbook.co/vendor-directory/stytch
+    source_ids:
+      - src_1d28545b15b0f85210fb42564078baece3e558a8f4fe4e95250f680f9abce844

--- a/vendors/te/techdollar.yaml
+++ b/vendors/te/techdollar.yaml
@@ -1,0 +1,49 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyyts97tfc5g1ehvpqpz9b3g
+slug: techdollar
+slug_aliases: []
+name: techdollar
+domains:
+  - value: techdollar.com
+    role: primary
+    valid_from: 2026-08-01T13:50:00.000Z
+category: financial
+description: Structured lending for individuals and investors at leading frontier technology companies.
+links:
+  site: https://techdollar.com
+sources:
+  - source_id: src_64d173cb144512b1379ed78cd22b951c147365e95d4a64a35a3b4fdada6cc062
+    url: https://techdollar.com/
+  - source_id: src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d
+    url: https://pulley.com/perks
+programs: []
+offers:
+  - offer_id: off_01kyyts97y0dasyvjykmzkas6a
+    offer_slug: discounted-rates-for-borrowers-with-equity-held-on-pulley
+    offer_slug_aliases: []
+    title: Discounted rates for borrowers with equity held on Pulley
+    summary: Receive discounted loan borrowing rates when collateralizing equity held on Pulley.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T12:27:57.374Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Discounted borrowing rates
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: constant
+        statement: Borrowers with equity held on Pulley.
+        value: true
+    roles:
+      terms_authority_entity_id: ent_01kyyts97tfc5g1ehvpqpz9b3g
+      access_operator_entity_id: ent_01kyyr9svfavvhqt4vy0e0b25k
+    access:
+      availability: membership
+      method: other
+    source_ids:
+      - src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d

--- a/vendors/th/the-swarm.yaml
+++ b/vendors/th/the-swarm.yaml
@@ -1,0 +1,62 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyyts97tpxmfh63db6h6jmxx
+slug: the-swarm
+slug_aliases: []
+name: The Swarm
+domains:
+  - value: theswarm.com
+    role: primary
+    valid_from: 2026-08-01T13:50:00.000Z
+category: sales
+description: The Swarm curates a rich dataset of 580M profiles with daily job changes, 100M companies with fundraising data, and a unique relationship mapping technology for builders and investors.
+links:
+  site: https://theswarm.com
+sources:
+  - source_id: src_542c2b80b81a62939836f767735b1c430b78501e58f3c5e15f598ee2f8415574
+    url: https://www.theswarm.com/
+  - source_id: src_eaddcd07533be82597727c39ed4bf892af10e6ccea2fa80d98148d92705976f9
+    url: https://perkbook.co/vendor-directory/the
+programs:
+  - program_id: prg_01kyyts97xhd7eqb8jn4ath6rm
+    program_slug: the-swarm-startup-program
+    program_slug_aliases: []
+    title: The Swarm Startup Program
+    summary: The Swarm Startup Program provides offers and perks for startups using The Swarm network intelligence platform.
+    source_ids:
+      - src_eaddcd07533be82597727c39ed4bf892af10e6ccea2fa80d98148d92705976f9
+offers:
+  - offer_id: off_01kyyts97x2gnknxdt3n2jsxgr
+    program_id: prg_01kyyts97xhd7eqb8jn4ath6rm
+    offer_slug: 1-year-free-with-the-swarm-for-startups
+    offer_slug_aliases: []
+    title: 1 year free with The Swarm for Startups
+    summary: Startups get 1 year of free access to The Swarm network intelligence platform.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:17:26.928Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: 1 year of free service with The Swarm for Startups
+          duration:
+            kind: exact
+            value: P1Y
+          kind: free-service
+          service: The Swarm for Startups
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: constant
+        statement: Available to all startups
+        value: true
+    roles:
+      terms_authority_entity_id: ent_01kyyts97tpxmfh63db6h6jmxx
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: membership
+      method: other
+      url: https://perkbook.co/vendor-directory/the
+    source_ids:
+      - src_eaddcd07533be82597727c39ed4bf892af10e6ccea2fa80d98148d92705976f9

--- a/vendors/tw/twilio.yaml
+++ b/vendors/tw/twilio.yaml
@@ -1,0 +1,66 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyyts97tg62epymp01r8t62x
+slug: twilio
+slug_aliases: []
+name: twilio
+domains:
+  - value: twilio.com
+    role: primary
+    valid_from: 2026-08-01T13:50:00.000Z
+category: communication
+description: Build amazing customer experiences on the Twilio platform with APIs for SMS, RCS, voice, and email, plus conversational AI for smarter engagement, and identity verification for trust.
+links:
+  site: https://twilio.com
+sources:
+  - source_id: src_8b3cca7df388cc3512ce2f63771b5907f79342a1c62b86e217c778a55fab7872
+    url: https://www.twilio.com/en-us
+  - source_id: src_511c3f56c6102bae03861aa9ab7e0f0d1abc8aed735be85b20e21b6468d8fbbb
+    url: https://perkbook.co/vendor-directory/twilio
+programs:
+  - program_id: prg_01kyyts97x7mr6fgm40hzz2bc1
+    program_slug: twilio-for-startups
+    program_slug_aliases: []
+    title: Twilio for Startups
+    summary: Twilio for Startups gives early-stage companies free resources; API credits; and access to Twilio communications infrastructure covering SMS; voice; WhatsApp; email; and AI-powered customer engagement tools.
+    source_ids:
+      - src_511c3f56c6102bae03861aa9ab7e0f0d1abc8aed735be85b20e21b6468d8fbbb
+offers:
+  - offer_id: off_01kyyts97x16681bavkagybafr
+    program_id: prg_01kyyts97x7mr6fgm40hzz2bc1
+    offer_slug: 500-twilio-for-startups-credits-and-free-resources
+    offer_slug_aliases: []
+    title: $500 Twilio for Startups Credits and Free Resources
+    summary: Early-stage startups can receive $500 in Twilio credits and access to free resources covering SMS, voice, WhatsApp, email, and AI tools.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:17:26.929Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: $500 USD in Twilio API credits and free resources
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 50000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        fact: company.stage
+        kind: predicate
+        operator: eq
+        statement: Available to early-stage startups
+        value:
+          type: string
+          value: early-stage
+    roles:
+      terms_authority_entity_id: ent_01kyyts97tg62epymp01r8t62x
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: membership
+      method: other
+    source_ids:
+      - src_511c3f56c6102bae03861aa9ab7e0f0d1abc8aed735be85b20e21b6468d8fbbb

--- a/vendors/ty/typeform.yaml
+++ b/vendors/ty/typeform.yaml
@@ -14,7 +14,16 @@ links:
 sources:
   - source_id: src_2142b211d7f3a133a55a0454789308aa35b4ea13453a4ade8c56f485a2a0e8a9
     url: https://help.typeform.com/hc/en-us/articles/360045878891-Startup-discount-at-Typeform
-programs: []
+  - source_id: src_45ff19615a1aeaf68137fedfd0c3c1d7090d550af82d4fd44925756fc139a08d
+    url: https://typeform.com/typeform-startups
+programs:
+  - program_id: prg_01kyyts97vvvzftz25kpmyqexd
+    program_slug: typeform-for-startups
+    program_slug_aliases: []
+    title: Typeform for Startups
+    summary: Typeform for Startups provides eligible early-stage startups with discounts on Typeform annual Business plans.
+    source_ids:
+      - src_45ff19615a1aeaf68137fedfd0c3c1d7090d550af82d4fd44925756fc139a08d
 offers:
   - offer_id: off_01kyy6rm11g27a3qdqh4bedb2x
     offer_slug: typeform-startup-discount
@@ -83,3 +92,68 @@ offers:
       url: https://help.typeform.com/hc/en-us/articles/360045878891-Startup-discount-at-Typeform
     source_ids:
       - src_2142b211d7f3a133a55a0454789308aa35b4ea13453a4ade8c56f485a2a0e8a9
+  - offer_id: off_01kyyts97v6ykdrf6fks01qdgz
+    program_id: prg_01kyyts97vvvzftz25kpmyqexd
+    offer_slug: typeform-for-startups-discount
+    offer_slug_aliases: []
+    title: Typeform for Startups Discount
+    summary: Eligible startups receive up to 75% off Typeform annual Business plans.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T07:46:21.027Z
+    economics:
+      benefits:
+        - applies_to: Annual Business plans
+          benefit_id: ben_01
+          description: Up to 75% off annual Business plans
+          kind: discount
+          percentage:
+            basis_points: 7500
+            kind: up-to
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: Must not already be a paying Typeform customer
+            value:
+              type: boolean
+              value: false
+          - criterion_id: cri_02
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: Less than $5M in funding
+            value:
+              type: number
+              value: 5000000
+          - criterion_id: cri_03
+            fact: company.employee_count
+            kind: predicate
+            operator: lt
+            statement: Less than 50 employees
+            value:
+              type: number
+              value: 50
+          - criterion_id: cri_04
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: Less than 5 years old
+            value:
+              type: number
+              value: 60
+    roles:
+      terms_authority_entity_id: ent_01kyy6rm11pr34gjj52the9v91
+      access_operator_entity_id: ent_01kyy6rm11pr34gjj52the9v91
+    access:
+      availability: public
+      method: form
+      url: https://typeform.com/typeform-startups
+    source_ids:
+      - src_45ff19615a1aeaf68137fedfd0c3c1d7090d550af82d4fd44925756fc139a08d

--- a/vendors/vi/visible.yaml
+++ b/vendors/vi/visible.yaml
@@ -1,0 +1,51 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyyts97tqh1939spnpyz6kef
+slug: visible
+slug_aliases: []
+name: Visible
+domains:
+  - value: visible.vc
+    role: primary
+    valid_from: 2026-08-01T13:50:00.000Z
+category: fundraising
+description: 950+ VC funds use Visible to turn scattered portfolio data into answers. 7,000+ founders use it to raise faster and keep investors close.
+links:
+  site: https://visible.vc
+sources:
+  - source_id: src_32296addae3433f07c07985960a055ab74f2d7e4c72ddca7e1294e09bbee18fd
+    url: https://visible.vc/
+  - source_id: src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d
+    url: https://pulley.com/perks
+programs: []
+offers:
+  - offer_id: off_01kyyts97xxdjs3vncd5p0qhwj
+    offer_slug: companies-get-access-to-the-starter-plan-at-no-cost-with-the-code-pulley690
+    offer_slug_aliases: []
+    title: Companies get access to the Starter Plan at no cost with the code PULLEY690.
+    summary: Get access to the Visible Starter Plan at no cost using code PULLEY690.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T12:27:57.374Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Access to Starter Plan at no cost
+          kind: free-service
+          service: Visible Starter Plan
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: constant
+        statement: Use code PULLEY690.
+        value: true
+    roles:
+      terms_authority_entity_id: ent_01kyyts97tqh1939spnpyz6kef
+      access_operator_entity_id: ent_01kyyr9svfavvhqt4vy0e0b25k
+    access:
+      availability: public
+      method: code
+      public_code: PULLEY690
+    source_ids:
+      - src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d

--- a/vendors/vo/vouch.yaml
+++ b/vendors/vo/vouch.yaml
@@ -1,0 +1,53 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyyts97tryy2fc40wrck4qj1
+slug: vouch
+slug_aliases: []
+name: Vouch
+domains:
+  - value: vouch.us
+    role: primary
+    valid_from: 2026-08-01T13:50:00.000Z
+category: insurance
+description: Vouch is the technology-powered insurance broker for growing companies. Expert coverage, digital tools, and industry-specific protection built for your next milestone.
+links:
+  site: https://vouch.us
+sources:
+  - source_id: src_e2d13c48367aee606d15d7eef91db7b99ec9987debb764340686ff930a2367c5
+    url: https://www.vouch.us/
+  - source_id: src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d
+    url: https://pulley.com/perks
+programs: []
+offers:
+  - offer_id: off_01kyyts97x2xzetfat5waejvtb
+    offer_slug: 5-off-insurance-with-vouch
+    offer_slug_aliases: []
+    title: 5% off insurance with Vouch
+    summary: Get 5% off insurance coverage for your startup with Vouch.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T12:27:57.374Z
+    economics:
+      benefits:
+        - applies_to: insurance
+          benefit_id: ben_01
+          description: 5% off insurance with Vouch
+          kind: discount
+          percentage:
+            basis_points: 500
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: constant
+        statement: Available to Pulley users.
+        value: true
+    roles:
+      terms_authority_entity_id: ent_01kyyts97tryy2fc40wrck4qj1
+      access_operator_entity_id: ent_01kyyr9svfavvhqt4vy0e0b25k
+    access:
+      availability: membership
+      method: other
+    source_ids:
+      - src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d

--- a/vendors/wa/warp.yaml
+++ b/vendors/wa/warp.yaml
@@ -1,0 +1,59 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyyts97tcznwmnxa1ehcfvaa
+slug: warp
+slug_aliases: []
+name: Warp
+domains:
+  - value: joinwarp.com
+    role: primary
+    valid_from: 2026-08-01T13:50:00.000Z
+  - value: warp.co
+    role: alias
+    valid_from: 2026-08-01T13:50:00.000Z
+category: hr
+description: Warp is the AI-native employee management platform for high-growth companies. Payroll, compliance, and benefits that scale from 10 to 1000+ employees—all on autopilot.
+links:
+  site: https://warp.co
+sources:
+  - source_id: src_b342e78c18af71c0e3fad78b9b15e12d7920db5552ddc90f0d6277230349b290
+    url: https://www.warp.co/
+  - source_id: src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d
+    url: https://pulley.com/perks
+programs: []
+offers:
+  - offer_id: off_01kyyts97x0p3v0w8vx6qz42gc
+    offer_slug: get-3-months-free-a-dedicated-account-manager-and-a-benefits-advisor-when-you-si
+    offer_slug_aliases: []
+    title: Get 3 months free, a dedicated Account Manager, and a Benefits Advisor when you sign up for any plan on Warp.
+    summary: Receive 3 months free, a dedicated Account Manager, and a Benefits Advisor on Warp.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T12:27:57.374Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: 3 months free when you sign up for any plan on Warp
+          duration:
+            kind: exact
+            value: P3M
+          kind: free-service
+          service: Warp platform
+        - benefit_id: ben_02
+          description: Dedicated Account Manager and Benefits Advisor
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: constant
+        statement: Sign up for any plan on Warp via Pulley.
+        value: true
+    roles:
+      terms_authority_entity_id: ent_01kyyts97tcznwmnxa1ehcfvaa
+      access_operator_entity_id: ent_01kyyr9svfavvhqt4vy0e0b25k
+    access:
+      availability: membership
+      method: other
+    source_ids:
+      - src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d

--- a/vendors/we/webflow.yaml
+++ b/vendors/we/webflow.yaml
@@ -1,0 +1,88 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyyts97tw201a54k874p582j
+slug: webflow
+slug_aliases: []
+name: Webflow
+domains:
+  - value: webflow.com
+    role: primary
+    valid_from: 2026-08-01T13:50:00.000Z
+category: code
+description: Design, build, optimize, and rank in AI search — all in Webflow. Enterprise-grade security, CMS, hosting, and AEO built in. Trusted by over 300k teams.
+links:
+  site: https://webflow.com
+sources:
+  - source_id: src_3b7f0693c2fe4e9389779a6465308c00b52f2b7b0912be86c2dddba240b6f7b8
+    url: https://webflow.com/
+  - source_id: src_6cc03b5900b9769f04004bc9827f822fbf78372f5c83295afa4f08803dca29e7
+    url: https://perkbook.co/vendor-directory/webflow
+programs:
+  - program_id: prg_01kyyts97xvxe61g6c13paysdv
+    program_slug: webflow-for-startups
+    program_slug_aliases: []
+    title: Webflow for Startups
+    summary: Webflow for Startups offers eligible early-stage companies free access to Webflow's CMS plan for building marketing sites.
+    source_ids:
+      - src_6cc03b5900b9769f04004bc9827f822fbf78372f5c83295afa4f08803dca29e7
+offers:
+  - offer_id: off_01kyyts97x4wqg62nam8yejq5e
+    program_id: prg_01kyyts97xvxe61g6c13paysdv
+    offer_slug: 1-year-free-cms-plan-with-webflow-for-startups
+    offer_slug_aliases: []
+    title: 1 year free CMS Plan with Webflow for Startups
+    summary: Eligible startups receive one full year free on the Webflow CMS Site plan.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:17:55.654Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: 1 year free on the Webflow CMS Site plan
+          duration:
+            kind: exact
+            value: P1Y
+          kind: free-service
+          service: CMS Site plan
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.employee_count
+            kind: predicate
+            operator: lt
+            statement: Under 50 employees
+            value:
+              type: number
+              value: 50
+          - criterion_id: cri_02
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: Raised less than $15M
+            value:
+              type: number
+              value: 15000000
+          - criterion_id: cri_03
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: New Webflow customer
+            value:
+              type: boolean
+              value: false
+          - criterion_id: cri_04
+            kind: manual
+            reason: external-verification
+            statement: Referred by an approved Webflow startup partner
+    roles:
+      terms_authority_entity_id: ent_01kyyts97tw201a54k874p582j
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: referral
+      instructions: Sign Up to Unlock
+      method: other
+    source_ids:
+      - src_6cc03b5900b9769f04004bc9827f822fbf78372f5c83295afa4f08803dca29e7

--- a/vendors/za/zapier.yaml
+++ b/vendors/za/zapier.yaml
@@ -1,0 +1,70 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kyyts97tghgjktasgc05vqj2
+slug: zapier
+slug_aliases: []
+name: Zapier
+domains:
+  - value: zapier.com
+    role: primary
+    valid_from: 2026-08-01T13:50:00.000Z
+category: code
+description: Build and scale AI workflows and agents across 9,000+ apps with Zapier—the most connected AI orchestration platform. Trusted by 3 million+ businesses.
+links:
+  site: https://zapier.com
+sources:
+  - source_id: src_1ac2e617ebbc05ad032583bbb8dde7022d9ed6ecf594c0493ae4edb3996dd4d6
+    url: https://zapier.com/
+  - source_id: src_ab9c2c5701f886bfd3cf14d56f949f7894854b1026181d7273931856c10e7472
+    url: https://perkbook.co/vendor-directory/zapier
+programs:
+  - program_id: prg_01kyyts97xbwwymek4ge0064ym
+    program_slug: zapier-for-startups
+    program_slug_aliases: []
+    title: Zapier for Startups
+    summary: Zapier for Startups offers early-stage teams discounts and free trial access to Zapier's no-code automation platform.
+    source_ids:
+      - src_ab9c2c5701f886bfd3cf14d56f949f7894854b1026181d7273931856c10e7472
+offers:
+  - offer_id: off_01kyyts97xp750r16w9why4kj3
+    program_id: prg_01kyyts97xbwwymek4ge0064ym
+    offer_slug: 33-off-annual-plans-with-zapier-for-startups
+    offer_slug_aliases: []
+    title: 33% off annual plans with Zapier for Startups
+    summary: Early-stage startups get a 14-day free trial plus 33% off annual plans with Zapier for Startups.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-01T08:17:55.660Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: 14 days free
+          duration:
+            kind: exact
+            value: P14D
+          kind: free-service
+          service: Zapier annual plan
+        - applies_to: annual plans
+          benefit_id: ben_02
+          description: 33% off annual plans
+          kind: discount
+          percentage:
+            basis_points: 3300
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: vendor-discretion
+        statement: Available to qualifying early-stage startups
+    roles:
+      terms_authority_entity_id: ent_01kyyts97tghgjktasgc05vqj2
+      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+    access:
+      availability: membership
+      instructions: Sign Up to Unlock
+      method: other
+      url: https://perkbook.co/vendor-directory/zapier
+    source_ids:
+      - src_ab9c2c5701f886bfd3cf14d56f949f7894854b1026181d7273931856c10e7472


### PR DESCRIPTION
Adds the final 67 distinct, evidence-reviewed startup offers in the +200 campaign.\n\n- 37 new vendor identities\n- 31 new programs\n- 67 net-new offers\n- changed-only catalog validation and admission\n- target live total: 306 offers