### PR TITLE
catalog: add Trigger.dev current YC deal

### DIFF
--- a/vendors/tr/trigger-dev.yaml
+++ b/vendors/tr/trigger-dev.yaml
@@ -1,0 +1,71 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kz1nqbkgj5fba134asszj8wy
+slug: trigger-dev
+slug_aliases: []
+name: Trigger.dev
+domains:
+  - value: trigger.dev
+    role: primary
+    valid_from: 2026-08-02T16:43:13.387Z
+category: infra
+description: Trigger.dev is an open-source platform for durable AI agents, background jobs, and long-running workflows with retries, queues, observability, and elastic scaling.
+links:
+  site: https://trigger.dev
+sources:
+  - source_id: src_1255bb72695ce4619536142379251a6a9dff342aa7908373eeabbe5b631373c2
+    url: https://trigger.dev/yc
+programs: []
+offers:
+  - offer_id: off_01kz1nqbkjr2qn56jmxntneweb
+    offer_slug: current-yc-batch-credits
+    offer_slug_aliases: []
+    title: $10,000 in credits for current YC batch companies
+    summary: Current Y Combinator batch companies receive $10,000 in Trigger.dev credits for 12 months, a dedicated Slack channel, hands-on technical support, and a featured customer story.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-02T16:43:13.387Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: $10,000 in Trigger.dev credits for 12 months
+          duration:
+            kind: exact
+            value: P1Y
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 1000000
+            kind: exact
+        - benefit_id: ben_02
+          description: Dedicated Slack channel with the Trigger.dev founders and engineering team
+          kind: other
+        - benefit_id: ben_03
+          description: Hands-on help with evaluation, setup, and technical support
+          kind: other
+        - benefit_id: ben_04
+          description: Featured as a customer story on the Trigger.dev website
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        fact: company.partner_memberships
+        kind: predicate
+        operator: contains
+        statement: Company must be in the current Y Combinator batch
+        value:
+          type: string
+          value: YC current batch
+    roles:
+      terms_authority_entity_id: ent_01kz1nqbkgj5fba134asszj8wy
+      access_operator_entity_id: ent_01kz1nqbkgj5fba134asszj8wy
+    access:
+      availability: membership
+      instructions: Submit a work email, company name, and YC verification link generated inside Bookface; Trigger.dev says it will set up the credits and respond within one business day.
+      method: form
+      url: https://trigger.dev/yc
+    terms_url: https://trigger.dev/yc
+    source_ids:
+      - src_1255bb72695ce4619536142379251a6a9dff342aa7908373eeabbe5b631373c2


### PR DESCRIPTION
## What changed

Adds Trigger.dev as one new vendor with exactly one offer: the current Y Combinator batch deal.

The offer records only facts published on Trigger.dev's current first-party page:

- exactly $10,000 in Trigger.dev credits for 12 months;
- a dedicated Slack channel with the founders and engineering team;
- hands-on help with evaluation, setup, and technical support;
- a featured customer story on the Trigger.dev website;
- eligibility limited to companies in the current YC batch; and
- access through a form requiring work email, company name, and a YC verification link generated inside Bookface.

The source also advertises a separate YC alumni deal. This data-only pull request intentionally scopes itself to one current-batch offer so the change remains one vendor and exactly one offer; it does not merge the two tiers or attribute alumni economics to the current-batch record.

## Sources

- First-party deal, benefits, eligibility, application fields, and fulfillment timing: https://trigger.dev/yc

## Verification

- Exactly one new file: `vendors/tr/trigger-dev.yaml`
- Exactly one vendor and one offer; no program entity invented
- Source ID is the SHA-256 of the canonical source URL
- Candidate Verifier logic: `status=valid, vendors=1, programs=0, offers=1`
- Data-only commit with DCO sign-off

## Certification

- [x] I changed only allowed repository content and did not mix vendor YAML with other paths.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commit includes a `Signed-off-by` line.
