### PR TITLE
data: add Appice Liftoff startup credits

### DIFF
--- a/vendors/ap/appice.yaml
+++ b/vendors/ap/appice.yaml
@@ -1,0 +1,68 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kz992w9pw5xb38w1sbzd7q3s
+slug: appice
+slug_aliases: []
+name: Appice
+domains:
+  - value: appice.ai
+    role: primary
+    valid_from: 2026-08-05T15:36:00.000Z
+category: marketing
+description: Appice provides a real-time customer decisioning platform for acquisition, activation, retention, and monetisation workflows.
+links:
+  site: https://appice.ai
+sources:
+  - source_id: src_0082e63088103b5ce31af00076dea3c65532a6e7828a01d92e4e073b3ee2ff42
+    url: https://appice.ai/startup
+programs:
+  - program_id: prg_01kz992w9qs7mjtdqxt3cmjaxx
+    program_slug: appice-liftoff
+    program_slug_aliases: []
+    title: Appice Liftoff
+    summary: Appice Liftoff supplies early-stage startups with platform credits, decision templates, onboarding workshops, direct support, and a founder community.
+    source_ids:
+      - src_0082e63088103b5ce31af00076dea3c65532a6e7828a01d92e4e073b3ee2ff42
+offers:
+  - offer_id: off_01kz992w9qrkrt0vte7kknthqm
+    program_id: prg_01kz992w9qs7mjtdqxt3cmjaxx
+    offer_slug: up-to-fifty-thousand-dollars-credits
+    offer_slug_aliases: []
+    title: Up to $50,000 in Appice credits for 12 months
+    summary: Eligible startups receive credits valid for 12 months, sized by stage at $10,000 for pre-seed, $25,000 for seed, and up to $50,000 for Series A.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-05T15:36:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: $10,000 for pre-seed startups, $25,000 for seed startups, or up to $50,000 for Series A startups in Appice credits
+          duration:
+            kind: exact
+            value: P1Y
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 5000000
+            kind: up-to
+        - benefit_id: ben_02
+          description: Three live onboarding workshops and direct Slack support from Appice engineering and solutions staff
+          kind: free-service
+          service: onboarding workshops and direct Slack support
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: not-machine-evaluable
+        statement: The startup must be pre-seed through Series A, have raised no more than $5 million, have incorporated within the last five years, operate a live product or working private beta with real users, and have a customer engagement or growth use case.
+    roles:
+      terms_authority_entity_id: ent_01kz992w9pw5xb38w1sbzd7q3s
+      access_operator_entity_id: ent_01kz992w9pw5xb38w1sbzd7q3s
+    access:
+      availability: public
+      method: form
+      url: https://appice.ai/startup
+    source_ids:
+      - src_0082e63088103b5ce31af00076dea3c65532a6e7828a01d92e4e073b3ee2ff42


### PR DESCRIPTION
## What changed

Adds one new Appice vendor record and its Liftoff startup offer. The single offer models the published stage-based credits ($10K pre-seed, $25K seed, up to $50K Series A), 12-month validity, onboarding/support benefits, and the complete first-party eligibility bar.

Closes #213.

## Sources

- https://appice.ai/startup

## Certification

- [x] I changed only allowed repository content and did not mix vendor YAML with other paths.
- [x] Public sources substantiate every submitted factual value; any Sourcey-written prose is a neutral summary, not a fabricated vendor quote.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commits include a `Signed-off-by` line.

## Local verification

The digest-pinned Sourcey Candidate Verifier reports: `{"status":"valid","vendors":1,"programs":1,"offers":1}`.