### PR TITLE
Add Netlify startup program

### DIFF
--- a/vendors/ne/netlify.yaml
+++ b/vendors/ne/netlify.yaml
@@ -1,0 +1,70 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kz4xsd0ns3k4apb2f6mb5mzt
+slug: netlify
+slug_aliases: []
+name: Netlify
+domains:
+  - value: netlify.com
+    role: primary
+    valid_from: 2026-08-04T00:00:00Z
+category: hosting-infra
+description: Netlify is a platform for building, deploying, operating, and scaling web applications with managed infrastructure, functions, AI tooling, and delivery services.
+links:
+  site: https://www.netlify.com
+sources:
+  - source_id: src_6324cb2d791d084cc52da615b38ddd5f57b9827bd3ce63938578fbb596865ed5
+    url: https://www.netlify.com/partners/startups/
+programs:
+  - program_id: prg_01kz4xsd0nmarcjg5n62g20k6v
+    program_slug: netlify-for-startups
+    program_slug_aliases: []
+    title: Netlify for Startups
+    summary: A partner-routed program providing eligible venture-backed, AI-native startups with discounted Netlify access and structured support from early product development through scale.
+    source_ids:
+      - src_6324cb2d791d084cc52da615b38ddd5f57b9827bd3ce63938578fbb596865ed5
+offers:
+  - offer_id: off_01kz4xsd0n8z1360n0v4fjxcx2
+    program_id: prg_01kz4xsd0nmarcjg5n62g20k6v
+    offer_slug: discounted-startup-access
+    offer_slug_aliases: []
+    title: Netlify Discounted Startup Access
+    summary: Eligible portfolio companies of approved venture, accelerator, incubator, or startup-studio partners receive discounted Netlify access plus structured support and platform tooling.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-04T00:00:00Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: A discounted Netlify rate relative to standard pricing, with details shared after approval.
+          kind: other
+        - benefit_id: ben_02
+          description: Structured support and access to Netlify platform tools for prototyping, deployment, AI integration, security, and scaling.
+          kind: other
+      consideration:
+        kind: unknown
+        description: Approved startups select and pay for Netlify access at the program's undisclosed discounted rate.
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: Must be a VC-backed early-stage startup building an AI-native product.
+          - criterion_id: cri_02
+            kind: manual
+            reason: external-verification
+            statement: Must be a portfolio company of an approved venture firm, accelerator, incubator, or startup-studio partner and confirm that affiliation.
+          - criterion_id: cri_03
+            kind: manual
+            reason: vendor-discretion
+            statement: Netlify approval is required, and the benefit cannot be combined with other discounts or promotions.
+    roles:
+      terms_authority_entity_id: ent_01kz4xsd0ns3k4apb2f6mb5mzt
+      access_operator_entity_id: ent_01kz4xsd0ns3k4apb2f6mb5mzt
+    access:
+      availability: membership
+      method: contact
+      url: https://www.netlify.com/partners/startups/
+    source_ids:
+      - src_6324cb2d791d084cc52da615b38ddd5f57b9827bd3ce63938578fbb596865ed5

--- a/vendors/ne/netlify.yaml
+++ b/vendors/ne/netlify.yaml
@@ -27,8 +27,8 @@ offers:
     program_id: prg_01kz4xsd0nmarcjg5n62g20k6v
     offer_slug: discounted-startup-access
     offer_slug_aliases: []
-    title: Discounted Netlify access
-    summary: Eligible portfolio companies of approved venture, accelerator, incubator, or startup-studio partners receive discounted Netlify access plus structured support and platform tooling.
+    title: Ship in Days. Scale for Years.
+    summary: Eligible teams get discounted access plus structured support to move faster.
     lifecycle:
       status: active
       effective_from: 2026-08-04T00:00:00Z
@@ -66,6 +66,6 @@ offers:
       availability: membership
       method: other
       url: https://www.netlify.com/partners/startups/
-      instructions: Request startup access through an approved VC, incubator, accelerator, or startup-studio partner and confirm that affiliation; Netlify approval is required.
+      instructions: Confirm eligibility, request access, then start shipping.
     source_ids:
       - src_6324cb2d791d084cc52da615b38ddd5f57b9827bd3ce63938578fbb596865ed5

--- a/vendors/ne/netlify.yaml
+++ b/vendors/ne/netlify.yaml
@@ -8,7 +8,7 @@ domains:
     role: primary
     valid_from: 2026-08-04T00:00:00Z
 category: hosting-infra
-description: Netlify is a platform for building, deploying, operating, and scaling web applications with managed infrastructure, functions, AI tooling, and delivery services.
+description: Netlify is an AI-native, full-stack cloud platform for building, deploying, and scaling modern web applications with serverless functions, edge logic, and AI-driven workflows.
 links:
   site: https://www.netlify.com
 sources:
@@ -27,7 +27,7 @@ offers:
     program_id: prg_01kz4xsd0nmarcjg5n62g20k6v
     offer_slug: discounted-startup-access
     offer_slug_aliases: []
-    title: Netlify Discounted Startup Access
+    title: Discounted Netlify access
     summary: Eligible portfolio companies of approved venture, accelerator, incubator, or startup-studio partners receive discounted Netlify access plus structured support and platform tooling.
     lifecycle:
       status: active
@@ -64,7 +64,8 @@ offers:
       access_operator_entity_id: ent_01kz4xsd0ns3k4apb2f6mb5mzt
     access:
       availability: membership
-      method: contact
+      method: other
       url: https://www.netlify.com/partners/startups/
+      instructions: Request startup access through an approved VC, incubator, accelerator, or startup-studio partner and confirm that affiliation; Netlify approval is required.
     source_ids:
       - src_6324cb2d791d084cc52da615b38ddd5f57b9827bd3ce63938578fbb596865ed5


### PR DESCRIPTION
Adds one vendor record for the current Netlify for Startups program, sourced from Netlify’s first-party partner page. The record captures discounted access, structured support, partner affiliation requirements, and non-stacking terms.\n\nLocal pinned candidate verifier: valid (1 vendor, 1 program, 1 offer).\n\nCloses #121