### PR TITLE
catalog: add Reclaim.ai startup discount

### DIFF
--- a/vendors/re/reclaim-ai.yaml
+++ b/vendors/re/reclaim-ai.yaml
@@ -31,7 +31,7 @@ offers:
     economics:
       consideration:
         kind: variable
-        description: Purchase of an eligible Starter or Business subscription for at least five user seats; price varies by plan and seat count.
+        description: Purchase at least five seats on an eligible Reclaim Starter or Business plan.
       benefits:
         - benefit_id: ben_01
           description: 20% off eligible Reclaim.ai plans for three years

--- a/vendors/re/reclaim-ai.yaml
+++ b/vendors/re/reclaim-ai.yaml
@@ -1,0 +1,85 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kzaqsy8zn8s817yg13g2a1tm
+slug: reclaim-ai
+slug_aliases: []
+name: Reclaim.ai
+domains:
+  - value: reclaim.ai
+    role: primary
+    valid_from: 2026-08-06T05:12:45.087Z
+category: productivity
+description: Reclaim.ai is an AI calendar and scheduling platform for managing meetings, tasks, habits, and focus time.
+links:
+  site: https://reclaim.ai
+sources:
+  - source_id: src_eb5dc7bf2473f230633e44f5e768985ce323ba76b051805094a6010b735fb2bc
+    url: https://reclaim.ai/pricing/startup-discount
+  - source_id: src_0347efe3a7ef7bc02d64a32db5fc616123877e73ca6cea9de3b762b2e5293943
+    url: https://reclaim.ai/pricing
+  - source_id: src_b2585a4727d9bdc78cdba5ba5f3240461b76dd86164b220d93614ec5d03b5a3e
+    url: https://reclaim.ai/terms
+programs: []
+offers:
+  - offer_id: off_01kzaqsy9086qcce1m68c6sn8q
+    offer_slug: reclaim-ai-startup-discount
+    offer_slug_aliases: []
+    title: Reclaim.ai Startup Discount
+    summary: Eligible early-stage startups receive 20% off Reclaim.ai Starter and Business plans for three years.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-06T05:12:45.087Z
+    economics:
+      consideration:
+        kind: variable
+        description: Purchase of an eligible Starter or Business subscription for at least five user seats; price varies by plan and seat count.
+      benefits:
+        - benefit_id: ben_01
+          description: 20% off eligible Reclaim.ai plans for three years
+          kind: discount
+          percentage:
+            kind: exact
+            basis_points: 2000
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            statement: The subscription must include at least five Reclaim user seats
+            reason: external-verification
+          - criterion_id: cri_02
+            fact: company.employee_count
+            kind: predicate
+            operator: lt
+            statement: Company has fewer than 100 employees
+            value:
+              type: number
+              value: 100
+          - criterion_id: cri_03
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: Company has raised less than $10 million
+            value:
+              type: number
+              value: 10000000
+          - criterion_id: cri_04
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: Company was founded fewer than five years ago
+            value:
+              type: number
+              value: 60
+    roles:
+      terms_authority_entity_id: ent_01kzaqsy8zn8s817yg13g2a1tm
+      access_operator_entity_id: ent_01kzaqsy8zn8s817yg13g2a1tm
+    access:
+      availability: public
+      method: form
+      url: https://reclaim.ai/pricing/startup-discount
+    terms_url: https://reclaim.ai/pricing/startup-discount
+    source_ids:
+      - src_eb5dc7bf2473f230633e44f5e768985ce323ba76b051805094a6010b735fb2bc
+      - src_0347efe3a7ef7bc02d64a32db5fc616123877e73ca6cea9de3b762b2e5293943
+      - src_b2585a4727d9bdc78cdba5ba5f3240461b76dd86164b220d93614ec5d03b5a3e


### PR DESCRIPTION
## What changed

- add one canonical Reclaim.ai vendor record under the identity-derived `vendors/re/` shard
- document the vendor-published 20% startup discount for Starter and Business plans over three years
- encode the published seat, employee-count, funding, and company-age eligibility requirements

## Sources

- https://reclaim.ai/pricing/startup-discount
- https://reclaim.ai/pricing
- https://reclaim.ai/terms

## Verification

The digest-pinned Sourcey Catalog Verifier from upstream main returned:

```json
{"status":"valid","vendors":1,"programs":0,"offers":1}
```

Exact verification inputs: base `140b8defa508b2a3d9996eda86e1df9b346baa5c`, head `19876a1b1d652dd90146b09aaf3133e4b0fa60e3`, taxonomy/verifier digest `b43fe8711c38e98adb2d50bebbaafed291aebb32dbfc04db527d0998b63da048`.

## Certification

- [x] I changed only allowed repository content and did not mix vendor YAML with other paths.
- [x] Public sources substantiate every submitted factual value; any Sourcey-written prose is a neutral summary, not a fabricated vendor quote.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commits include a `Signed-off-by` line.

Closes #236
