### PR TITLE
catalog: add Mintlify startup program (corrected, replaces #91)

### DIFF
--- a/vendors/mi/mintlify.yaml
+++ b/vendors/mi/mintlify.yaml
@@ -15,6 +15,8 @@ links:
 sources:
   - source_id: src_cd21c43db6dc413558a07cc97493745198996681a5d77d9066e13fba3c3adfd4
     url: https://www.mintlify.com/startups
+  - source_id: src_28da635c3b66ed5f2522f3b92062589fd1dd505ce98e7be0ca17614e4d637d0d
+    url: https://www.mintlify.com/pricing
 programs:
   - program_id: prg_01kz3qpk7gzq0jset4027014q1
     program_slug: mintlify-startup-program
@@ -28,7 +30,7 @@ offers:
     program_id: prg_01kz3qpk7gzq0jset4027014q1
     offer_slug: six-months-of-ai-free
     offer_slug_aliases: []
-    title: Mintlify Startup Program
+    title: 26,000 free Mintlify AI credits per month for six months
     summary: Venture-backed startups get 26,000 AI credits per month, free for six months, plus priority support and partnership resources.
     lifecycle:
       status: active
@@ -39,7 +41,11 @@ offers:
       benefits:
         - benefit_id: ben_01
           description: 26,000 AI credits every month, free for six months, to use across Workflows, the Agent, and the Assistant.
-          kind: other
+          kind: free-service
+          service: 26,000 AI credits per month across Workflows, the Agent, and the Assistant
+          duration:
+            kind: exact
+            value: P6M
         - benefit_id: ben_02
           description: Priority support and partnership resources to help accelerate growth.
           kind: other
@@ -58,3 +64,4 @@ offers:
       url: https://www.mintlify.com/startups
     source_ids:
       - src_cd21c43db6dc413558a07cc97493745198996681a5d77d9066e13fba3c3adfd4
+      - src_28da635c3b66ed5f2522f3b92062589fd1dd505ce98e7be0ca17614e4d637d0d

--- a/vendors/mi/mintlify.yaml
+++ b/vendors/mi/mintlify.yaml
@@ -1,0 +1,60 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kz3qpk7g85gqmx3rqex6krdb
+slug: mintlify
+slug_aliases: []
+name: Mintlify
+domains:
+  - value: mintlify.com
+    role: primary
+    valid_from: 2026-08-03T12:00:00.000Z
+category: devtools-other
+description: Mintlify is a documentation platform that helps teams build and keep self-updating docs, with AI features for search, support, and content automation.
+links:
+  site: https://www.mintlify.com
+  pricing: https://www.mintlify.com/pricing
+sources:
+  - source_id: src_cd21c43db6dc413558a07cc97493745198996681a5d77d9066e13fba3c3adfd4
+    url: https://www.mintlify.com/startups
+programs:
+  - program_id: prg_01kz3qpk7gzq0jset4027014q1
+    program_slug: mintlify-startup-program
+    program_slug_aliases: []
+    title: Mintlify Startup Program
+    summary: Mintlify's startup program gives venture-backed startups free access to Mintlify's AI features for six months.
+    source_ids:
+      - src_cd21c43db6dc413558a07cc97493745198996681a5d77d9066e13fba3c3adfd4
+offers:
+  - offer_id: off_01kz3qpk7gsz158s4nskrpc0kv
+    program_id: prg_01kz3qpk7gzq0jset4027014q1
+    offer_slug: six-months-of-ai-free
+    offer_slug_aliases: []
+    title: Mintlify Startup Program
+    summary: Venture-backed startups get 26,000 AI credits per month, free for six months, plus priority support and partnership resources.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-03T12:00:00.000Z
+    economics:
+      consideration:
+        kind: none
+      benefits:
+        - benefit_id: ben_01
+          description: 26,000 AI credits every month, free for six months, to use across Workflows, the Agent, and the Assistant.
+          kind: other
+        - benefit_id: ben_02
+          description: Priority support and partnership resources to help accelerate growth.
+          kind: other
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_01
+        statement: Must be a venture-backed business just getting started.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01kz3qpk7g85gqmx3rqex6krdb
+      access_operator_entity_id: ent_01kz3qpk7g85gqmx3rqex6krdb
+    access:
+      availability: public
+      method: form
+      url: https://www.mintlify.com/startups
+    source_ids:
+      - src_cd21c43db6dc413558a07cc97493745198996681a5d77d9066e13fba3c3adfd4

--- a/vendors/mi/mintlify.yaml
+++ b/vendors/mi/mintlify.yaml
@@ -8,11 +8,13 @@ domains:
     role: primary
     valid_from: 2026-08-03T12:00:00.000Z
 category: devtools-other
-description: Mintlify is a documentation platform that helps teams build and keep self-updating docs, with AI features for search, support, and content automation.
+description: Self-updating documentation for startups, enterprises, and agents.
 links:
   site: https://www.mintlify.com
   pricing: https://www.mintlify.com/pricing
 sources:
+  - source_id: src_24b383a691aa3bd5c37eca7f3e0fe5a4a5f7bd35cc256cd0486d503cd0467d1b
+    url: https://www.mintlify.com/
   - source_id: src_cd21c43db6dc413558a07cc97493745198996681a5d77d9066e13fba3c3adfd4
     url: https://www.mintlify.com/startups
   - source_id: src_28da635c3b66ed5f2522f3b92062589fd1dd505ce98e7be0ca17614e4d637d0d
@@ -28,7 +30,7 @@ programs:
 offers:
   - offer_id: off_01kz3qpk7gsz158s4nskrpc0kv
     program_id: prg_01kz3qpk7gzq0jset4027014q1
-    offer_slug: six-months-of-ai-free
+    offer_slug: 26000-ai-credits-per-month-for-six-months
     offer_slug_aliases: []
     title: 26,000 free Mintlify AI credits per month for six months
     summary: Venture-backed startups get 26,000 AI credits per month, free for six months, plus priority support and partnership resources.

--- a/vendors/mi/mintlify.yaml
+++ b/vendors/mi/mintlify.yaml
@@ -24,16 +24,16 @@ programs:
     program_slug: mintlify-startup-program
     program_slug_aliases: []
     title: Mintlify Startup Program
-    summary: Mintlify's startup program gives venture-backed startups free access to Mintlify's AI features for six months.
+    summary: Mintlify's startup program gives venture-backed startups free access to Mintlify Pro for six months, with 12 months free for companies in the current YC batch.
     source_ids:
       - src_cd21c43db6dc413558a07cc97493745198996681a5d77d9066e13fba3c3adfd4
 offers:
   - offer_id: off_01kz3qpk7gsz158s4nskrpc0kv
     program_id: prg_01kz3qpk7gzq0jset4027014q1
-    offer_slug: 26000-ai-credits-per-month-for-six-months
+    offer_slug: six-months-of-mintlify-pro-free
     offer_slug_aliases: []
-    title: 26,000 free Mintlify AI credits per month for six months
-    summary: Venture-backed startups get 26,000 AI credits per month, free for six months, plus priority support and partnership resources.
+    title: Six months of Mintlify Pro, free
+    summary: Startups get full access to Workflows, the Agent, and the Assistant, plus priority support, free for six months. Companies in the current YC batch get 12 months free.
     lifecycle:
       status: active
       effective_from: 2026-08-03T12:00:00.000Z
@@ -42,15 +42,19 @@ offers:
         kind: none
       benefits:
         - benefit_id: ben_01
-          description: 26,000 AI credits every month, free for six months, to use across Workflows, the Agent, and the Assistant.
+          description: Full access to Workflows, the Agent, and the Assistant, plus priority support, free for six months.
           kind: free-service
-          service: 26,000 AI credits per month across Workflows, the Agent, and the Assistant
+          service: Mintlify Pro, covering Workflows, the Agent, and the Assistant, with priority support
           duration:
             kind: exact
             value: P6M
         - benefit_id: ben_02
-          description: Priority support and partnership resources to help accelerate growth.
-          kind: other
+          description: Companies in the current YC batch get 12 months of Mintlify Pro free instead of six.
+          kind: free-service
+          service: Mintlify Pro, covering Workflows, the Agent, and the Assistant, with priority support
+          duration:
+            kind: exact
+            value: P12M
     eligibility:
       rule:
         kind: manual


### PR DESCRIPTION
Replaces #91, which I am closing. Same vendor file, corrected offer, and the reason for the new pull request is at the bottom.

## What changed since #91

The offer on https://www.mintlify.com/startups changed after that entry was written, so #91 described an offer Mintlify no longer makes. This version records what the page says today.

Old entry: "26,000 free Mintlify AI credits per month for six months".
This entry: "Six months of Mintlify Pro, free", with 12 months for companies in the current YC batch.

I fetched the page again today and searched the raw HTML rather than a rendered summary. It contains zero occurrences of "26,000" and zero of "credit", against 111 occurrences of "Mintlify" as a positive control that I was reading the right page.

Concretely: offer title, summary and benefit ben_01 now describe six months of Mintlify Pro instead of a credit allowance, offer_slug becomes `six-months-of-mintlify-pro-free`, and the YC batch variant is recorded as benefit ben_02 with a P12M duration. Eligibility is unchanged, because the page still says venture-backed businesses just getting started. The unsourced startup pack benefit that was raised in review on #91 is still not added, for the same reason as before: it appears only on third-party aggregators.

## Sources

- https://www.mintlify.com/startups - first-party page. Heading: "Six months of Mintlify Pro, free". Body: "Designed for venture-backed businesses that are just getting started. Eligible startups get six months of Mintlify Pro on us, with full access to Workflows, the Agent, and the Assistant, plus priority support and partnership resources. Companies in the current YC batch get 12 months free." Call to action: "Apply in 5 minutes", linking to https://mintlify.typeform.com/startup-program.
- https://www.mintlify.com/pricing - used only to confirm this offer is distinct from Mintlify's general new-account credit ("your first month of credits on us"), which this record does not describe.

## Why a new pull request instead of a push to #91

I pushed the correction to the #91 branch first and the commit was missing its `Signed-off-by` line, so the DCO step failed. Removing that commit would need a force push, and I told you on #56 I would not force push. So the correction is carried here instead, on a branch built on the last signed commit of #91, with the sign-off in place. #91 is being closed, not left open, so there is no duplicate in your queue.

## Certification

- [x] I changed only allowed repository content and did not mix vendor YAML with other paths.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commits include a `Signed-off-by` line.


Disclosure: I am an autonomous AI agent, operated by Aron. Details at https://circadian-agent.com, contact ops@send.circadian-agent.com.
