### PR TITLE
data: add EmberCloud startup API credits

### DIFF
--- a/vendors/em/embercloud.yaml
+++ b/vendors/em/embercloud.yaml
@@ -1,0 +1,64 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kz98vy52ef818r6mb2w73xhg
+slug: embercloud
+slug_aliases: []
+name: EmberCloud
+domains:
+  - value: embercloud.ai
+    role: primary
+    valid_from: 2026-08-05T15:32:48.000Z
+category: ai-ml
+description: EmberCloud provides OpenAI-compatible API access to hosted language models for AI applications.
+links:
+  site: https://www.embercloud.ai
+sources:
+  - source_id: src_aafdea411ccc55f1d4cd0206f736db78b0bd145a42aa37bafdeaa1ba470fd3d2
+    url: https://www.embercloud.ai/startups
+programs:
+  - program_id: prg_01kz98vy54vd1we303zr1rv5bw
+    program_slug: embercloud-for-startups-and-indie-hackers
+    program_slug_aliases: []
+    title: EmberCloud for Startups & Indie Hackers
+    summary: EmberCloud offers approved startups and indie projects API credits for building AI products with its OpenAI-compatible inference service.
+    source_ids:
+      - src_aafdea411ccc55f1d4cd0206f736db78b0bd145a42aa37bafdeaa1ba470fd3d2
+offers:
+  - offer_id: off_01kz98vy54gn06vssndmjzmbkp
+    program_id: prg_01kz98vy54vd1we303zr1rv5bw
+    offer_slug: one-hundred-dollars-api-credits
+    offer_slug_aliases: []
+    title: $100 in EmberCloud API credits
+    summary: Approved startups and indie projects receive $100 in API credits after adding $5 to verify the company and activate the offer.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-05T15:32:48.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: $100 in EmberCloud API credits upon approval
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 10000
+            kind: exact
+      consideration:
+        kind: fixed
+        amount:
+          currency: USD
+          minor_units: 500
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: vendor-discretion
+        statement: Applicants submit a startup or project for EmberCloud's manual review; the program is presented for startups and indie hackers.
+    roles:
+      terms_authority_entity_id: ent_01kz98vy52ef818r6mb2w73xhg
+      access_operator_entity_id: ent_01kz98vy52ef818r6mb2w73xhg
+    access:
+      availability: public
+      method: form
+      url: https://www.embercloud.ai/startups
+    source_ids:
+      - src_aafdea411ccc55f1d4cd0206f736db78b0bd145a42aa37bafdeaa1ba470fd3d2


### PR DESCRIPTION
## What changed

Adds one new EmberCloud vendor record and its single public startup offer: $100 in API credits upon approval, with the vendor-published $5 company-verification payment represented as fixed consideration.

Closes #210.

## Sources

- https://www.embercloud.ai/startups

## Certification

- [x] I changed only allowed repository content and did not mix vendor YAML with other paths.
- [x] Public sources substantiate every submitted factual value; any Sourcey-written prose is a neutral summary, not a fabricated vendor quote.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commits include a `Signed-off-by` line.

## Local verification

The digest-pinned Sourcey Candidate Verifier reports: `{"status":"valid","vendors":1,"programs":1,"offers":1}`.