### PR TITLE
Add Airwallex startup offer

### DIFF
--- a/vendors/ai/airwallex.yaml
+++ b/vendors/ai/airwallex.yaml
@@ -19,38 +19,84 @@ programs:
     program_slug: airwallex-for-startups
     program_slug_aliases: []
     title: Airwallex for Startups
-    summary: A regional program for venture-backed startups offering fee savings, Airwallex plan access, partner perks, and startup-focused support.
+    summary: A no-cost program for venture-backed Australian and New Zealand startups, with published Airwallex benefits that vary by startup stage.
     source_ids:
       - src_cb2be51ba472b23a2aafd3e4eeb23ab61713dc5150e7d67d4ea9b6f4303237eb
 offers:
-  - offer_id: off_01kz4xsd0mf5p7jsxw22kp5n7k
+  - offer_id: off_01kz5yxt13mz6n78pkay2mbvpq
     program_id: prg_01kz4xsd0mbk63mas9eb1z6szw
-    offer_slug: australia-startup-offer
+    offer_slug: pre-seed-explore-access
     offer_slug_aliases: []
-    title: Airwallex for Startups Australia Offer
-    summary: Eligible Australian startups get three months of Airwallex plan access plus fee waivers on up to AUD $100,000 of payments and AUD $100,000 of foreign-exchange conversions.
+    title: 3 months of Airwallex Explore
+    summary: Eligible venture-backed pre-seed startups in Australia or New Zealand receive three months of free access to the Airwallex Explore tier.
     lifecycle:
       status: active
       effective_from: 2026-08-04T00:00:00Z
     economics:
       benefits:
         - benefit_id: ben_01
-          description: Three months of Airwallex Explore for pre-seed startups or Airwallex Grow for seed-stage startups.
+          description: Free access to the Airwallex Explore tier for three months.
           duration:
             kind: exact
             value: P3M
           kind: free-service
-          service: Airwallex Explore or Grow plan, according to startup stage
+          service: Airwallex Explore tier
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: Must be a venture-backed pre-seed startup with an active Airwallex account.
+          - criterion_id: cri_02
+            kind: manual
+            reason: external-verification
+            statement: Must have a business entity registered in Australia or New Zealand with a valid ABN or NZBN.
+          - criterion_id: cri_03
+            kind: manual
+            reason: external-verification
+            statement: The offer is for new customers and is subject to program approval and terms.
+    roles:
+      terms_authority_entity_id: ent_01kz4xsd0m76d5ensjb8150avj
+      access_operator_entity_id: ent_01kz4xsd0m76d5ensjb8150avj
+    access:
+      availability: public
+      method: form
+      url: https://www.airwallex.com/en-au/signup
+    source_ids:
+      - src_cb2be51ba472b23a2aafd3e4eeb23ab61713dc5150e7d67d4ea9b6f4303237eb
+  - offer_id: off_01kz4xsd0mf5p7jsxw22kp5n7k
+    program_id: prg_01kz4xsd0mbk63mas9eb1z6szw
+    offer_slug: seed-stage-offers
+    offer_slug_aliases:
+      - australia-startup-offer
+    title: Airwallex offers for seed-stage startups
+    summary: Eligible venture-backed seed-stage startups in Australia or New Zealand receive three months of Grow, payment and FX fee waivers, and Yield access.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-04T00:00:00Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Free access to the Airwallex Grow tier for three months.
+          duration:
+            kind: exact
+            value: P3M
+          kind: free-service
+          service: Airwallex Grow tier
         - benefit_id: ben_02
-          description: Fees waived on the first AUD $100,000 of payments collected by eligible seed-stage startups.
+          description: Fees waived on the first AUD $100,000 of payments collected.
           kind: waiver
           waived_item: Payment collection fees on the first AUD $100,000 collected
         - benefit_id: ben_03
-          description: Foreign-exchange fees waived on the first AUD $100,000 converted by eligible seed-stage startups.
+          description: Foreign-exchange fees waived on the first AUD $100,000 converted.
           kind: waiver
           waived_item: Foreign-exchange fees on the first AUD $100,000 converted
         - benefit_id: ben_04
-          description: Access to Airwallex Yield for eligible seed-stage startups.
+          description: Access to Airwallex Yield for earning returns on AUD and USD funds.
           kind: other
       consideration:
         kind: none
@@ -61,7 +107,7 @@ offers:
           - criterion_id: cri_01
             kind: manual
             reason: external-verification
-            statement: Must be a venture-backed startup at pre-seed, seed, or Series A stage with an active Airwallex account.
+            statement: Must be a venture-backed seed-stage startup with an active Airwallex account.
           - criterion_id: cri_02
             kind: manual
             reason: external-verification
@@ -69,13 +115,13 @@ offers:
           - criterion_id: cri_03
             kind: manual
             reason: external-verification
-            statement: The listed special offers are available to new customers and are subject to program approval and terms.
+            statement: The offer is for new customers and is subject to program approval and terms.
     roles:
       terms_authority_entity_id: ent_01kz4xsd0m76d5ensjb8150avj
       access_operator_entity_id: ent_01kz4xsd0m76d5ensjb8150avj
     access:
       availability: public
       method: form
-      url: https://www.airwallex.com/en-au/startups
+      url: https://www.airwallex.com/en-au/signup
     source_ids:
       - src_cb2be51ba472b23a2aafd3e4eeb23ab61713dc5150e7d67d4ea9b6f4303237eb

--- a/vendors/ai/airwallex.yaml
+++ b/vendors/ai/airwallex.yaml
@@ -1,0 +1,81 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kz4xsd0m76d5ensjb8150avj
+slug: airwallex
+slug_aliases: []
+name: Airwallex
+domains:
+  - value: airwallex.com
+    role: primary
+    valid_from: 2026-08-04T00:00:00Z
+category: payments-fintech
+description: Airwallex is a global financial platform for managing business accounts, payments, treasury, spend, and embedded finance across currencies and markets.
+links:
+  site: https://www.airwallex.com
+sources:
+  - source_id: src_cb2be51ba472b23a2aafd3e4eeb23ab61713dc5150e7d67d4ea9b6f4303237eb
+    url: https://www.airwallex.com/en-au/startups
+programs:
+  - program_id: prg_01kz4xsd0mbk63mas9eb1z6szw
+    program_slug: airwallex-for-startups
+    program_slug_aliases: []
+    title: Airwallex for Startups
+    summary: A regional program for venture-backed startups offering fee savings, Airwallex plan access, partner perks, and startup-focused support.
+    source_ids:
+      - src_cb2be51ba472b23a2aafd3e4eeb23ab61713dc5150e7d67d4ea9b6f4303237eb
+offers:
+  - offer_id: off_01kz4xsd0mf5p7jsxw22kp5n7k
+    program_id: prg_01kz4xsd0mbk63mas9eb1z6szw
+    offer_slug: australia-startup-offer
+    offer_slug_aliases: []
+    title: Airwallex for Startups Australia Offer
+    summary: Eligible Australian startups get three months of Airwallex plan access plus fee waivers on up to AUD $100,000 of payments and AUD $100,000 of foreign-exchange conversions.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-04T00:00:00Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Three months of Airwallex Explore for pre-seed startups or Airwallex Grow for seed-stage startups.
+          duration:
+            kind: exact
+            value: P3M
+          kind: free-service
+          service: Airwallex Explore or Grow plan, according to startup stage
+        - benefit_id: ben_02
+          description: Fees waived on the first AUD $100,000 of payments collected by eligible seed-stage startups.
+          kind: waiver
+          waived_item: Payment collection fees on the first AUD $100,000 collected
+        - benefit_id: ben_03
+          description: Foreign-exchange fees waived on the first AUD $100,000 converted by eligible seed-stage startups.
+          kind: waiver
+          waived_item: Foreign-exchange fees on the first AUD $100,000 converted
+        - benefit_id: ben_04
+          description: Access to Airwallex Yield for eligible seed-stage startups.
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: Must be a venture-backed startup at pre-seed, seed, or Series A stage with an active Airwallex account.
+          - criterion_id: cri_02
+            kind: manual
+            reason: external-verification
+            statement: Must have a business entity registered in Australia or New Zealand with a valid ABN or NZBN.
+          - criterion_id: cri_03
+            kind: manual
+            reason: external-verification
+            statement: The listed special offers are available to new customers and are subject to program approval and terms.
+    roles:
+      terms_authority_entity_id: ent_01kz4xsd0m76d5ensjb8150avj
+      access_operator_entity_id: ent_01kz4xsd0m76d5ensjb8150avj
+    access:
+      availability: public
+      method: form
+      url: https://www.airwallex.com/en-au/startups
+    source_ids:
+      - src_cb2be51ba472b23a2aafd3e4eeb23ab61713dc5150e7d67d4ea9b6f4303237eb


### PR DESCRIPTION
Adds one vendor record for the current Airwallex for Startups Australia offer, sourced from Airwallex’s first-party program page. The record captures stage-specific plan access, payment and FX fee waivers, regional eligibility, and application access.\n\nLocal pinned candidate verifier: valid (1 vendor, 1 program, 1 offer).\n\nCloses #118