### PR TITLE
ci: separate public validation from private admission

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -51,7 +51,6 @@ jobs:
             --strip-components=1 \
             -C "$RUNNER_TEMP/candidate-verifier"
       - name: Validate only the changed identity closure
-        id: change
         env:
           BASE_REVISION: ${{ github.event.pull_request.base.sha }}
           HEAD_REVISION: ${{ github.event.pull_request.head.sha }}
@@ -61,38 +60,19 @@ jobs:
             --repository "$GITHUB_WORKSPACE" \
             --base "$BASE_REVISION" \
             --head "$HEAD_REVISION"
-          if git diff --quiet "$BASE_REVISION" "$HEAD_REVISION" -- vendors; then
-            echo "vendors=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "vendors=true" >> "$GITHUB_OUTPUT"
-          fi
-      - name: Verify the exact reviewed data admission
-        if: steps.change.outputs.vendors == 'true'
+      - name: Verify Developer Certificate of Origin sign-off
         env:
+          BASE_REVISION: ${{ github.event.pull_request.base.sha }}
           HEAD_REVISION: ${{ github.event.pull_request.head.sha }}
         run: |
-          source_tree="$(git rev-parse "$HEAD_REVISION^{tree}")"
-          origin="https://artifacts.sourcey.com/catalog/data/admissions/tree-${source_tree}"
-          archive="sourcey-catalog-admission.tar.gz"
-          curl --fail-with-body --silent --show-error --max-time 120 \
-            --output "$RUNNER_TEMP/$archive" "$origin/$archive"
-          curl --fail-with-body --silent --show-error --max-time 120 \
-            --output "$RUNNER_TEMP/$archive.sha256" "$origin/$archive.sha256"
-          (
-            cd "$RUNNER_TEMP"
-            sha256sum --check "$archive.sha256"
-          )
-          tar -tzf "$RUNNER_TEMP/$archive" > "$RUNNER_TEMP/admission-members.txt"
-          if grep -Eq '(^$|^/|(^|/)\.\.?(/|$)|\\)' "$RUNNER_TEMP/admission-members.txt"; then
-            echo "Admission archive contains an unsafe member path." >&2
-            exit 1
-          fi
-          if sort "$RUNNER_TEMP/admission-members.txt" | uniq -d | grep -q .; then
-            echo "Admission archive repeats a member path." >&2
-            exit 1
-          fi
-          if tar -tvzf "$RUNNER_TEMP/$archive" \
-            | awk 'substr($0, 1, 1) != "-" { found=1 } END { exit !found }'; then
-            echo "Admission archive contains a non-regular member." >&2
+          missing=()
+          while IFS= read -r commit; do
+            if ! git show -s --format=%B "$commit" \
+              | grep -Eq '^Signed-off-by: .+ <[^>]+>$'; then
+              missing+=("$commit")
+            fi
+          done < <(git rev-list "$BASE_REVISION..$HEAD_REVISION")
+          if (( ${#missing[@]} > 0 )); then
+            printf 'Commits missing Signed-off-by certification:\n%s\n' "${missing[*]}" >&2
             exit 1
           fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,9 @@ that identity-derived path.
 - Sign off commits using `Signed-off-by: Name <email>` to certify the
   [Developer Certificate of Origin](https://developercertificate.org/).
 
-CI validates only the changed dependency closure through the exact
-digest-pinned Sourcey Candidate Verifier. A required external admission check
-binds evidence to the exact pull-request head. Once an admitted pull request is
-merged, publication and live activation are automatic.
+The repository's `validate` check validates only the changed dependency closure
+through the exact digest-pinned Sourcey Candidate Verifier and enforces the DCO.
+Sourcey's separate required `sourcey/admission` check proves that private,
+replayable evidence and authority were admitted for the exact pull-request Git
+tree; contributors never upload that private material. Once both checks pass and
+the pull request is merged, publication and live activation are automatic.


### PR DESCRIPTION
Keeps the public repository boundary minimal: validate now checks only the changed catalog closure and DCO, while the independently issued sourcey/admission status owns private evidence admission for the exact Git tree. No catalog data or product code changes.