### PR TITLE
catalog: add ClickHouse YC startup offer

### DIFF
--- a/vendors/cl/clickhouse.yaml
+++ b/vendors/cl/clickhouse.yaml
@@ -1,0 +1,77 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kz1hehnpkvje3yn1zkfem2bd
+slug: clickhouse
+slug_aliases: []
+name: ClickHouse
+domains:
+  - value: clickhouse.com
+    role: primary
+    valid_from: 2026-08-02T15:28:30.390Z
+category: databases
+description: Real-time analytical database and managed cloud service for high-performance queries over large data volumes.
+links:
+  site: https://clickhouse.com
+sources:
+  - source_id: src_a6c773b745e9bf437c51fc2e749c22eb67dede631d13538b6a0c0fee25327a4c
+    url: https://clickhouse.com/deals/ycombinator
+  - source_id: src_1f6156f04e6f01d00ac9ec86a4344d14cf701f444bf133c49ced541a92e07f9c
+    url: https://clickhouse.com/legal/agreements/cloud-startup-program
+programs:
+  - program_id: prg_01kz1hehnpfbkpawqv3xphk1nw
+    program_slug: y-combinator-plus-clickhouse
+    program_slug_aliases: []
+    title: Y Combinator + ClickHouse
+    summary: ClickHouse provides qualifying Y Combinator startups with ClickHouse Cloud credits, support, and expert training.
+    source_ids:
+      - src_a6c773b745e9bf437c51fc2e749c22eb67dede631d13538b6a0c0fee25327a4c
+      - src_1f6156f04e6f01d00ac9ec86a4344d14cf701f444bf133c49ced541a92e07f9c
+offers:
+  - offer_id: off_01kz1hehnp4jeamc88gqj5gr40
+    program_id: prg_01kz1hehnpfbkpawqv3xphk1nw
+    offer_slug: 10000-in-clickhouse-cloud-credits-for-24-months
+    offer_slug_aliases: []
+    title: $10,000 in ClickHouse Cloud credits for 24 months
+    summary: Qualifying Y Combinator startups receive $10,000 in ClickHouse Cloud credits valid for 24 months, ClickHouse Basic Support, and a one-hour expert training session.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-02T15:28:30.390Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: $10,000 in ClickHouse Cloud credits valid for 24 months
+          duration:
+            kind: exact
+            value: P24M
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 1000000
+            kind: exact
+        - benefit_id: ben_02
+          description: ClickHouse Basic Support included
+          kind: free-service
+          service: ClickHouse Basic Support
+        - benefit_id: ben_03
+          description: One-hour expert training session
+          kind: other
+      consideration:
+        kind: unknown
+        description: The public program page and agreement do not establish separate consideration.
+    eligibility:
+      rule:
+        criterion_id: cri_requirement_01
+        kind: manual
+        reason: not-machine-evaluable
+        statement: Applicant must be part of the current Y Combinator program, be pre-Series D, have a valid YC secret code, and not be a current ClickHouse Cloud customer.
+    roles:
+      terms_authority_entity_id: ent_01kz1hehnpkvje3yn1zkfem2bd
+      access_operator_entity_id: ent_01kz1hehnpkvje3yn1zkfem2bd
+    access:
+      availability: public
+      method: form
+      url: https://clickhouse.com/deals/ycombinator
+    terms_url: https://clickhouse.com/legal/agreements/cloud-startup-program
+    source_ids:
+      - src_a6c773b745e9bf437c51fc2e749c22eb67dede631d13538b6a0c0fee25327a4c
+      - src_1f6156f04e6f01d00ac9ec86a4344d14cf701f444bf133c49ced541a92e07f9c


### PR DESCRIPTION
## What changed

Adds ClickHouse and its public Y Combinator startup offer as one new vendor YAML. The offer records $10,000 in ClickHouse Cloud credits valid for 24 months, Basic Support, a one-hour expert training session, and the published eligibility requirements.

## Sources

- https://clickhouse.com/deals/ycombinator
- https://clickhouse.com/legal/agreements/cloud-startup-program

## Certification

- [x] I changed only allowed repository content and did not mix vendor YAML with other paths.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commits include a `Signed-off-by` line.
