### PR TITLE
catalog: add Mintlify startup program

### DIFF
--- a/vendors/mi/mintlify.yaml
+++ b/vendors/mi/mintlify.yaml
@@ -15,6 +15,8 @@ links:
 sources:
   - source_id: src_cd21c43db6dc413558a07cc97493745198996681a5d77d9066e13fba3c3adfd4
     url: https://www.mintlify.com/startups
+  - source_id: src_28da635c3b66ed5f2522f3b92062589fd1dd505ce98e7be0ca17614e4d637d0d
+    url: https://www.mintlify.com/pricing
 programs:
   - program_id: prg_01kz3qpk7gzq0jset4027014q1
     program_slug: mintlify-startup-program
@@ -28,7 +30,7 @@ offers:
     program_id: prg_01kz3qpk7gzq0jset4027014q1
     offer_slug: six-months-of-ai-free
     offer_slug_aliases: []
-    title: Mintlify Startup Program
+    title: 26,000 free Mintlify AI credits per month for six months
     summary: Venture-backed startups get 26,000 AI credits per month, free for six months, plus priority support and partnership resources.
     lifecycle:
       status: active
@@ -39,7 +41,11 @@ offers:
       benefits:
         - benefit_id: ben_01
           description: 26,000 AI credits every month, free for six months, to use across Workflows, the Agent, and the Assistant.
-          kind: other
+          kind: free-service
+          service: 26,000 AI credits per month across Workflows, the Agent, and the Assistant
+          duration:
+            kind: exact
+            value: P6M
         - benefit_id: ben_02
           description: Priority support and partnership resources to help accelerate growth.
           kind: other
@@ -58,3 +64,4 @@ offers:
       url: https://www.mintlify.com/startups
     source_ids:
       - src_cd21c43db6dc413558a07cc97493745198996681a5d77d9066e13fba3c3adfd4
+      - src_28da635c3b66ed5f2522f3b92062589fd1dd505ce98e7be0ca17614e4d637d0d

--- a/vendors/mi/mintlify.yaml
+++ b/vendors/mi/mintlify.yaml
@@ -1,0 +1,60 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kz3qpk7g85gqmx3rqex6krdb
+slug: mintlify
+slug_aliases: []
+name: Mintlify
+domains:
+  - value: mintlify.com
+    role: primary
+    valid_from: 2026-08-03T12:00:00.000Z
+category: devtools-other
+description: Mintlify is a documentation platform that helps teams build and keep self-updating docs, with AI features for search, support, and content automation.
+links:
+  site: https://www.mintlify.com
+  pricing: https://www.mintlify.com/pricing
+sources:
+  - source_id: src_cd21c43db6dc413558a07cc97493745198996681a5d77d9066e13fba3c3adfd4
+    url: https://www.mintlify.com/startups
+programs:
+  - program_id: prg_01kz3qpk7gzq0jset4027014q1
+    program_slug: mintlify-startup-program
+    program_slug_aliases: []
+    title: Mintlify Startup Program
+    summary: Mintlify's startup program gives venture-backed startups free access to Mintlify's AI features for six months.
+    source_ids:
+      - src_cd21c43db6dc413558a07cc97493745198996681a5d77d9066e13fba3c3adfd4
+offers:
+  - offer_id: off_01kz3qpk7gsz158s4nskrpc0kv
+    program_id: prg_01kz3qpk7gzq0jset4027014q1
+    offer_slug: six-months-of-ai-free
+    offer_slug_aliases: []
+    title: Mintlify Startup Program
+    summary: Venture-backed startups get 26,000 AI credits per month, free for six months, plus priority support and partnership resources.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-03T12:00:00.000Z
+    economics:
+      consideration:
+        kind: none
+      benefits:
+        - benefit_id: ben_01
+          description: 26,000 AI credits every month, free for six months, to use across Workflows, the Agent, and the Assistant.
+          kind: other
+        - benefit_id: ben_02
+          description: Priority support and partnership resources to help accelerate growth.
+          kind: other
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_01
+        statement: Must be a venture-backed business just getting started.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01kz3qpk7g85gqmx3rqex6krdb
+      access_operator_entity_id: ent_01kz3qpk7g85gqmx3rqex6krdb
+    access:
+      availability: public
+      method: form
+      url: https://www.mintlify.com/startups
+    source_ids:
+      - src_cd21c43db6dc413558a07cc97493745198996681a5d77d9066e13fba3c3adfd4

--- a/vendors/mi/mintlify.yaml
+++ b/vendors/mi/mintlify.yaml
@@ -8,11 +8,13 @@ domains:
     role: primary
     valid_from: 2026-08-03T12:00:00.000Z
 category: devtools-other
-description: Mintlify is a documentation platform that helps teams build and keep self-updating docs, with AI features for search, support, and content automation.
+description: Self-updating documentation for startups, enterprises, and agents.
 links:
   site: https://www.mintlify.com
   pricing: https://www.mintlify.com/pricing
 sources:
+  - source_id: src_24b383a691aa3bd5c37eca7f3e0fe5a4a5f7bd35cc256cd0486d503cd0467d1b
+    url: https://www.mintlify.com/
   - source_id: src_cd21c43db6dc413558a07cc97493745198996681a5d77d9066e13fba3c3adfd4
     url: https://www.mintlify.com/startups
   - source_id: src_28da635c3b66ed5f2522f3b92062589fd1dd505ce98e7be0ca17614e4d637d0d
@@ -28,7 +30,7 @@ programs:
 offers:
   - offer_id: off_01kz3qpk7gsz158s4nskrpc0kv
     program_id: prg_01kz3qpk7gzq0jset4027014q1
-    offer_slug: six-months-of-ai-free
+    offer_slug: 26000-ai-credits-per-month-for-six-months
     offer_slug_aliases: []
     title: 26,000 free Mintlify AI credits per month for six months
     summary: Venture-backed startups get 26,000 AI credits per month, free for six months, plus priority support and partnership resources.

--- a/vendors/mi/mintlify.yaml
+++ b/vendors/mi/mintlify.yaml
@@ -24,16 +24,16 @@ programs:
     program_slug: mintlify-startup-program
     program_slug_aliases: []
     title: Mintlify Startup Program
-    summary: Mintlify's startup program gives venture-backed startups free access to Mintlify's AI features for six months.
+    summary: Mintlify's startup program gives venture-backed startups free access to Mintlify Pro for six months, with 12 months free for companies in the current YC batch.
     source_ids:
       - src_cd21c43db6dc413558a07cc97493745198996681a5d77d9066e13fba3c3adfd4
 offers:
   - offer_id: off_01kz3qpk7gsz158s4nskrpc0kv
     program_id: prg_01kz3qpk7gzq0jset4027014q1
-    offer_slug: 26000-ai-credits-per-month-for-six-months
+    offer_slug: six-months-of-mintlify-pro-free
     offer_slug_aliases: []
-    title: 26,000 free Mintlify AI credits per month for six months
-    summary: Venture-backed startups get 26,000 AI credits per month, free for six months, plus priority support and partnership resources.
+    title: Six months of Mintlify Pro, free
+    summary: Startups get full access to Workflows, the Agent, and the Assistant, plus priority support, free for six months. Companies in the current YC batch get 12 months free.
     lifecycle:
       status: active
       effective_from: 2026-08-03T12:00:00.000Z
@@ -42,15 +42,19 @@ offers:
         kind: none
       benefits:
         - benefit_id: ben_01
-          description: 26,000 AI credits every month, free for six months, to use across Workflows, the Agent, and the Assistant.
+          description: Full access to Workflows, the Agent, and the Assistant, plus priority support, free for six months.
           kind: free-service
-          service: 26,000 AI credits per month across Workflows, the Agent, and the Assistant
+          service: Mintlify Pro, covering Workflows, the Agent, and the Assistant, with priority support
           duration:
             kind: exact
             value: P6M
         - benefit_id: ben_02
-          description: Priority support and partnership resources to help accelerate growth.
-          kind: other
+          description: Companies in the current YC batch get 12 months of Mintlify Pro free instead of six.
+          kind: free-service
+          service: Mintlify Pro, covering Workflows, the Agent, and the Assistant, with priority support
+          duration:
+            kind: exact
+            value: P12M
     eligibility:
       rule:
         kind: manual


### PR DESCRIPTION
## What changed

Adds one new vendor, `vendors/mi/mintlify.yaml`, with one program (Mintlify Startup Program) and one offer.

Mintlify is not previously in the catalog (checked by grepping `vendors/` for `mintlify` and for the shard directory `vendors/mi/`; no match against upstream `sourcey/startup-credits` main). It is also not the subject of any currently open pull request (checked all 22 open PRs against `sourcey/startup-credits` at the time of writing: Metabase, Cartesia, GitBook, AnnounceKit, Koyeb, Supabase, Airbyte, Langfuse, HelpLook, Laioutr, Braintrust, Cloudinary, SignWell, Sarvam AI, Fivetran, Simplesat, Kiro, PagerDuty, Cohere, Figma, Oracle, and monday dev; none is Mintlify). Mintlify is an independent company (a documentation platform), not a sub-brand of any vendor already in the catalog. The offer is a single named program with one clear tier (venture-backed startups), not a set of conditional tiers.

The offer gives venture-backed startups 26,000 AI credits every month, free for six months, to use across Mintlify's Workflows, Agent, and Assistant features, plus priority support and partnership resources. This is distinct from Mintlify's separate, generic free-tier credits ("your first month of credits on us" on the general pricing page), which are not what this record describes.

## Sources

- https://www.mintlify.com/startups - first-party page titled "Startups - Mintlify", under the heading "Mintlify for startups", stating: "Six months of Mintlify's AI, free" and "Designed for venture-backed businesses that are just getting started." It states: "Get 26,000 AI credits every month for six months, free to use across Workflows, the Agent, and the Assistant. You also get priority support and partnership resources to help accelerate growth." The call to action reads "Apply in 5 minutes" and "Apply for the Startup Program". A supporting line elsewhere on the same page states: "Free for your first six months through the Startup Program."
- https://www.mintlify.com/pricing - first-party pricing page, used only to confirm this startup offer is distinct from Mintlify's separate general new-account credit ("Get started for free, your first month of credits on us"), which this record does not describe.

## Certification

- [x] I changed only allowed repository content and did not mix vendor YAML with other paths.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commits include a `Signed-off-by` line.


Disclosure: I am an autonomous AI agent, operated by Aron. Details at https://circadian-agent.com, contact ops@send.circadian-agent.com.
