### PR TITLE
catalog: add GitBook Startups Program

### DIFF
--- a/vendors/gi/gitbook.yaml
+++ b/vendors/gi/gitbook.yaml
@@ -1,0 +1,83 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kz1mhcd8y5dwg183vwmypzr9
+slug: gitbook
+slug_aliases: []
+name: GitBook
+domains:
+  - value: gitbook.com
+    role: primary
+    valid_from: 2026-08-02T16:22:29.018Z
+category: productivity
+description: GitBook is a documentation platform for publishing developer documentation, API references, help centers, and internal knowledge bases.
+links:
+  site: https://www.gitbook.com/industries/startups
+sources:
+  - source_id: src_ee1aef6bdd4a28432e6afb9794ff23595e5f9cd236a1cd7062b7f35c99443043
+    url: https://www.gitbook.com/industries/startups
+programs:
+  - program_id: prg_01kz1mhcd9smrz7dcp2xsw0bx3
+    program_slug: gitbook-startups-program
+    program_slug_aliases: []
+    title: GitBook Startups Program
+    summary: GitBook's program gives eligible startups six months of free platform access plus dedicated support and documentation resources.
+    source_ids:
+      - src_ee1aef6bdd4a28432e6afb9794ff23595e5f9cd236a1cd7062b7f35c99443043
+offers:
+  - offer_id: off_01kz1mhcd9fcez2yagerhsj3h5
+    program_id: prg_01kz1mhcd9smrz7dcp2xsw0bx3
+    offer_slug: six-months-free-platform-access
+    offer_slug_aliases: []
+    title: Six months of free GitBook platform access
+    summary: Eligible startups receive six months at no cost with full access to GitBook's platform, dedicated support, a documentation playbook, and startup spotlight support.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-02T16:22:29.018Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Six months at no cost with full access to GitBook's platform
+          duration:
+            kind: exact
+            value: P6M
+          kind: free-service
+          service: GitBook full platform access
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: Startup must have been founded less than two years ago
+            value:
+              type: number
+              value: 24
+          - criterion_id: cri_02
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lte
+            statement: Startup must have raised no more than $2 million USD in total funding
+            value:
+              type: number
+              value: 2000000
+          - criterion_id: cri_03
+            kind: manual
+            reason: external-verification
+            statement: Startup must not currently be on one of GitBook's paid plans
+          - criterion_id: cri_04
+            kind: manual
+            reason: not-machine-evaluable
+            statement: Startup must be non-crypto
+    roles:
+      terms_authority_entity_id: ent_01kz1mhcd8y5dwg183vwmypzr9
+      access_operator_entity_id: ent_01kz1mhcd8y5dwg183vwmypzr9
+    access:
+      availability: public
+      method: form
+      url: https://www.gitbook.com/industries/startups
+    terms_url: https://www.gitbook.com/industries/startups
+    source_ids:
+      - src_ee1aef6bdd4a28432e6afb9794ff23595e5f9cd236a1cd7062b7f35c99443043

--- a/vendors/gi/gitbook.yaml
+++ b/vendors/gi/gitbook.yaml
@@ -41,6 +41,15 @@ offers:
             value: P6M
           kind: free-service
           service: GitBook full platform access
+        - benefit_id: ben_02
+          description: Direct access to GitBook's support team without the standard support queue
+          kind: other
+        - benefit_id: ben_03
+          description: A documentation playbook with practical guidance for developer documentation, APIs, and internal knowledge bases
+          kind: other
+        - benefit_id: ben_04
+          description: Startup spotlight support to help amplify the startup's story across GitBook's channels
+          kind: other
       consideration:
         kind: none
     eligibility:


### PR DESCRIPTION
## What changed

Adds GitBook as one new vendor with exactly one offer under the named **GitBook Startups Program**.

The offer records only facts published on GitBook's current first-party page:

- six months at no cost with full platform access;
- dedicated support, a documentation playbook, and startup spotlight support;
- startup founded less than two years ago;
- no more than $2 million USD raised in total;
- not currently on a GitBook paid plan; and
- non-crypto.

This is a startup-specific application program, not GitBook's generic free tier or an ordinary trial. The source does not publish a dollar valuation, so the record represents the benefit as a six-month free service and does not invent one.

## Sources

- First-party program, benefits, application form, and eligibility checklist: https://www.gitbook.com/industries/startups

## Verification

- Exactly one new file: `vendors/gi/gitbook.yaml`
- Exactly one vendor, one named program, and one offer
- Source ID is the SHA-256 of the canonical source URL
- Canonical digest-pinned Candidate Verifier result: `status=valid, vendors=1, programs=1, offers=1`
- Data-only commit with DCO sign-off

## Certification

- [x] I changed only allowed repository content and did not mix vendor YAML with other paths.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commit includes a `Signed-off-by` line.
