### PR TITLE
catalog: add Gleap startup program

### DIFF
--- a/vendors/gl/gleap.yaml
+++ b/vendors/gl/gleap.yaml
@@ -1,0 +1,99 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kz802sprm7338gk6v5ewrrzd
+slug: gleap
+slug_aliases: []
+name: Gleap
+domains:
+  - value: gleap.io
+    role: primary
+    valid_from: 2026-08-05T03:39:40.641Z
+category: support
+description: Gleap provides a customer feedback and support platform with AI agents, bug reporting, roadmaps, surveys, product tours, automation, and integrations.
+links:
+  site: https://www.gleap.io
+sources:
+  - source_id: src_c7d16be7990a014da830bc6e48670b32bc8cbf899b90de74754cfdac4e01f101
+    url: https://www.gleap.io/early-stage-startups
+programs:
+  - program_id: prg_01kz802sq01ra8ewt1t7rtb9d7
+    program_slug: gleap-for-startups
+    program_slug_aliases: []
+    title: Gleap for Startups
+    summary: Gleap for Startups gives eligible early-stage product companies half-price access to the Team or Pro plan for their first year.
+    source_ids:
+      - src_c7d16be7990a014da830bc6e48670b32bc8cbf899b90de74754cfdac4e01f101
+offers:
+  - offer_id: off_01kz802sq1cr8gx8v7c6wr2ae1
+    program_id: prg_01kz802sq01ra8ewt1t7rtb9d7
+    offer_slug: gleap-team-or-pro-startup-discount
+    offer_slug_aliases: []
+    title: Gleap for Startups - 50% Off Team or Pro
+    summary: Eligible early-stage product startups receive 50% off Gleap Team or Pro for 12 months; annual billing starts at $74.50 per month for Team or $149.50 for Pro.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-05T03:39:40.641Z
+    economics:
+      benefits:
+        - applies_to: Gleap Team or Pro plans
+          benefit_id: ben_01
+          description: 50% off Team or Pro for 12 months; annual billing starts at $74.50 per month for Team or $149.50 per month for Pro.
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            basis_points: 5000
+            kind: exact
+      consideration:
+        kind: variable
+        description: Purchase an eligible Team or Pro subscription at its discounted plan price.
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.age_months
+            kind: predicate
+            operator: lte
+            statement: Company must have been founded within the last three years
+            value:
+              type: number
+              value: 36
+          - criterion_id: cri_02
+            fact: company.employee_count
+            kind: predicate
+            operator: lt
+            statement: Company must have fewer than 20 full-time employees
+            value:
+              type: number
+              value: 20
+          - criterion_id: cri_03
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: Company must have raised less than USD 2 million in total funding
+            value:
+              type: number
+              value: 2000000
+          - criterion_id: cri_04
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: Company must not currently be on a paid Gleap plan
+            value:
+              type: boolean
+              value: false
+          - criterion_id: cri_05
+            kind: manual
+            reason: not-machine-evaluable
+            statement: Applicant must be actively building a product rather than operating an agency
+    roles:
+      terms_authority_entity_id: ent_01kz802sprm7338gk6v5ewrrzd
+      access_operator_entity_id: ent_01kz802sprm7338gk6v5ewrrzd
+    access:
+      availability: public
+      method: form
+      url: https://www.gleap.io/early-stage-startups
+    terms_url: https://www.gleap.io/early-stage-startups
+    source_ids:
+      - src_c7d16be7990a014da830bc6e48670b32bc8cbf899b90de74754cfdac4e01f101


### PR DESCRIPTION
## What changed

- Adds one new vendor record for Gleap with one startup program and one offer.
- Records the 50% Team or Pro discount for eligible early-stage startups.
- Closes #193.

## Sources

- https://www.gleap.io/early-stage-startups
- https://www.gleap.io

## Validation

- Pinned Candidate Verifier: `{"status":"valid","vendors":1,"programs":1,"offers":1}`
- Commit includes a DCO sign-off.

## Certification

- [x] I changed only allowed repository content and did not mix vendor YAML with other paths.
- [x] Public sources substantiate every submitted factual value; any Sourcey-written prose is a neutral summary, not a fabricated vendor quote.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commits include a `Signed-off-by` line.
