### PR TITLE
ci: streamline contributor validation

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,9 +6,14 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: validate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   validate:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,11 @@ dependency closure. It must never rebuild the full catalog. Merge is the sole
 human activation and every live surface advances from the same resulting live
 head.
 
+The public `validate` check must start automatically for an opened or updated
+data pull request, use the exact digest-pinned workspace-owned verifier, and
+return actionable field errors before private review. `sourcey/admission` is a
+separate Sourcey-owned evidence gate and never contributor-authored work.
+
 `vendors/` is the only public data collection. Offers, programs, links, and
 sources are nested in their owning vendor document. Do not add a generic
 `data/` wrapper or another top-level collection unless Kam explicitly approves

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,9 @@ For a new record, copy a nearby vendor file and preserve the shape:
   not need one; and
 - keep separate Offers for materially different economics, eligibility, duration, access, or
   terms. Do not split one application bundle into a card per benefit.
+- Keep each `summary` to 240 characters: it is the compact public synopsis used in listings and
+  metadata. An Offer may use optional `description` for longer source-backed context. Economics,
+  eligibility, and access still belong in their structured fields rather than repeated prose.
 
 - Describe only public vendor, program, and offer facts supported by the URLs
   in the record.
@@ -32,7 +35,33 @@ For a new record, copy a nearby vendor file and preserve the shape:
 
 The repository's `validate` check validates only the changed dependency closure
 through the exact digest-pinned Sourcey Candidate Verifier and enforces the DCO.
+It starts automatically when a pull request is opened or updated. A green `validate`
+check means the submitted tree is structurally and semantically valid; contributors can
+push corrections to the same branch and receive a fresh result without maintainer review.
 Sourcey's separate required `sourcey/admission` check proves that private,
 replayable evidence and authority were admitted for the exact pull-request Git
 tree; contributors never upload that private material. Once both checks pass and
 the pull request is merged, publication and live activation are automatic.
+
+For an exact local preflight, run this from a checkout with `origin/main` fetched:
+
+```bash
+base="$(git merge-base HEAD origin/main)"
+digest="$(<.github/sourcey-candidate-verifier.sha256)"
+work="$(mktemp -d)"
+archive="sourcey-candidate-verifier-sha256-${digest}.tar.gz"
+curl --fail --silent --show-error \
+  "https://artifacts.sourcey.com/catalog/code/candidate-verifier/sha256-${digest}/${archive}" \
+  --output "${work}/${archive}"
+curl --fail --silent --show-error \
+  "https://artifacts.sourcey.com/catalog/code/candidate-verifier/sha256-${digest}/${archive}.sha256" \
+  --output "${work}/${archive}.sha256"
+(cd "${work}" && shasum -a 256 --check "${archive}.sha256")
+mkdir "${work}/verifier"
+tar -xzf "${work}/${archive}" --strip-components=1 -C "${work}/verifier"
+node "${work}/verifier/sourcey-candidate-verifier.js" \
+  validate-change --repository "$PWD" --base "${base}" --head HEAD
+rm -rf "${work}"
+```
+
+This is the same pinned executable used by CI, not a second validator.


### PR DESCRIPTION
Makes changed-closure validation fast and repeatable for contributors.

- cancels stale runs for the same pull request
- caps the validation job at five minutes
- documents summary/description semantics
- documents the exact pinned local preflight

No vendor data changes.

Signed-off-by: Kam <kam@sourcey.com>