### PR TITLE
data: add Estuary startup credits

### DIFF
--- a/vendors/es/estuary.yaml
+++ b/vendors/es/estuary.yaml
@@ -1,0 +1,77 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kz9pjmaq71h292a7y83rns5z
+slug: estuary
+slug_aliases: []
+name: Estuary
+domains:
+  - value: estuary.dev
+    role: primary
+    valid_from: 2026-08-05T19:32:02.000Z
+category: data-analytics
+description: Estuary provides managed real-time and batch data integration, change data capture, and pipelines across databases, SaaS apps, streams, warehouses, and lakes.
+links:
+  site: https://estuary.dev
+sources:
+  - source_id: src_a5abcf41ed03082a9bca23c1b3a49796cd3a030bed74596b62a386f85b93ddbb
+    url: https://estuary.dev/startup/
+programs:
+  - program_id: prg_01kz9pjmasrm345ze8f90b2en4
+    program_slug: estuary-for-startups
+    program_slug_aliases: []
+    title: Estuary for Startups
+    summary: A startup program providing Estuary Cloud usage credits, complimentary technical support, and data-integration guides without requiring accelerator affiliation.
+    source_ids:
+      - src_a5abcf41ed03082a9bca23c1b3a49796cd3a030bed74596b62a386f85b93ddbb
+offers:
+  - offer_id: off_01kz9pjmasgfjpbbh17kzv74jz
+    program_id: prg_01kz9pjmasrm345ze8f90b2en4
+    offer_slug: estuary-for-startups-cloud-credits
+    offer_slug_aliases: []
+    title: Estuary for Startups Cloud Credits
+    summary: Early-stage startups with less than $5 million raised and no current or former Estuary account receive $2,000 in Cloud credits for 12 months. No accelerator affiliation is required.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-05T19:32:02.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: $2,000 in Estuary Cloud usage credits
+          duration:
+            kind: exact
+            value: P1Y
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 200000
+            kind: exact
+        - benefit_id: ben_02
+          description: Complimentary email and Slack technical support for setup and best practices
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: Startup has raised less than $5 million in total funding.
+            value:
+              type: number
+              value: 5000000
+          - criterion_id: cri_02
+            kind: manual
+            reason: vendor-discretion
+            statement: Applicant must not be a current or former Estuary customer.
+    roles:
+      terms_authority_entity_id: ent_01kz9pjmaq71h292a7y83rns5z
+      access_operator_entity_id: ent_01kz9pjmaq71h292a7y83rns5z
+    access:
+      availability: public
+      method: form
+      url: https://estuary.dev/contact-us/
+    source_ids:
+      - src_a5abcf41ed03082a9bca23c1b3a49796cd3a030bed74596b62a386f85b93ddbb


### PR DESCRIPTION
## Summary

- Add Estuary as a data integration vendor.
- Add its official Estuary for Startups program.
- Record $2,000 in Estuary Cloud usage credits for 12 months, complimentary technical support, and the published eligibility constraints.
- Use only the official vendor page as the factual source.

## Verification

- Official source returns HTTP 200: https://estuary.dev/startup/
- Sourcey candidate verifier: `{"status":"valid","vendors":1,"programs":1,"offers":1}`
- Commit is DCO-signed.
- Data-only change limited to `vendors/es/estuary.yaml`.

Closes #224
