### PR TITLE
Add ClickHouse YC startup credits

### DIFF
--- a/vendors/cl/clickhouse.yaml
+++ b/vendors/cl/clickhouse.yaml
@@ -1,0 +1,63 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kz1g8thkc3kg920cqaz2zfjs
+slug: clickhouse
+slug_aliases: []
+name: ClickHouse
+domains:
+  - value: clickhouse.com
+    role: primary
+    valid_from: 2026-08-02T15:07:54.000Z
+category: databases
+description: ClickHouse provides a cloud-native database for real-time analytics at scale.
+links:
+  site: https://clickhouse.com
+sources:
+  - source_id: src_a6c773b745e9bf437c51fc2e749c22eb67dede631d13538b6a0c0fee25327a4c
+    url: https://clickhouse.com/deals/ycombinator
+programs: []
+offers:
+  - offer_id: off_01kz1g8v2kdx4328fvd40s0q9y
+    offer_slug: y-combinator-cloud-credits
+    offer_slug_aliases: []
+    title: Y Combinator + ClickHouse Cloud credits
+    summary: Eligible Y Combinator startups receive $10,000 in ClickHouse Cloud credits valid for 24 months, Basic Support, a one-hour expert training session, and promotional opportunities.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-02T15:07:54.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: $10,000 in ClickHouse Cloud credits valid for 24 months
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 1000000
+            kind: exact
+        - benefit_id: ben_02
+          description: ClickHouse Basic Support
+          kind: other
+        - benefit_id: ben_03
+          description: One-hour expert training session
+          kind: other
+        - benefit_id: ben_04
+          description: Opportunities for a joint blog feature, channel promotion, and speaking at ClickHouse community events
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: external-verification
+        statement: Applicant must be an eligible Y Combinator startup with a valid YC secret code, must not have raised a Series D or later round, and must not be a current ClickHouse Cloud customer.
+    roles:
+      terms_authority_entity_id: ent_01kz1g8thkc3kg920cqaz2zfjs
+      access_operator_entity_id: ent_01kz1g8thkc3kg920cqaz2zfjs
+    access:
+      availability: membership
+      instructions: Sign up for a ClickHouse Cloud trial, then submit the application with the ClickHouse Organization ID and company details for review.
+      method: form
+      url: https://clickhouse.com/deals/ycombinator
+    source_ids:
+      - src_a6c773b745e9bf437c51fc2e749c22eb67dede631d13538b6a0c0fee25327a4c


### PR DESCRIPTION
## Summary

Adds ClickHouse as one new vendor with its current Y Combinator startup offer: $10,000 in ClickHouse Cloud credits valid for 24 months, Basic Support, a one-hour expert training session, and promotional opportunities.

## Source

- https://clickhouse.com/deals/ycombinator

## Scope

- One new vendor YAML
- One offer
- Data only
- Canonical candidate validator passes locally

Signed-off-by: Dracothefirst <dareen.l.belvu@gmail.com>