### PR TITLE
data: add Composio startup offer

### DIFF
--- a/vendors/co/composio.yaml
+++ b/vendors/co/composio.yaml
@@ -50,7 +50,7 @@ offers:
       rule:
         kind: manual
         criterion_id: cri_01
-        statement: Applicants must be accepted into Composio's startup program.
+        statement: Only accepted startups receive this offer.
         reason: vendor-discretion
     roles:
       terms_authority_entity_id: ent_01kz30yqnfe6gkpjqqjb3fj1e9

--- a/vendors/co/composio.yaml
+++ b/vendors/co/composio.yaml
@@ -31,17 +31,16 @@ offers:
     offer_slug: six-months-free-business-plan
     offer_slug_aliases: []
     title: Six months free on Composio Business
-    summary: Eligible software startups with under $5M raised receive the Composio Business plan free for six months; accelerator affiliation is not required.
+    summary: Accepted startups receive the Composio Business plan free for six months.
     lifecycle:
       status: active
       effective_from: 2026-08-03T05:18:43.821Z
     economics:
       consideration:
-        kind: variable
-        description: No charge during the six-month program period. Unless canceled before that period ends, the plan automatically renews at the then-current standard Business plan rate.
+        kind: none
       benefits:
         - benefit_id: ben_01
-          description: Six months of the Composio Business plan at no charge; the standard plan is currently listed at $229 per month.
+          description: Six months of the Composio Business plan at no charge.
           kind: free-service
           service: Composio Business plan
           duration:
@@ -51,8 +50,8 @@ offers:
       rule:
         kind: manual
         criterion_id: cri_01
-        statement: Open to early-stage and growth-stage companies building software products that have raised less than $5 million; accelerator affiliation is optional.
-        reason: not-machine-evaluable
+        statement: Applicants must be accepted into Composio's startup program.
+        reason: vendor-discretion
     roles:
       terms_authority_entity_id: ent_01kz30yqnfe6gkpjqqjb3fj1e9
       access_operator_entity_id: ent_01kz30yqnfe6gkpjqqjb3fj1e9

--- a/vendors/co/composio.yaml
+++ b/vendors/co/composio.yaml
@@ -1,0 +1,66 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kz30yqnfe6gkpjqqjb3fj1e9
+slug: composio
+slug_aliases: []
+name: Composio
+domains:
+  - value: composio.dev
+    role: primary
+    valid_from: 2026-08-03T05:18:43.821Z
+category: apis-integration
+description: Composio provides tool integrations, authentication infrastructure, triggers, and a code sandbox for developers building AI agents.
+links:
+  site: https://composio.dev
+  pricing: https://composio.dev/pricing
+sources:
+  - source_id: src_f3c1ef0b683b68c47f5aa92e4b5bcdbcd27607e036bf0da5f6afe8693d8fe806
+    url: https://composio.dev/startups
+  - source_id: src_b75a6f2ccd302aa285925f104ab7a01e45c63a2e496cc1b26560ac358b3bccfb
+    url: https://composio.dev/pricing.md
+programs:
+  - program_id: prg_01kz30yqng83gdzz5g6t5zeakr
+    program_slug: composio-startups-program
+    program_slug_aliases: []
+    title: Composio Startups Program
+    summary: Composio's startup program gives qualifying software companies its Business plan free for six months, with applications typically reviewed within a week.
+    source_ids:
+      - src_f3c1ef0b683b68c47f5aa92e4b5bcdbcd27607e036bf0da5f6afe8693d8fe806
+offers:
+  - offer_id: off_01kz30yqngdmgsasz3zckp44k8
+    program_id: prg_01kz30yqng83gdzz5g6t5zeakr
+    offer_slug: six-months-free-business-plan
+    offer_slug_aliases: []
+    title: Six months free on Composio Business
+    summary: Eligible software startups with under $5M raised receive the Composio Business plan free for six months; accelerator affiliation is not required.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-03T05:18:43.821Z
+    economics:
+      consideration:
+        kind: variable
+        description: No charge during the six-month program period. Unless canceled before that period ends, the plan automatically renews at the then-current standard Business plan rate.
+      benefits:
+        - benefit_id: ben_01
+          description: Six months of the Composio Business plan at no charge; the standard plan is currently listed at $229 per month.
+          kind: free-service
+          service: Composio Business plan
+          duration:
+            kind: exact
+            value: P6M
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_01
+        statement: Open to early-stage and growth-stage companies building software products that have raised less than $5 million; accelerator affiliation is optional.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01kz30yqnfe6gkpjqqjb3fj1e9
+      access_operator_entity_id: ent_01kz30yqnfe6gkpjqqjb3fj1e9
+    access:
+      availability: public
+      method: form
+      url: https://composio.dev/startups
+    terms_url: https://composio.dev/terms
+    source_ids:
+      - src_f3c1ef0b683b68c47f5aa92e4b5bcdbcd27607e036bf0da5f6afe8693d8fe806
+      - src_b75a6f2ccd302aa285925f104ab7a01e45c63a2e496cc1b26560ac358b3bccfb


### PR DESCRIPTION
## Summary

- add a new Composio vendor record at `vendors/co/composio.yaml`
- describe the public Composio Startups Program and its six-month Business-plan offer
- record the no-charge consideration, vendor-discretion eligibility, public access form, and first-party sources

## First-party sources

- https://composio.dev/startups
- https://composio.dev/pricing.md
- https://composio.dev/terms

## Validation

- exact digest-pinned Candidate Verifier: `{"status":"valid","vendors":1,"programs":1,"offers":1}`
- local candidate checks: `3 passed`
- DCO sign-off included on both commits

## Review revision

- addressed review `4848303315` in `ed9b839bc4fcf8a9bb912cbb7a5597a9e3ceca3c` by removing unsupported renewal, price-valuation, fundraising, and accelerator claims

Closes #97.

Prepared for Frantic bounty #120.