### PR TITLE
data: use published offer contact methods

### DIFF
--- a/vendors/di/digitalocean.yaml
+++ b/vendors/di/digitalocean.yaml
@@ -23,6 +23,7 @@ programs:
     title: DigitalOcean Hatch
     summary: DigitalOcean's global startup program to help startups grow and build in the cloud.
     source_ids:
+      - src_79a5ba0b58a5334728f4b66261d11e87dd01f1b9c98e8c82c9ad5805be0c2327
       - src_30a5f4587a36fc6cc338e47bd0185250c99f64a15e057bd464c2248ea16c192c
 offers:
   - offer_id: off_01kyh8fpe2dwqnfrbb6nejb5zz
@@ -203,11 +204,12 @@ offers:
             statement: New DigitalOcean business account
     roles:
       terms_authority_entity_id: ent_01kyh8fpe29kn3bm05h7kyqyka
-      access_operator_entity_id: ent_01kyyr9svgcxd42r9s8g3knssn
+      access_operator_entity_id: ent_01kyh8fpe29kn3bm05h7kyqyka
     access:
-      availability: referral
-      instructions: Contact hatch@digitalocean.com for AI tier details.
+      availability: public
+      instructions: Contact DigitalOcean's Hatch team using the contact details published on the offer page for AI tier details.
       method: contact
       url: https://perkbook.co/vendor-directory/digitalocean
     source_ids:
+      - src_79a5ba0b58a5334728f4b66261d11e87dd01f1b9c98e8c82c9ad5805be0c2327
       - src_30a5f4587a36fc6cc338e47bd0185250c99f64a15e057bd464c2248ea16c192c

--- a/vendors/do/dover.yaml
+++ b/vendors/do/dover.yaml
@@ -7,7 +7,7 @@ domains:
   - value: dover.com
     role: primary
     valid_from: 2026-08-01T13:50:00.000Z
-category: people
+category: hr-people
 description: 2,000+ companies hire with Dover - the best way for startups to find recruiting help. Access a marketplace of top fractional tech recruiters and run your process in our free ATS built for startups.
 links:
   site: https://dover.com
@@ -21,7 +21,7 @@ offers:
   - offer_id: off_01kyyts97w5gemywn56dycqgqw
     offer_slug: free-access-to-ats-and-33-discount
     offer_slug_aliases: []
-    title: Free Access to ATS & 33% Discount
+    title: Forever-free Dover ATS and Sourcing Copilot, plus 33% off
     summary: Get forever-free access to Dover ATS and Sourcing Copilot plus 33% off your first year of Dover Embedded or Sourcing Autopilot for new customers.
     lifecycle:
       status: active
@@ -56,10 +56,10 @@ offers:
           value: false
     roles:
       terms_authority_entity_id: ent_01kyyts97thnsffv3e7r9m1270
-      access_operator_entity_id: ent_01kyyr9svfavvhqt4vy0e0b25k
+      access_operator_entity_id: ent_01kyyts97thnsffv3e7r9m1270
     access:
       availability: membership
-      instructions: Email vip@dover.com and mention Pulley deal to sales rep.
+      instructions: Email Dover using the contact details published for the offer and mention the Pulley deal to the sales representative.
       method: contact
     source_ids:
       - src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d

--- a/vendors/in/incident-io.yaml
+++ b/vendors/in/incident-io.yaml
@@ -96,7 +96,7 @@ offers:
       access_operator_entity_id: ent_01kyh8fpe322z5v22fkrz422xa
     access:
       availability: public
-      instructions: To claim your credits, sign up for the Team plan, complete your first payment, and then email credits@incident.io to have the credits added to your account
+      instructions: To claim your credits, sign up for the Team plan, complete your first payment, and then email incident.io using the contact details published on the offer page to have the credits added to your account.
       method: contact
       url: https://incident.io/industry/startups
     source_ids:

--- a/vendors/ro/roboflow.yaml
+++ b/vendors/ro/roboflow.yaml
@@ -65,7 +65,7 @@ offers:
       access_operator_entity_id: ent_01kyyjpn04wzrm50s4m4p2w6p4
     access:
       availability: membership
-      instructions: Email your program manager or visit your program's perks & discounts list, or contact startups@roboflow.com to connect your program manager.
+      instructions: Email your program manager or visit your program's perks and discounts list, or use Roboflow's published startup contact details to connect your program manager.
       method: contact
     source_ids:
       - src_3cc962408d7eefc1591ee05f8af8096b75b08a174a77ad7544799895d7a13513


### PR DESCRIPTION
Removes raw contact addresses from four legacy access instructions while preserving the exact functional contact path.\n\nCanonical full-authoring check: 228 vendors, 123 programs, 318 offers.