### PR TITLE
ci: require DCO for authored commits

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -81,7 +81,7 @@ jobs:
               | grep -Eq '^Signed-off-by: .+ <[^>]+>$'; then
               missing+=("$commit")
             fi
-          done < <(git rev-list "$change_base..$HEAD_REVISION")
+          done < <(git rev-list --no-merges "$change_base..$HEAD_REVISION")
           if (( ${#missing[@]} > 0 )); then
             printf 'Commits missing Signed-off-by certification:\n%s\n' "${missing[*]}" >&2
             exit 1


### PR DESCRIPTION
Keeps DCO enforcement on contributor-authored commits while excluding GitHub-generated merge commits created by the repository's normal Update branch control.\n\nThis changes no catalog data.