### PR TITLE
catalog: add Airbyte YC startup promotion

### DIFF
--- a/vendors/ai/airbyte.yaml
+++ b/vendors/ai/airbyte.yaml
@@ -34,8 +34,7 @@ offers:
       effective_from: 2026-08-02T18:22:53.000Z
     economics:
       consideration:
-        kind: unknown
-        description: The public promotion page does not establish separate consideration.
+        kind: none
       benefits:
         - benefit_id: ben_01
           description: $75,000 in Airbyte credits

--- a/vendors/ai/airbyte.yaml
+++ b/vendors/ai/airbyte.yaml
@@ -52,10 +52,28 @@ offers:
           kind: other
     eligibility:
       rule:
-        criterion_id: cri_requirement_01
-        kind: manual
-        reason: not-machine-evaluable
-        statement: Applicant must be a company in a current or previous Y Combinator batch, have raised less than $5 million total, accept the Airbyte Cloud standard Terms of Service, and not be an existing Airbyte customer.
+        kind: all
+        rules:
+          - criterion_id: cri_requirement_01
+            kind: manual
+            reason: external-verification
+            statement: Applicant must be a company in a current or previous Y Combinator batch.
+          - criterion_id: cri_requirement_02
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: Applicant must have raised less than $5 million total.
+            value:
+              type: number
+              value: 5000000
+          - criterion_id: cri_requirement_03
+            kind: manual
+            reason: not-machine-evaluable
+            statement: Applicant must accept the Airbyte Cloud standard Terms of Service.
+          - criterion_id: cri_requirement_04
+            kind: manual
+            reason: not-machine-evaluable
+            statement: Applicant must not be an existing Airbyte customer.
     roles:
       terms_authority_entity_id: ent_01kz1ve26g2rkj6w37js1yrz0z
       access_operator_entity_id: ent_01kz1ve26g2rkj6w37js1yrz0z
@@ -65,4 +83,3 @@ offers:
       url: https://airbyte.com/company/ycombinator-startup-promotion
     source_ids:
       - src_31737e075786a03e0cb80bc62bc1066eb88c817e5792e1bee596287af314ce3a
-

--- a/vendors/ai/airbyte.yaml
+++ b/vendors/ai/airbyte.yaml
@@ -1,0 +1,69 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kz1ve26g2rkj6w37js1yrz0z
+slug: airbyte
+slug_aliases: []
+name: Airbyte
+domains:
+  - value: airbyte.com
+    role: primary
+    valid_from: 2026-08-02T18:22:53.000Z
+category: data-analytics
+description: Airbyte provides a data movement platform for connecting and replicating data across systems.
+links:
+  site: https://airbyte.com
+sources:
+  - source_id: src_31737e075786a03e0cb80bc62bc1066eb88c817e5792e1bee596287af314ce3a
+    url: https://airbyte.com/company/ycombinator-startup-promotion
+programs:
+  - program_id: prg_01kz1ve26gzmk7d7rwp5maf0df
+    program_slug: y-combinator-startup-promotion
+    program_slug_aliases: []
+    title: Y Combinator Startup Promotion
+    summary: Airbyte provides eligible Y Combinator companies with Airbyte credits and startup enablement resources.
+    source_ids:
+      - src_31737e075786a03e0cb80bc62bc1066eb88c817e5792e1bee596287af314ce3a
+offers:
+  - offer_id: off_01kz1ve26gdj4gc72mq582qtgy
+    program_id: prg_01kz1ve26gzmk7d7rwp5maf0df
+    offer_slug: 75000-in-airbyte-credits
+    offer_slug_aliases: []
+    title: $75,000 in Airbyte credits
+    summary: Eligible companies receive $75,000 in Airbyte credits, access to Airbyte learning resources, a place in the next Airbyte workshop, and Airbyte swag.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-02T18:22:53.000Z
+    economics:
+      consideration:
+        kind: unknown
+        description: The public promotion page does not establish separate consideration.
+      benefits:
+        - benefit_id: ben_01
+          description: $75,000 in Airbyte credits
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 7500000
+            kind: exact
+        - benefit_id: ben_02
+          description: Access to the free Airbyte learning platform and a place in the next Airbyte workshop.
+          kind: other
+        - benefit_id: ben_03
+          description: Airbyte swag.
+          kind: other
+    eligibility:
+      rule:
+        criterion_id: cri_requirement_01
+        kind: manual
+        reason: not-machine-evaluable
+        statement: Applicant must be a company in a current or previous Y Combinator batch, have raised less than $5 million total, accept the Airbyte Cloud standard Terms of Service, and not be an existing Airbyte customer.
+    roles:
+      terms_authority_entity_id: ent_01kz1ve26g2rkj6w37js1yrz0z
+      access_operator_entity_id: ent_01kz1ve26g2rkj6w37js1yrz0z
+    access:
+      availability: public
+      method: form
+      url: https://airbyte.com/company/ycombinator-startup-promotion
+    source_ids:
+      - src_31737e075786a03e0cb80bc62bc1066eb88c817e5792e1bee596287af314ce3a
+


### PR DESCRIPTION
## What changed

Adds Airbyte as one new vendor with one offer under the public **Y Combinator
Startup Promotion**. The vendor's English-language page states that eligible
companies receive $75,000 in Airbyte credits.

The record includes only the vendor-published conditions: current or prior Y
Combinator participation, less than $5 million total funding, acceptance of
Airbyte Cloud standard Terms of Service, and no existing Airbyte customer
relationship. This is an application-based startup promotion, not a generic
free tier, ordinary trial, coupon, affiliate listing, or aggregator entry.

## Sources

- https://airbyte.com/company/ycombinator-startup-promotion

## Certification

- [x] I changed only allowed repository content and did not mix vendor YAML with other paths.
- [x] I did not author freshness, provenance, signature, or trust-tier claims.
- [x] The commit includes a `Signed-off-by: Name <email>` line.