### PR TITLE
Add Serverspace startup cloud credits

### DIFF
--- a/vendors/se/serverspace.yaml
+++ b/vendors/se/serverspace.yaml
@@ -1,0 +1,78 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kz9abfmx35rb5yqrcyq8n15j
+slug: serverspace
+slug_aliases: []
+name: Serverspace
+domains:
+  - value: serverspace.us
+    role: primary
+    valid_from: 2026-08-05T15:58:25.000Z
+category: hosting-infra
+description: Cloud infrastructure provider offering virtual servers, networks, managed Kubernetes, storage, and developer tools.
+links:
+  site: https://serverspace.us
+sources:
+  - source_id: src_53c0ab6f2359b3a4e4382b26ba63f5d9bcbdc7a302a10ecb9e1378f45ab519c6
+    url: https://serverspace.us/solutions/startup-cloud-program/
+programs:
+  - program_id: prg_01kz9abfmy9f4d0fhe4q691ng1
+    program_slug: serverspace-startup-program
+    program_slug_aliases: []
+    title: Serverspace Startup Program
+    summary: Serverspace provides qualifying startups with cloud credits, technical support, partner perks, and expert sessions.
+    source_ids:
+      - src_53c0ab6f2359b3a4e4382b26ba63f5d9bcbdc7a302a10ecb9e1378f45ab519c6
+offers:
+  - offer_id: off_01kz9abfmy57713cdr4bhnjvr4
+    program_id: prg_01kz9abfmy9f4d0fhe4q691ng1
+    offer_slug: up-to-10000-in-cloud-credits-for-one-year
+    offer_slug_aliases: []
+    title: Up to $10,000 in cloud credits for one year
+    summary: Qualifying startups can receive a tailored first-year cloud credit package of up to $10,000, 24/7 technical support, partner perks, and personalized expert sessions.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-05T15:58:25.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $10,000 in Serverspace cloud infrastructure credits
+          duration:
+            kind: exact
+            value: P1Y
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 1000000
+            kind: up-to
+        - benefit_id: ben_02
+          description: 24/7 technical human support with a stated 15-minute response time
+          kind: free-service
+          service: Premium technical support
+        - benefit_id: ben_03
+          description: Partner discounts, early beta access, and dedicated mentorship
+          kind: other
+        - benefit_id: ben_04
+          description: Personalized sessions with product managers, engineers, and other experts
+          kind: free-service
+          service: Expert sessions
+      consideration:
+        description: Program participants agree that Serverspace may include their company name and logo in partner lists and promotional materials.
+        kind: variable
+    eligibility:
+      rule:
+        criterion_id: cri_requirement_01
+        kind: manual
+        reason: not-machine-evaluable
+        statement: Applicant must have an active company website, a business email on that domain, a startup founded within the last five years, its own logo and brand identity, and a defined business plan or investor pitch.
+    roles:
+      terms_authority_entity_id: ent_01kz9abfmx35rb5yqrcyq8n15j
+      access_operator_entity_id: ent_01kz9abfmx35rb5yqrcyq8n15j
+    access:
+      availability: public
+      instructions: Complete the application form to join the waitlist. Serverspace states that it is accepting applications while active review is temporarily paused.
+      method: form
+      url: https://serverspace.us/solutions/startup-cloud-program/
+    terms_url: https://serverspace.us/solutions/startup-cloud-program/
+    source_ids:
+      - src_53c0ab6f2359b3a4e4382b26ba63f5d9bcbdc7a302a10ecb9e1378f45ab519c6


### PR DESCRIPTION
Adds the Serverspace Startup Program from the provider's first-party offer page.

- Up to $10,000 in cloud credits for one year
- 24/7 technical support
- Partner perks and expert sessions
- Documents the current application-review pause and waitlist
- Local candidate verifier: `valid` (1 vendor, 1 program, 1 offer)

Closes #219