### PR TITLE
catalog: add AnnounceKit startup program

### DIFF
--- a/vendors/an/announcekit.yaml
+++ b/vendors/an/announcekit.yaml
@@ -1,0 +1,91 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kz1pgp7tk1jg94ewzd5qb4gh
+slug: announcekit
+slug_aliases: []
+name: AnnounceKit
+domains:
+  - value: announcekit.app
+    role: primary
+    valid_from: 2026-08-02T16:57:03.483Z
+category: marketing
+description: AnnounceKit provides changelogs, in-app notification widgets, product roadmaps, and feedback tools for product teams.
+links:
+  site: https://announcekit.app/
+sources:
+  - source_id: src_9a0e0d823cdb10994a754c81ad043397c98c863afe3849323a1cad5c86c19a0a
+    url: https://announcekit.app/startup
+programs:
+  - program_id: prg_01kz1pgp7vpkztc01r6kke6sa9
+    program_slug: startup-program
+    program_slug_aliases: []
+    title: AnnounceKit Startup Program
+    summary: AnnounceKit offers eligible early-stage startups half-price access to any paid plan for their first year.
+    source_ids:
+      - src_9a0e0d823cdb10994a754c81ad043397c98c863afe3849323a1cad5c86c19a0a
+offers:
+  - offer_id: off_01kz1pgp7v6fyv63xd4w9bem4p
+    program_id: prg_01kz1pgp7vpkztc01r6kke6sa9
+    offer_slug: startup-program
+    offer_slug_aliases: []
+    title: AnnounceKit Startup Program
+    summary: Eligible early-stage startups receive 50% off any AnnounceKit plan for 12 months, with all plan features and no long-term commitment.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-02T16:57:03.483Z
+    economics:
+      benefits:
+        - applies_to: AnnounceKit Essentials, Growth, or Scale plans
+          benefit_id: ben_01
+          description: 50% off the listed price of any AnnounceKit plan for the first 12 months.
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            basis_points: 5000
+            kind: exact
+      consideration:
+        description: The startup pays 50% of the selected plan's listed price during the 12-month discount period.
+        kind: variable
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.employee_count
+            kind: predicate
+            operator: lt
+            statement: The startup has fewer than 5 employees, including founders and part-time team members.
+            value:
+              type: number
+              value: 5
+          - criterion_id: cri_02
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: The company was incorporated less than 24 months ago.
+            value:
+              type: number
+              value: 24
+          - criterion_id: cri_03
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lte
+            statement: The startup has raised no more than $1 million across all funding rounds; bootstrapped companies qualify.
+            value:
+              type: number
+              value: 1000000
+          - criterion_id: cri_04
+            kind: manual
+            reason: not-machine-evaluable
+            statement: The startup has a live product or a product in active development.
+    roles:
+      terms_authority_entity_id: ent_01kz1pgp7tk1jg94ewzd5qb4gh
+      access_operator_entity_id: ent_01kz1pgp7tk1jg94ewzd5qb4gh
+    access:
+      availability: public
+      method: contact
+      url: https://announcekit.app/startup
+      instructions: Email support@announcekit.com with the company name, website, team size, founding date, and funding raised.
+    source_ids:
+      - src_9a0e0d823cdb10994a754c81ad043397c98c863afe3849323a1cad5c86c19a0a


### PR DESCRIPTION
## What changed

Adds AnnounceKit as one new vendor with one startup-specific offer: 50% off any Essentials, Growth, or Scale plan for 12 months. The record includes the published employee-count, company-age, funding, product-status, consideration, duration, and email application requirements.

Prepared and submitted by Nova, an AI agent operating transparently through the `nova-deputy` GitHub identity.

## Sources

- https://announcekit.app/startup — first-party English-language program page with current benefit, eligibility, duration, and application instructions.

## Validation

The repository-pinned Sourcey Candidate Verifier passed locally with `status: valid`, `vendors: 1`, `programs: 1`, and `offers: 1`.

## Certification

- [x] I changed only allowed repository content and did not mix vendor YAML with other paths.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commits include a `Signed-off-by` line.