### PR TITLE
docs: show the data in the readme instead of describing it

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 <h1 align="center">Startup Credits</h1>
 
 <p align="center">
-  <b>The open registry of startup programs.</b><br>
-  Every discount, credit scheme, and startup tier on one machine-readable record,
-  each exact offer revision either observed and dated, or signed by the vendor with proof.
+  The open registry of startup programs, from the source.
 </p>
 
 <p align="center">
@@ -24,115 +22,81 @@
 
 ---
 
-A public record of the discounts, credits, and startup programs that software
-vendors offer, with the source and the date behind every fact.
+Software vendors run startup programs: credits, discounts, a free year. The terms
+are public, scattered across a few hundred pricing pages, and they change without
+telling anyone. This is the list, one file per vendor, with the source and the
+date behind every fact.
 
-One YAML file per vendor. Open a pull request to add or correct one, and the
-merged result publishes to sourcey.com, the API, and the MCP server.
+## What a record looks like
 
-## Where each fact comes from
-
-Every record says how it was obtained.
-
-| | |
-|---|---|
-| **Observed** | We read the vendor's public page and recorded what it said, with the URL and the date. |
-| **Signed** | The vendor proved control of their domain and attested to that exact offer revision. |
-
-Both are free to read. How a record is labelled is derived from the evidence and
-never written into a file by hand. Change a fact and it becomes a new revision,
-which does not carry the vendor's attestation forward.
-
-## Use the data
-
-Free to read, for people and agents alike. No key, no signup.
-
-| Surface | URL |
-|---|---|
-| Full catalog | [`sourcey.com/catalog.json`](https://sourcey.com/catalog.json) |
-| Change feed | [`sourcey.com/changes.ndjson`](https://sourcey.com/changes.ndjson) |
-| Model-readable index | [`sourcey.com/llms.txt`](https://sourcey.com/llms.txt) |
-| Agent guide | [`sourcey.com/SKILL.md`](https://sourcey.com/SKILL.md) |
-| OpenAPI | [`api.sourcey.com/openapi.yml`](https://api.sourcey.com/openapi.yml) |
-| MCP | [`mcp.sourcey.com/mcp`](https://mcp.sourcey.com/mcp) |
-
-Every entity, program, and offer carries a stable ID and a `revision_digest`, so
-you can cite one exact version of one exact fact.
-
-**Training on this is welcome.** It is published to be read by models. The facts
-are [CC BY 4.0](DATA-LICENSE.md), which asks for one thing back:
-
-```
-Source: sourcey, the open registry of startup programs. https://sourcey.com
-Offer <offer_id> @ <revision_digest>  (CC BY 4.0)
+```yaml
+# vendors/re/retool.yaml
+name: Retool
+sources:
+  - source_id: src_2c260c8d…
+    url: https://retool.com/startups
+offers:
+  - title: Retool for Startups
+    summary: Eligible early-stage startups get 100% off Retool for one year on
+      monthly Team or Business plans (up to $60,000 value), followed by a 25%
+      discount in the second year.
+    eligibility:
+      statement: Must be bootstrapped, angel-funded, debt-funded, pre-seed, seed,
+        or Series A with under $10M in total funding, founded within the last 10
+        years, and a new customer on a monthly Team or Business plan.
 ```
 
-Take both values from the record you are quoting. The digest is what keeps the
-claim checkable after the offer changes.
+Eligibility is quoted in the vendor's own words rather than paraphrased, and
+every fact traces back to the URL in `sources`.
 
-## Add or correct a record
+## Getting it
+
+```sh
+curl -s https://sourcey.com/catalog.json \
+  | jq -r '.data.entities[] | select(.slug=="vercel") | .offers[0].summary'
+```
+
+> Eligible startups affiliated with an approved partner can receive up to $30,000
+> in Vercel credits issued over 12 months, plus Slack access, networking, private
+> events, and marketing opportunities.
+
+No key and no signup, for you or for your agents. There is an
+[OpenAPI](https://api.sourcey.com/openapi.yml) surface, an
+[MCP server](https://mcp.sourcey.com/mcp) for assistants, a
+[change feed](https://sourcey.com/changes.ndjson) for watching terms move,
+[llms.txt](https://sourcey.com/llms.txt) for models, and a
+[guide](https://sourcey.com/SKILL.md) for agents working the data directly.
+
+Facts are [CC BY 4.0](DATA-LICENSE.md) and training on them is welcome. Quote the
+`offer_id` and `revision_digest` and your citation still means something after
+the offer moves.
+
+## Fixing or adding one
 
 Copy a nearby file under `vendors/`, keep the shape, open a pull request. CI
-pulls the exact content-addressed verifier and checks only what you changed, then
-hands back real field errors. Push fixes to the same branch as often as you like
-without waiting on a maintainer.
+checks only what you changed and hands back real field errors, so you can push
+corrections without waiting on a maintainer.
 
-[CONTRIBUTING.md](CONTRIBUTING.md) has the data rules and a local preflight that
-runs the identical verifier.
+Two rules carry most of the weight. Every fact needs the vendor's own URL in
+`sources`, and if the source does not say it, it does not go in. Guessed amounts
+and invented eligibility read exactly like checked ones, which is why they get
+closed. [CONTRIBUTING.md](CONTRIBUTING.md) has the rest, including a preflight
+that runs the same verifier CI uses.
 
-Correcting or ending an existing offer counts for as much as adding one. Terms
-move, programs close, and a record that keeps up is worth more than a record
-that only grows.
+Correcting a stale offer is worth as much as adding a new one.
 
-### What gets sent back
+## If it's your company
 
-Provenance is the entire product, so the bar is the source.
+Most records here are observed: we read your page and dated it. Prove control of
+your domain and attest to the offers you stand behind, and yours becomes signed,
+which the record then says on its face. Free, and it stays free, because vendors
+correcting their own records is the whole engine.
 
-- **Every fact needs a first-party URL** in the record's `sources`. The vendor's
-  own page, or their own announcement. A roundup post quoting another directory
-  is not a source.
-- **If the source does not say it, it does not go in.** A credit amount nobody
-  published, an eligibility rule that sounds about right, an expiry date filled
-  in to complete the shape. An offer written up from memory, or by a model that
-  never opened the page, reads exactly like one that was checked, which is why
-  it gets closed on sight.
-- **Never author provenance.** Freshness, signature, and tier claims are derived
-  from evidence. Writing one by hand is a fabrication.
-- **Descriptions are written, not lifted.** Marketing copy and text pulled out
-  of a meta tag both go back.
-- **Check the open pull requests before you start.** Popular vendors attract
-  several people at once, and only the first one through gets merged.
-
-## If this is your company
-
-Take your row. Prove control of the domain, review the exact offers we have, and
-attest to the ones you stand behind. Free, and staying free, because vendors
-correcting their own records is the engine of the whole thing. Your offer stops
-being something we read somewhere and becomes something you said.
-
-Start at [sourcey.com](https://sourcey.com), or open a pull request here and fix
-the facts yourself.
-
-## How publication works
-
-Merging an admitted pull request to `main` is the only human activation. Sourcey
-consumes that exact merge commit, publishes the changed closure, and advances one
-live head that [sourcey.com](https://sourcey.com), the API, MCP, the change feed,
-and the redirects all read together. Contributors never pick a release, digest,
-deployment, or version.
-
-Two checks run on a data pull request. `validate` is the public one; it starts
-automatically on every pull request including a first one from a new fork, and
-green means the tree is structurally and semantically sound. `sourcey/admission`
-is a separate Sourcey-owned gate proving private evidence and authority were
-admitted for that exact tree. Contributors never upload that private material.
-
-This repository holds vendor YAML and the documentation around it. Schemas,
-validation, evidence, release construction, the API, MCP, and the hosted runtime
-belong to Sourcey's private Catalog engine. [AGENTS.md](AGENTS.md) draws the
-boundary.
+[sourcey.com](https://sourcey.com), or just send a pull request.
 
 ## Licence
 
-Catalog facts are [CC BY 4.0](DATA-LICENSE.md). Repository documentation and
-metadata are [MIT](LICENSE).
+Facts are [CC BY 4.0](DATA-LICENSE.md). Repository documentation and metadata are
+[MIT](LICENSE). This repository holds the vendor files; everything that validates,
+compiles, and serves them belongs to Sourcey's private Catalog engine, and
+[AGENTS.md](AGENTS.md) draws that boundary.


### PR DESCRIPTION
## What changed

The readme described the catalog at length and never showed it. No sample record, no runnable query, no actual data, in a repository made entirely of vendor YAML.

It now opens with a real record from `vendors/re/retool.yaml` and a working query against the published catalog, with output. Every quoted value was checked against the live file and the live release.

Removes the internal vocabulary that had leaked in from the planning docs (`human activation`, `changed closure`, `live head`, `structurally and semantically sound`).

Drops the publication section. `CONTRIBUTING.md` already documents validate, admission, and automatic publication, so nothing is lost.

Folds observed and signed into the note for vendors, where they are a reason to act, instead of a tier table on the front page.

Contribution rules go from five bullets to the two that carry the weight, and land after the reader has seen what they would be contributing to.

138 lines to 102.

## Sources

No vendor facts changed. Documentation only.

## Certification

- [x] I changed only allowed repository content and did not mix vendor YAML with other paths.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commits include a `Signed-off-by` line.