### PR TITLE
Add Groq startup credits offer

### DIFF
--- a/vendors/gr/groq.yaml
+++ b/vendors/gr/groq.yaml
@@ -1,0 +1,54 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kzamwmfj9a44m1dzyhdafp70
+slug: groq
+slug_aliases: []
+name: Groq
+domains:
+  - value: groq.com
+    role: primary
+    valid_from: 2026-08-05T00:00:00Z
+category: ai-ml
+description: Groq provides fast inference APIs and developer infrastructure for building AI applications.
+links:
+  site: https://groq.com
+sources:
+  - source_id: src_b4d2f18f12e67217dbec0e7ba07bc6a6f95a8b98aef37cdece371a7a7c56539c
+    url: https://console.groq.com/docs/billing-faqs
+programs: []
+offers:
+  - offer_id: off_01kzamwmfxb2sbz98m8c1s7yk6
+    offer_slug: groq-for-startups
+    offer_slug_aliases: []
+    title: Groq for Startups
+    summary: Startups may be eligible for $10,000 in Groq credits to help scale their products.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-05T00:00:00Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: $10,000 in Groq credits.
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 1000000
+            kind: exact
+      consideration:
+        kind: unknown
+        description: The public FAQ does not state separate consideration for the startup credit program.
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_01
+        reason: not-machine-evaluable
+        statement: Applicant is building a startup and may be eligible for the Groq for Startups program.
+    roles:
+      terms_authority_entity_id: ent_01kzamwmfj9a44m1dzyhdafp70
+      access_operator_entity_id: ent_01kzamwmfj9a44m1dzyhdafp70
+    access:
+      availability: public
+      method: other
+      url: https://console.groq.com/docs/billing-faqs
+    source_ids:
+      - src_b4d2f18f12e67217dbec0e7ba07bc6a6f95a8b98aef37cdece371a7a7c56539c

--- a/vendors/gr/groq.yaml
+++ b/vendors/gr/groq.yaml
@@ -14,6 +14,8 @@ links:
 sources:
   - source_id: src_b4d2f18f12e67217dbec0e7ba07bc6a6f95a8b98aef37cdece371a7a7c56539c
     url: https://console.groq.com/docs/billing-faqs
+  - source_id: src_c688e46a5ca0250f25b6cf707c032a81ceab5eb6c4d4164a37ebe28063434c98
+    url: https://groq.com
 programs: []
 offers:
   - offer_id: off_01kzamwmfxb2sbz98m8c1s7yk6


### PR DESCRIPTION
## What changed
Added the Groq vendor and its current Groq for Startups credit offer. The record contains one offer and no program record because the cited public FAQ describes the offer directly.

## Sources
- https://console.groq.com/docs/billing-faqs

The source states that startups may be eligible for Groq for Startups, which unlocks $10,000 in credits. Eligibility remains manual because the public FAQ does not publish additional criteria.

## Certification
- [x] I changed only allowed repository content and did not mix vendor YAML with other paths.
- [x] Public sources substantiate every submitted factual value; any Sourcey-written prose is a neutral summary, not a fabricated vendor quote.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commit includes a Signed-off-by line.