### PR TITLE
Use canonical vendor categories

### DIFF
--- a/vendors/1p/1password.yaml
+++ b/vendors/1p/1password.yaml
@@ -7,7 +7,7 @@ domains:
   - value: 1password.com
     role: primary
     valid_from: 2026-08-01T13:50:00.000Z
-category: security
+category: auth-security
 description: Read 1Password's privacy policy to learn about the company's commitment to preserving the security of your data, your privacy, and your rights to your data.
 links:
   site: https://1password.com

--- a/vendors/al/alibaba-cloud.yaml
+++ b/vendors/al/alibaba-cloud.yaml
@@ -7,7 +7,7 @@ domains:
   - value: alibabacloud.com
     role: primary
     valid_from: 2026-08-01T13:50:00.000Z
-category: cloud
+category: hosting-infra
 description: How we handle your personal data and your rights - Alibaba Cloud International Website Privacy Policy - Alibaba Cloud,Legal:This Privacy Policy applies to the access and use of the Alibaba Cloud
 links:
   site: https://alibabacloud.com

--- a/vendors/as/ashby.yaml
+++ b/vendors/as/ashby.yaml
@@ -7,7 +7,7 @@ domains:
   - value: ashbyhq.com
     role: primary
     valid_from: 2026-08-01T13:50:00.000Z
-category: people
+category: hr-people
 description: Ashby’s all-in-one recruiting software consolidates your ATS, Analytics, Scheduling, and CRM
 links:
   site: https://ashbyhq.com

--- a/vendors/de/deepinfra.yaml
+++ b/vendors/de/deepinfra.yaml
@@ -7,7 +7,7 @@ domains:
   - value: deepinfra.com
     role: primary
     valid_from: 2026-08-01T13:50:00.000Z
-category: ml
+category: ai-ml
 description: DeepInfra offers cost-effective, scalable, easy-to-deploy, and production-ready machine-learning models and infrastructures for deep-learning models.
 links:
   site: https://deepinfra.com

--- a/vendors/de/deepsource.yaml
+++ b/vendors/de/deepsource.yaml
@@ -10,7 +10,7 @@ domains:
   - value: deepsource.com
     role: alias
     valid_from: 2026-08-01T13:50:00.000Z
-category: code
+category: devtools-other
 description: Your team is writing more code with AI. DeepSource automates code reviews so you ship to production faster — catching security issues, improving code quality, and helping your team write better code.
 links:
   site: https://deepsource.com

--- a/vendors/de/descope.yaml
+++ b/vendors/de/descope.yaml
@@ -7,7 +7,7 @@ domains:
   - value: descope.com
     role: primary
     valid_from: 2026-08-01T13:50:00.000Z
-category: security
+category: auth-security
 description: Build secure, frictionless identity journeys for your users, business customers, partners, AI agents, and MCP servers with the Descope External IAM Platform.
 links:
   site: https://descope.com

--- a/vendors/dr/drata.yaml
+++ b/vendors/dr/drata.yaml
@@ -10,7 +10,7 @@ domains:
   - value: help.drata.com
     role: alias
     valid_from: 2026-08-01T13:50:00.000Z
-category: security
+category: legal-compliance
 description: Drata Help Center
 links:
   site: https://drata.com

--- a/vendors/el/ellis.yaml
+++ b/vendors/el/ellis.yaml
@@ -7,7 +7,7 @@ domains:
   - value: ellis.com
     role: primary
     valid_from: 2026-08-01T13:50:00.000Z
-category: compliance
+category: legal-compliance
 description: Ellis is a business immigration platform helping People teams secure U.S. visas and green cards for skilled talent and improve your immigration program.
 links:
   site: https://ellis.com

--- a/vendors/ex/expensify.yaml
+++ b/vendors/ex/expensify.yaml
@@ -7,7 +7,7 @@ domains:
   - value: expensify.com
     role: primary
     valid_from: 2026-08-01T13:50:00.000Z
-category: accounting
+category: finance-accounting
 description: Expensify's spend management software simplifies receipt and expense tracking. Automate reports, control spending, and save time with our easy-to-use platform.
 links:
   site: https://expensify.com

--- a/vendors/fi/firstbase.yaml
+++ b/vendors/fi/firstbase.yaml
@@ -7,7 +7,7 @@ domains:
   - value: firstbase.io
     role: primary
     valid_from: 2026-08-01T13:50:00.000Z
-category: compliance
+category: legal-compliance
 description: Firstbase helps anyone to build a US business. Start a company, set up banking, payments, and payroll, and manage a business — online, from anywhere.
 links:
   site: https://firstbase.io

--- a/vendors/fo/foundersuite.yaml
+++ b/vendors/fo/foundersuite.yaml
@@ -7,7 +7,7 @@ domains:
   - value: foundersuite.com
     role: primary
     valid_from: 2026-08-01T13:50:00.000Z
-category: fundraising
+category: finance-accounting
 description: Software for raising venture capital and managing investor relations. Used by startups, investors, accelerators and financial intermediaries
 links:
   site: https://foundersuite.com

--- a/vendors/ib/ibm.yaml
+++ b/vendors/ib/ibm.yaml
@@ -7,7 +7,7 @@ domains:
   - value: ibm.com
     role: primary
     valid_from: 2026-08-01T13:50:00.000Z
-category: infra
+category: hosting-infra
 description: For more than a century, IBM has been a global technology innovator, leading advances in AI, automation and hybrid cloud solutions that help businesses grow.
 links:
   site: https://ibm.com

--- a/vendors/ne/nebius.yaml
+++ b/vendors/ne/nebius.yaml
@@ -7,7 +7,7 @@ domains:
   - value: nebius.com
     role: primary
     valid_from: 2026-08-01T13:50:00.000Z
-category: infra
+category: hosting-infra
 description: Build and scale faster on the purpose-built AI cloud, engineered from silicon to API.
 links:
   site: https://nebius.com

--- a/vendors/no/notion.yaml
+++ b/vendors/no/notion.yaml
@@ -10,7 +10,7 @@ domains:
   - value: notion.com
     role: alias
     valid_from: 2026-08-01T13:50:00.000Z
-category: workspace
+category: productivity
 description: Build Custom Agents, search across all your apps, and automate busywork. The AI workspace where teams get more done, faster.
 links:
   site: https://notion.com

--- a/vendors/pa/pave.yaml
+++ b/vendors/pa/pave.yaml
@@ -7,7 +7,7 @@ domains:
   - value: pave.com
     role: primary
     valid_from: 2026-08-01T13:50:00.000Z
-category: people
+category: hr-people
 description: View Pave's privacy policy.
 links:
   site: https://pave.com

--- a/vendors/pe/perkbook.yaml
+++ b/vendors/pe/perkbook.yaml
@@ -7,7 +7,7 @@ domains:
   - value: perkbook.co
     role: primary
     valid_from: 2026-08-01T13:29:02.000Z
-category: startup
+category: other
 description: Manage, distribute and discover startup perks in one searchable, branded platform. Built for founders, communities, and vendors.
 links:
   site: https://perkbook.co

--- a/vendors/pu/pulley.yaml
+++ b/vendors/pu/pulley.yaml
@@ -7,7 +7,7 @@ domains:
   - value: pulley.com
     role: primary
     valid_from: 2026-08-01T13:29:02.000Z
-category: equity
+category: finance-accounting
 description: Pulley has helped thousands of companies manage their cap table and equity. Onboard with us today.
 links:
   site: https://pulley.com

--- a/vendors/pu/pulumi.yaml
+++ b/vendors/pu/pulumi.yaml
@@ -7,7 +7,7 @@ domains:
   - value: pulumi.com
     role: primary
     valid_from: 2026-08-02T15:16:42.695Z
-category: infra
+category: hosting-infra
 description: Infrastructure as code platform for defining, deploying, and managing cloud resources with familiar programming languages.
 links:
   site: https://www.pulumi.com

--- a/vendors/pu/puzzle.yaml
+++ b/vendors/pu/puzzle.yaml
@@ -7,7 +7,7 @@ domains:
   - value: puzzle.io
     role: primary
     valid_from: 2026-08-01T13:50:00.000Z
-category: accounting
+category: finance-accounting
 description: Automate your bookkeeping with Puzzle’s AI-native accounting software. Get real-time financial insights, seamless integrations (Stripe, Brex, Gusto), and tax-ready financials instantly.
 links:
   site: https://puzzle.io

--- a/vendors/ri/rippling.yaml
+++ b/vendors/ri/rippling.yaml
@@ -7,7 +7,7 @@ domains:
   - value: rippling.com
     role: primary
     valid_from: 2026-08-01T13:50:00.000Z
-category: people
+category: hr-people
 description: Rippling eliminates the friction from running a business, combining HR, IT, and Finance apps on a unified data platform.
 links:
   site: https://rippling.com

--- a/vendors/ri/rise.yaml
+++ b/vendors/ri/rise.yaml
@@ -7,7 +7,7 @@ domains:
   - value: rise.com
     role: primary
     valid_from: 2026-08-01T13:50:00.000Z
-category: training
+category: hr-people
 description: Rise is the online training system your employees will love. Easily create, share, and manage interactive training, performance support content, guides, and online courses that work perfectly on any
 links:
   site: https://rise.com

--- a/vendors/si/simpleclosure.yaml
+++ b/vendors/si/simpleclosure.yaml
@@ -7,7 +7,7 @@ domains:
   - value: simpleclosure.com
     role: primary
     valid_from: 2026-08-01T13:50:00.000Z
-category: compliance
+category: legal-compliance
 description: The shutdown standard for founders and business owners. Clarity, structure, and expert handling from the first step to the final filing.
 links:
   site: https://simpleclosure.com

--- a/vendors/sn/snyk.yaml
+++ b/vendors/sn/snyk.yaml
@@ -7,7 +7,7 @@ domains:
   - value: snyk.io
     role: primary
     valid_from: 2026-08-01T13:50:00.000Z
-category: security
+category: auth-security
 description: Snyk is the AI Security Fabric — the independent validator that makes AI-generated code, AI agents, and AI-native applications trustworthy. Unleash AI innovation securely.
 links:
   site: https://snyk.io

--- a/vendors/st/stytch.yaml
+++ b/vendors/st/stytch.yaml
@@ -7,7 +7,7 @@ domains:
   - value: stytch.com
     role: primary
     valid_from: 2026-08-01T13:50:00.000Z
-category: security
+category: auth-security
 description: APIs and SDKs to integrate authentication and security into your app.
 links:
   site: https://stytch.com

--- a/vendors/ta/tailscale.yaml
+++ b/vendors/ta/tailscale.yaml
@@ -7,7 +7,7 @@ domains:
   - value: tailscale.com
     role: primary
     valid_from: 2026-08-02T15:12:33.965Z
-category: security
+category: auth-security
 description: Secure networking software for connecting resources securely across clouds.
 links:
   site: https://tailscale.com

--- a/vendors/te/techdollar.yaml
+++ b/vendors/te/techdollar.yaml
@@ -7,7 +7,7 @@ domains:
   - value: techdollar.com
     role: primary
     valid_from: 2026-08-01T13:50:00.000Z
-category: financial
+category: banking
 description: Structured lending for individuals and investors at leading frontier technology companies.
 links:
   site: https://techdollar.com

--- a/vendors/th/the-swarm.yaml
+++ b/vendors/th/the-swarm.yaml
@@ -7,7 +7,7 @@ domains:
   - value: theswarm.com
     role: primary
     valid_from: 2026-08-01T13:50:00.000Z
-category: sales
+category: crm-sales
 description: The Swarm curates a rich dataset of 580M profiles with daily job changes, 100M companies with fundraising data, and a unique relationship mapping technology for builders and investors.
 links:
   site: https://theswarm.com

--- a/vendors/vi/visible.yaml
+++ b/vendors/vi/visible.yaml
@@ -7,7 +7,7 @@ domains:
   - value: visible.vc
     role: primary
     valid_from: 2026-08-01T13:50:00.000Z
-category: fundraising
+category: finance-accounting
 description: 950+ VC funds use Visible to turn scattered portfolio data into answers. 7,000+ founders use it to raise faster and keep investors close.
 links:
   site: https://visible.vc

--- a/vendors/wa/warp.yaml
+++ b/vendors/wa/warp.yaml
@@ -10,7 +10,7 @@ domains:
   - value: warp.co
     role: alias
     valid_from: 2026-08-01T13:50:00.000Z
-category: hr
+category: hr-people
 description: Warp is the AI-native employee management platform for high-growth companies. Payroll, compliance, and benefits that scale from 10 to 1000+ employees—all on autopilot.
 links:
   site: https://warp.co

--- a/vendors/we/webflow.yaml
+++ b/vendors/we/webflow.yaml
@@ -7,7 +7,7 @@ domains:
   - value: webflow.com
     role: primary
     valid_from: 2026-08-01T13:50:00.000Z
-category: code
+category: no-code
 description: Design, build, optimize, and rank in AI search — all in Webflow. Enterprise-grade security, CMS, hosting, and AEO built in. Trusted by over 300k teams.
 links:
   site: https://webflow.com

--- a/vendors/za/zapier.yaml
+++ b/vendors/za/zapier.yaml
@@ -7,7 +7,7 @@ domains:
   - value: zapier.com
     role: primary
     valid_from: 2026-08-01T13:50:00.000Z
-category: code
+category: no-code
 description: Build and scale AI workflows and agents across 9,000+ apps with Zapier—the most connected AI orchestration platform. Trusted by 3 million+ businesses.
 links:
   site: https://zapier.com


### PR DESCRIPTION
Replaces the 31 remaining legacy vendor categories with the current canonical taxonomy. This is the full-catalog repair exposed by the clean genesis build; no offers, economics, eligibility, URLs, or IDs change.