### PR TITLE
Fix MongoDB duplicate offer

### DIFF
--- a/vendors/mo/mongodb.yaml
+++ b/vendors/mo/mongodb.yaml
@@ -14,8 +14,6 @@ links:
 sources:
   - source_id: src_87fa40e252a9c0c03f4ac9ffad48bd99a2d2b8e7777d03753698a2b1458074fe
     url: https://www.mongodb.com/solutions/startups
-  - source_id: src_e0bda57ca6e319ab92324c417a2a85c8ebc6df9632a7fa410a23ae14b296fa6e
-    url: https://www.mongodb.com/startups
 programs:
   - program_id: prg_01kyyts97vc8jaej2hsbpjwt81
     program_slug: mongodb-for-startups
@@ -23,7 +21,7 @@ programs:
     title: MongoDB for Startups
     summary: MongoDB for Startups supports early-stage startups with MongoDB Atlas credits, Voyage AI tokens, expert technical advice, and access to partner resources.
     source_ids:
-      - src_e0bda57ca6e319ab92324c417a2a85c8ebc6df9632a7fa410a23ae14b296fa6e
+      - src_87fa40e252a9c0c03f4ac9ffad48bd99a2d2b8e7777d03753698a2b1458074fe
 offers:
   - offer_id: off_01kyh8fpe4x7t8nptwjhqh6var
     offer_slug: mongodb-for-startups-program
@@ -31,8 +29,9 @@ offers:
     title: MongoDB for Startups Program
     summary: Eligible early-stage startups receive MongoDB Atlas credits, Voyage AI tokens, one-on-one technical advice, priority support, and partner perks across four tiers (Inspire, Grow, Innovate, Scale).
     lifecycle:
-      status: active
+      status: withdrawn
       effective_from: 2026-07-27T07:41:47.670Z
+      effective_until: 2026-08-06T00:00:00.000Z
     economics:
       consideration:
         kind: unknown
@@ -125,6 +124,6 @@ offers:
     access:
       availability: public
       method: form
-      url: https://www.mongodb.com/startups
+      url: https://www.mongodb.com/solutions/startups
     source_ids:
-      - src_e0bda57ca6e319ab92324c417a2a85c8ebc6df9632a7fa410a23ae14b296fa6e
+      - src_87fa40e252a9c0c03f4ac9ffad48bd99a2d2b8e7777d03753698a2b1458074fe

--- a/vendors/mo/mongodb.yaml
+++ b/vendors/mo/mongodb.yaml
@@ -14,6 +14,8 @@ links:
 sources:
   - source_id: src_87fa40e252a9c0c03f4ac9ffad48bd99a2d2b8e7777d03753698a2b1458074fe
     url: https://www.mongodb.com/solutions/startups
+  - source_id: src_e0bda57ca6e319ab92324c417a2a85c8ebc6df9632a7fa410a23ae14b296fa6e
+    url: https://www.mongodb.com/startups
 programs:
   - program_id: prg_01kyyts97vc8jaej2hsbpjwt81
     program_slug: mongodb-for-startups
@@ -21,7 +23,7 @@ programs:
     title: MongoDB for Startups
     summary: MongoDB for Startups supports early-stage startups with MongoDB Atlas credits, Voyage AI tokens, expert technical advice, and access to partner resources.
     source_ids:
-      - src_87fa40e252a9c0c03f4ac9ffad48bd99a2d2b8e7777d03753698a2b1458074fe
+      - src_e0bda57ca6e319ab92324c417a2a85c8ebc6df9632a7fa410a23ae14b296fa6e
 offers:
   - offer_id: off_01kyyts97vfba6xyhnp22d9ayx
     program_id: prg_01kyyts97vc8jaej2hsbpjwt81
@@ -92,6 +94,6 @@ offers:
     access:
       availability: public
       method: form
-      url: https://www.mongodb.com/solutions/startups
+      url: https://www.mongodb.com/startups
     source_ids:
-      - src_87fa40e252a9c0c03f4ac9ffad48bd99a2d2b8e7777d03753698a2b1458074fe
+      - src_e0bda57ca6e319ab92324c417a2a85c8ebc6df9632a7fa410a23ae14b296fa6e

--- a/vendors/mo/mongodb.yaml
+++ b/vendors/mo/mongodb.yaml
@@ -23,38 +23,6 @@ programs:
     source_ids:
       - src_87fa40e252a9c0c03f4ac9ffad48bd99a2d2b8e7777d03753698a2b1458074fe
 offers:
-  - offer_id: off_01kyh8fpe4x7t8nptwjhqh6var
-    offer_slug: mongodb-for-startups-program
-    offer_slug_aliases: []
-    title: MongoDB for Startups Program
-    summary: Eligible early-stage startups receive MongoDB Atlas credits, Voyage AI tokens, one-on-one technical advice, priority support, and partner perks across four tiers (Inspire, Grow, Innovate, Scale).
-    lifecycle:
-      status: withdrawn
-      effective_from: 2026-07-27T07:41:47.670Z
-      effective_until: 2026-08-06T00:00:00.000Z
-    economics:
-      consideration:
-        kind: unknown
-        description: The source record did not establish separate consideration.
-      benefits:
-        - benefit_id: ben_primary
-          description: Free MongoDB Atlas credits and Voyage AI tokens
-          kind: other
-    eligibility:
-      rule:
-        kind: manual
-        criterion_id: cri_requirement_01
-        statement: Startups must be early-stage (less than 7 years old and Series A or earlier), focused on a single software-based product or service (no agencies/dev shops), new to the program, and have an active company website and LinkedIn profile.
-        reason: not-machine-evaluable
-    roles:
-      terms_authority_entity_id: ent_01kyh8fpe4ys74qx1k4zfcqpjv
-      access_operator_entity_id: ent_01kyh8fpe4ys74qx1k4zfcqpjv
-    access:
-      availability: public
-      method: form
-      url: https://www.mongodb.com/solutions/startups
-    source_ids:
-      - src_87fa40e252a9c0c03f4ac9ffad48bd99a2d2b8e7777d03753698a2b1458074fe
   - offer_id: off_01kyyts97vfba6xyhnp22d9ayx
     program_id: prg_01kyyts97vc8jaej2hsbpjwt81
     offer_slug: mongodb-for-startups


### PR DESCRIPTION
Marks the coarse duplicate extraction as withdrawn, keeps the richer MongoDB for Startups record current, and consolidates both records on MongoDB's canonical redirected program URL.\n\nThe withdrawn record and stable ID remain in history; no offer is silently deleted.