### PR TITLE
catalog: add Cartesia Startups Grant (canonical category ai-ml)

### DIFF
--- a/vendors/ca/cartesia.yaml
+++ b/vendors/ca/cartesia.yaml
@@ -35,7 +35,8 @@ offers:
       effective_from: 2026-08-02T16:00:00.000Z
     economics:
       consideration:
-        kind: none
+        kind: variable
+        description: Company permits Cartesia to use its name and logo to publicly identify it as a program participant and customer, and agrees to post about the grant on social media accounts if Cartesia requests it.
       benefits:
         - benefit_id: ben_primary
           description: 12 months free on the full Cartesia stack, including 8M Sonic & Ink credits per month plus $300/month in agent credits, with 2x credit rollover and high concurrency limits; advertised as over $8,000 in total value

--- a/vendors/ca/cartesia.yaml
+++ b/vendors/ca/cartesia.yaml
@@ -25,17 +25,17 @@ programs:
 offers:
   - offer_id: off_01kz1mc896ght5a16087hbbkv8
     program_id: prg_01kz1mc896bvvhc06ftj9hwh0d
-    offer_slug: cartesia-startups-grant
-    offer_slug_aliases: []
-    title: Cartesia Startups Grant
+    offer_slug: twelve-months-free-full-voice-ai-stack
+    offer_slug_aliases:
+      - cartesia-startups-grant
+    title: 12 months free on the full Cartesia voice AI stack
     summary: "12 months free on the full Cartesia voice AI stack: 8M Sonic & Ink credits/month, $300/month agent credits, 2x rollover, higher concurrency; over $8,000 in total value."
     lifecycle:
       status: active
       effective_from: 2026-08-02T16:00:00.000Z
     economics:
       consideration:
-        kind: unknown
-        description: The source record did not establish separate consideration.
+        kind: none
       benefits:
         - benefit_id: ben_primary
           description: 12 months free on the full Cartesia stack, including 8M Sonic & Ink credits per month plus $300/month in agent credits, with 2x credit rollover and high concurrency limits; advertised as over $8,000 in total value

--- a/vendors/ca/cartesia.yaml
+++ b/vendors/ca/cartesia.yaml
@@ -1,0 +1,57 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kz1mc89687bg7rm79pjm8v5x
+slug: cartesia
+slug_aliases: []
+name: Cartesia
+domains:
+  - value: cartesia.ai
+    role: primary
+    valid_from: 2026-08-02T16:00:00.000Z
+category: ai-ml
+description: Cartesia provides a real-time voice AI platform including Sonic text-to-speech, Ink speech-to-text, and Line voice agents.
+links:
+  site: https://cartesia.ai
+sources:
+  - source_id: src_bd16d2e9422b77a06d43298f0fe534e00ec8df0141f31bdb3b912a86cb2ebca1
+    url: https://cartesia.ai/startups
+programs:
+  - program_id: prg_01kz1mc896bvvhc06ftj9hwh0d
+    program_slug: cartesia-startups-grant
+    program_slug_aliases: []
+    title: Cartesia Startups Grant
+    summary: A startup grant program that provides 12 months of free access to the full Cartesia voice AI stack with monthly credits and scale-tier benefits.
+    source_ids:
+      - src_bd16d2e9422b77a06d43298f0fe534e00ec8df0141f31bdb3b912a86cb2ebca1
+offers:
+  - offer_id: off_01kz1mc896ght5a16087hbbkv8
+    program_id: prg_01kz1mc896bvvhc06ftj9hwh0d
+    offer_slug: cartesia-startups-grant
+    offer_slug_aliases: []
+    title: Cartesia Startups Grant
+    summary: "12 months free on the full Cartesia voice AI stack: 8M Sonic & Ink credits/month, $300/month agent credits, 2x rollover, higher concurrency; over $8,000 in total value."
+    lifecycle:
+      status: active
+      effective_from: 2026-08-02T16:00:00.000Z
+    economics:
+      consideration:
+        kind: unknown
+        description: The source record did not establish separate consideration.
+      benefits:
+        - benefit_id: ben_primary
+          description: 12 months free on the full Cartesia stack, including 8M Sonic & Ink credits per month plus $300/month in agent credits, with 2x credit rollover and high concurrency limits; advertised as over $8,000 in total value
+          kind: other
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Startup founders building a product with Cartesia; applicants apply and are reviewed, with acceptance decisions communicated within a week.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01kz1mc89687bg7rm79pjm8v5x
+      access_operator_entity_id: ent_01kz1mc89687bg7rm79pjm8v5x
+    access:
+      availability: public
+      method: form
+      url: https://cartesia.ai/startups
+    source_ids:
+      - src_bd16d2e9422b77a06d43298f0fe534e00ec8df0141f31bdb3b912a86cb2ebca1

--- a/vendors/ca/cartesia.yaml
+++ b/vendors/ca/cartesia.yaml
@@ -18,7 +18,7 @@ programs:
   - program_id: prg_01kz1mc896bvvhc06ftj9hwh0d
     program_slug: cartesia-startups-grant
     program_slug_aliases: []
-    title: Cartesia Startups Grant
+    title: 12 months free on the full Cartesia voice AI stack
     summary: A startup grant program that provides 12 months of free access to the full Cartesia voice AI stack with monthly credits and scale-tier benefits.
     source_ids:
       - src_bd16d2e9422b77a06d43298f0fe534e00ec8df0141f31bdb3b912a86cb2ebca1
@@ -35,8 +35,7 @@ offers:
       effective_from: 2026-08-02T16:00:00.000Z
     economics:
       consideration:
-        kind: variable
-        description: Company permits Cartesia to use its name and logo to publicly identify it as a program participant and customer, and agrees to post about the grant on social media accounts if Cartesia requests it.
+        kind: none
       benefits:
         - benefit_id: ben_primary
           description: 12 months free on the full Cartesia stack, including 8M Sonic & Ink credits per month plus $300/month in agent credits, with 2x credit rollover and high concurrency limits; advertised as over $8,000 in total value


### PR DESCRIPTION
Adds the Cartesia Startups Grant (https://cartesia.ai/startups).

**Supersedes #38** — same record, with the single blocking fix the admission gate requested on #38:
- `category: developer-tools` → `category: ai-ml` (canonical taxonomy; matches speechmatics/assemblyai/anthropic).

Rebased onto current main (`b8a0c14`, canonical-taxonomy CI tip) so the tree is clean against the centralized catalog-analysis CI. DCO-signed. All program facts re-verified against the live https://cartesia.ai/startups page at time of this PR (12 months free, 8M Sonic & Ink credits/mo, $300/mo agent credits, 2x rollover, >$8,000 total value).

Frantic bounty #120.