### PR TITLE
data: add Trigger.dev YC credits

### DIFF
--- a/vendors/tr/trigger-dev.yaml
+++ b/vendors/tr/trigger-dev.yaml
@@ -1,0 +1,122 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kz2ssxy6nvs40rhybfcrbck4
+slug: trigger-dev
+slug_aliases: []
+name: Trigger.dev
+domains:
+  - value: trigger.dev
+    role: primary
+    valid_from: 2026-08-03T03:13:46Z
+category: devtools-other
+description: Trigger.dev is an open-source platform for building durable AI agents and long-running workflows with TypeScript.
+links:
+  site: https://trigger.dev
+sources:
+  - source_id: src_1255bb72695ce4619536142379251a6a9dff342aa7908373eeabbe5b631373c2
+    url: https://trigger.dev/yc
+programs: []
+offers:
+  - offer_id: off_01kz2ssxy9qrjnm9e2tahn419e
+    offer_slug: current-yc-batch-credits
+    offer_slug_aliases: []
+    title: $10,000 in credits for the current YC batch
+    summary: Companies in the current Y Combinator batch receive $10,000 in Trigger.dev credits for 12 months, a dedicated Slack channel, technical support, and an optional customer story.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-03T03:13:46Z
+    economics:
+      consideration:
+        kind: none
+      benefits:
+        - benefit_id: ben_01
+          description: $10,000 in Trigger.dev credits for 12 months
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 1000000
+            kind: exact
+          duration:
+            kind: exact
+            value: P1Y
+        - benefit_id: ben_02
+          description: Dedicated Slack channel with the founders and engineering team
+          kind: other
+        - benefit_id: ben_03
+          description: Hands-on evaluation, setup, and technical support
+          kind: other
+        - benefit_id: ben_04
+          description: Optional feature as a customer story on the Trigger.dev website
+          kind: other
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        fact: company.partner_memberships
+        kind: predicate
+        operator: contains
+        statement: Must be a company in the current Y Combinator batch.
+        value:
+          type: string
+          value: YC current batch
+    roles:
+      terms_authority_entity_id: ent_01kz2ssxy6nvs40rhybfcrbck4
+      access_operator_entity_id: ent_01kz2ssxy6nvs40rhybfcrbck4
+    access:
+      availability: membership
+      instructions: Submit a work email and YC verification link.
+      method: form
+      url: https://trigger.dev/yc
+    source_ids:
+      - src_1255bb72695ce4619536142379251a6a9dff342aa7908373eeabbe5b631373c2
+  - offer_id: off_01kz2ssxy9zcbkrmvmyrtx3nsv
+    offer_slug: yc-alumni-credits
+    offer_slug_aliases: []
+    title: $5,000 in credits for YC alumni
+    summary: Y Combinator alumni companies receive $5,000 in Trigger.dev credits for 12 months, a dedicated Slack channel, technical support, and an optional customer story.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-03T03:13:46Z
+    economics:
+      consideration:
+        kind: none
+      benefits:
+        - benefit_id: ben_01
+          description: $5,000 in Trigger.dev credits for 12 months
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 500000
+            kind: exact
+          duration:
+            kind: exact
+            value: P1Y
+        - benefit_id: ben_02
+          description: Dedicated Slack channel with the founders and engineering team
+          kind: other
+        - benefit_id: ben_03
+          description: Hands-on evaluation, setup, and technical support
+          kind: other
+        - benefit_id: ben_04
+          description: Optional feature as a customer story on the Trigger.dev website
+          kind: other
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        fact: company.partner_memberships
+        kind: predicate
+        operator: contains
+        statement: Must be a Y Combinator alumni company.
+        value:
+          type: string
+          value: YC alumni
+    roles:
+      terms_authority_entity_id: ent_01kz2ssxy6nvs40rhybfcrbck4
+      access_operator_entity_id: ent_01kz2ssxy6nvs40rhybfcrbck4
+    access:
+      availability: membership
+      instructions: Submit a work email and YC verification link.
+      method: form
+      url: https://trigger.dev/yc
+    source_ids:
+      - src_1255bb72695ce4619536142379251a6a9dff342aa7908373eeabbe5b631373c2

--- a/vendors/tr/trigger-dev.yaml
+++ b/vendors/tr/trigger-dev.yaml
@@ -8,7 +8,7 @@ domains:
     role: primary
     valid_from: 2026-08-03T03:13:46Z
 category: devtools-other
-description: Trigger.dev is an open-source platform for building durable AI agents and long-running workflows with TypeScript.
+description: Trigger.dev helps teams build durable AI agents and long-running workflows with TypeScript.
 links:
   site: https://trigger.dev
 sources:
@@ -20,7 +20,7 @@ offers:
     offer_slug: current-yc-batch-credits
     offer_slug_aliases: []
     title: $10,000 in credits for the current YC batch
-    summary: Companies in the current Y Combinator batch receive $10,000 in Trigger.dev credits for 12 months, a dedicated Slack channel, technical support, and an optional customer story.
+    summary: Companies in the current Y Combinator batch receive $10,000 in Trigger.dev credits for 12 months, a dedicated Slack channel, technical support, and a customer story feature.
     lifecycle:
       status: active
       effective_from: 2026-08-03T03:13:46Z
@@ -46,7 +46,7 @@ offers:
           description: Hands-on evaluation, setup, and technical support
           kind: other
         - benefit_id: ben_04
-          description: Optional feature as a customer story on the Trigger.dev website
+          description: Featured as a customer story on the Trigger.dev website
           kind: other
     eligibility:
       rule:
@@ -63,16 +63,17 @@ offers:
       access_operator_entity_id: ent_01kz2ssxy6nvs40rhybfcrbck4
     access:
       availability: membership
-      instructions: Submit a work email and YC verification link.
+      instructions: Submit a work email, company name, and YC verification link.
       method: form
       url: https://trigger.dev/yc
+    terms_url: https://trigger.dev/yc
     source_ids:
       - src_1255bb72695ce4619536142379251a6a9dff342aa7908373eeabbe5b631373c2
   - offer_id: off_01kz2ssxy9zcbkrmvmyrtx3nsv
     offer_slug: yc-alumni-credits
     offer_slug_aliases: []
     title: $5,000 in credits for YC alumni
-    summary: Y Combinator alumni companies receive $5,000 in Trigger.dev credits for 12 months, a dedicated Slack channel, technical support, and an optional customer story.
+    summary: Y Combinator alumni companies receive $5,000 in Trigger.dev credits for 12 months.
     lifecycle:
       status: active
       effective_from: 2026-08-03T03:13:46Z
@@ -91,15 +92,6 @@ offers:
           duration:
             kind: exact
             value: P1Y
-        - benefit_id: ben_02
-          description: Dedicated Slack channel with the founders and engineering team
-          kind: other
-        - benefit_id: ben_03
-          description: Hands-on evaluation, setup, and technical support
-          kind: other
-        - benefit_id: ben_04
-          description: Optional feature as a customer story on the Trigger.dev website
-          kind: other
     eligibility:
       rule:
         criterion_id: cri_01
@@ -115,8 +107,9 @@ offers:
       access_operator_entity_id: ent_01kz2ssxy6nvs40rhybfcrbck4
     access:
       availability: membership
-      instructions: Submit a work email and YC verification link.
+      instructions: Submit a work email, company name, and YC verification link.
       method: form
       url: https://trigger.dev/yc
+    terms_url: https://trigger.dev/yc
     source_ids:
       - src_1255bb72695ce4619536142379251a6a9dff342aa7908373eeabbe5b631373c2


### PR DESCRIPTION
## What changed
Adds Trigger.dev's current Y Combinator credit offers for the current batch and alumni as one data-only vendor record.

## Sources
- https://trigger.dev/yc

## Certification
- [x] I changed only allowed repository content and did not mix vendor YAML with other paths.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commits include a `Signed-off-by` line.