### PR TITLE
catalog: add CircleCI startup program

### DIFF
--- a/vendors/ci/circleci.yaml
+++ b/vendors/ci/circleci.yaml
@@ -1,0 +1,107 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kz1gt52w0xhyz9phcj1k3ksz
+slug: circleci
+slug_aliases: []
+name: CircleCI
+domains:
+  - value: circleci.com
+    role: primary
+    valid_from: 2026-08-02T15:17:22.000Z
+category: ci-cd
+description: CircleCI is a continuous integration and delivery platform for automating software build, test, and deployment workflows.
+links:
+  site: https://circleci.com
+sources:
+  - source_id: src_e5a5ed476ffee42b40459b102d2dd846b9b34a19ac568e98ed1ce703a86f5645
+    url: https://circleci.com/startup-program/
+programs:
+  - program_id: prg_01kz1gt52wapkxg17kdgtnmjym
+    program_slug: circleci-for-startups
+    program_slug_aliases: []
+    title: CircleCI for Startups
+    summary: CircleCI's startup program provides eligible early-stage companies with compute credits, support, and guided onboarding for CI/CD pipelines.
+    source_ids:
+      - src_e5a5ed476ffee42b40459b102d2dd846b9b34a19ac568e98ed1ce703a86f5645
+offers:
+  - offer_id: off_01kz1gt52ws65aa9a32b5zjybk
+    program_id: prg_01kz1gt52wapkxg17kdgtnmjym
+    offer_slug: up-to-20000-compute-credits-for-up-to-24-months
+    offer_slug_aliases: []
+    title: Up to $20,000 in CircleCI compute credits for up to 24 months
+    summary: Eligible early-stage startups receive up to $20,000 in CircleCI compute credits for a promotional period of up to 24 months, plus Starter Support and guided onboarding and pipeline configuration support.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-02T15:17:22.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $20,000 in CircleCI compute credits for a promotional period of up to 24 months
+          duration:
+            kind: up-to
+            value: P24M
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 2000000
+            kind: up-to
+        - benefit_id: ben_02
+          description: Starter Support, valued by CircleCI at $249 per month, at no cost during the promotional period
+          kind: free-service
+          service: CircleCI Starter Support
+        - benefit_id: ben_03
+          description: Guided onboarding and pipeline configuration support, including pipeline architecture and migration guidance
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: Applicant must be new to CircleCI or currently use the CircleCI Free plan.
+          - criterion_id: cri_02
+            fact: company.stage
+            kind: predicate
+            operator: in
+            statement: Company is at Pre-Seed, Seed, or Series A stage.
+            value:
+              type: string-set
+              values:
+                - pre-seed
+                - seed
+                - series_a
+          - criterion_id: cri_03
+            fact: company.age_months
+            kind: predicate
+            operator: lte
+            statement: Company was founded within the last 5 years.
+            value:
+              type: number
+              value: 60
+          - kind: any
+            rules:
+              - criterion_id: cri_04
+                kind: manual
+                reason: external-verification
+                statement: Company is part of a recognized accelerator or venture capital portfolio.
+              - criterion_id: cri_05
+                fact: company.funding_raised_usd
+                kind: predicate
+                operator: gte
+                statement: Company has raised at least $500,000 USD.
+                value:
+                  type: number
+                  value: 500000
+    roles:
+      terms_authority_entity_id: ent_01kz1gt52w0xhyz9phcj1k3ksz
+      access_operator_entity_id: ent_01kz1gt52w0xhyz9phcj1k3ksz
+    access:
+      availability: public
+      method: form
+      url: https://circleci.com/startup-program/
+    terms_url: https://circleci.com/legal/terms-of-service/
+    source_ids:
+      - src_e5a5ed476ffee42b40459b102d2dd846b9b34a19ac568e98ed1ce703a86f5645


### PR DESCRIPTION
## What changed

Adds CircleCI and its public startup program as one new vendor YAML. The offer records up to $20,000 in compute credits for a promotional period of up to 24 months, Starter Support, guided onboarding, and the vendor's published eligibility requirements.

## Sources

- https://circleci.com/startup-program/
- https://circleci.com/legal/terms-of-service/

## Certification

- [x] I changed only allowed repository content and did not mix vendor YAML with other paths.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commit includes a `Signed-off-by` line.
