### PR TITLE
catalog: add Twingate for Startups offer

### DIFF
--- a/vendors/tw/twingate.yaml
+++ b/vendors/tw/twingate.yaml
@@ -1,0 +1,86 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kzc2rqsvxnb40ahgdejhn8jc
+slug: twingate
+slug_aliases: []
+name: Twingate
+domains:
+  - value: twingate.com
+    role: primary
+    valid_from: 2026-08-06T17:45:40.000Z
+category: auth-security
+description: Twingate provides zero-trust network access, replacing corporate VPNs with identity-based connectivity to private applications and resources.
+links:
+  site: https://www.twingate.com
+sources:
+  - source_id: src_d266045b964db3abf81ddcd30f35a3515eb7c11d521e2c91b7aebc5ff1862a56
+    url: https://www.twingate.com/startup-program
+programs:
+  - program_id: prg_01kzc2rqswdgq0fwywbqrzv477
+    program_slug: twingate-for-startups
+    program_slug_aliases: []
+    title: Twingate for Startups
+    summary: Accepted startups receive one year of the Twingate Enterprise for Startups plan at no cost for up to 50 users, covering Private Access Enterprise and DNS Filtering.
+    source_ids:
+      - src_d266045b964db3abf81ddcd30f35a3515eb7c11d521e2c91b7aebc5ff1862a56
+offers:
+  - offer_id: off_01kzc2rqswn1yk7gt21hexate3
+    program_id: prg_01kzc2rqswdgq0fwywbqrzv477
+    offer_slug: enterprise-for-startups-free-year
+    offer_slug_aliases: []
+    title: One free year of Enterprise for Startups
+    summary: Accepted startups receive one year of the Enterprise for Startups plan at no cost for up to 50 users, including Private Access Enterprise, DNS Filtering and Exit Networks, worth up to $10,000.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-06T17:45:40.000Z
+    economics:
+      consideration:
+        kind: none
+      benefits:
+        - benefit_id: ben_01
+          description: One free year of the Enterprise for Startups plan covering up to 50 users of Private Access Enterprise and DNS Filtering, including Exit Networks, stated by the vendor as worth up to $10,000. Users beyond 50 are available for an additional fee.
+          kind: free-service
+          service: Twingate Enterprise for Startups plan for up to 50 users
+          duration:
+            kind: exact
+            value: P1Y
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: not-machine-evaluable
+            statement: Applicant must apply using a valid work email address.
+          - criterion_id: cri_02
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: Applicant must be a first time customer; organizations that are current or former paying customers are not eligible.
+            value:
+              type: boolean
+              value: false
+          - criterion_id: cri_03
+            fact: company.employee_count
+            kind: predicate
+            operator: lte
+            statement: Startup must have 100 employees or less.
+            value:
+              type: number
+              value: 100
+          - criterion_id: cri_04
+            kind: manual
+            reason: external-verification
+            statement: Startup must have received Series A funding or earlier, or, if bootstrapped, must have been founded within the last 5 years.
+          - criterion_id: cri_05
+            kind: manual
+            reason: vendor-discretion
+            statement: Twingate may approve or decline specific applications at its discretion.
+    roles:
+      terms_authority_entity_id: ent_01kzc2rqsvxnb40ahgdejhn8jc
+      access_operator_entity_id: ent_01kzc2rqsvxnb40ahgdejhn8jc
+    access:
+      availability: public
+      method: form
+      url: https://www.twingate.com/startup-program
+    source_ids:
+      - src_d266045b964db3abf81ddcd30f35a3515eb7c11d521e2c91b7aebc5ff1862a56


### PR DESCRIPTION
Adds one new vendor, `twingate`, with one offer: the Twingate for Startups free year.

**Source (first-party, English):** https://www.twingate.com/startup-program

**Why it qualifies**

- Startup-specific: the program is explicitly for startups at Series A or earlier, or bootstrapped companies founded within the last five years. It is not a free tier, a trial, or a coupon.
- Materially useful: one free year of the Enterprise for Startups plan for up to 50 users, which the vendor's own page values at "up to $10,000".
- Currently available: the page is live and the application form is open, with a stated 7-10 business day decision.

**Record notes**

- `category: auth-security`.
- Consideration is `none`: the plan is stated as "at no cost for one year". The 50-user cap and the additional-user fee are recorded in the benefit description rather than as consideration, because they bound the benefit rather than being something the recipient gives.
- Eligibility is split into independently evaluable criteria. Two are machine-evaluable predicates (`company.is_current_customer eq false`, `company.employee_count lte 100`); the work-email requirement and the funding-stage-or-bootstrap-age requirement are `manual` because the page states them as an either/or that is not machine-evaluable as a single fact; the vendor's stated discretion to decline is recorded as `vendor-discretion`.
- Every economics, eligibility, lifecycle, domain and access fact in the record is drawn from the single cited first-party page. No facts were invented and no second source was needed.

Data-only: one new file, `vendors/tw/twingate.yaml`. No code, no schema, no generated output, no unrelated edits. DCO signed off.
