### PR TITLE
data: add exe.dev startup credits

### DIFF
--- a/vendors/ex/exe-dev.yaml
+++ b/vendors/ex/exe-dev.yaml
@@ -1,0 +1,68 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kzhkwt7gbafrgdjy4xvc4dhv
+slug: exe-dev
+slug_aliases: []
+name: exe.dev
+domains:
+  - value: exe.dev
+    role: primary
+    valid_from: 2026-08-08T21:19:05.963Z
+category: hosting-infra
+description: exe.dev provides isolated virtual machines with HTTPS endpoints, SSH access, edge authentication, and custom-domain support.
+links:
+  site: https://exe.dev
+sources:
+  - source_id: src_d86fa3270d9955fb45ac4ca0c13c894092d8e6353dc6d74e12be55deafcb4996
+    url: https://exe.dev/startup
+programs:
+  - program_id: prg_01kzhkwt7xwbp18r6g9cz795h8
+    program_slug: exe-dev-startup-program
+    program_slug_aliases: []
+    title: exe.dev Startup Program
+    summary: The exe.dev Startup Program gives eligible early-stage companies credits for isolated virtual-machine infrastructure and direct access to the vendor team.
+    source_ids:
+      - src_d86fa3270d9955fb45ac4ca0c13c894092d8e6353dc6d74e12be55deafcb4996
+offers:
+  - offer_id: off_01kzhkwt7ytd1rvdpbegdabj1g
+    program_id: prg_01kzhkwt7xwbp18r6g9cz795h8
+    offer_slug: exe-dev-startup-program-credits
+    offer_slug_aliases: []
+    title: $10,000 in exe.dev Startup Credits
+    summary: Eligible startups receive $10,000 in exe.dev credits valid for 12 months, plus a direct line to the team building the service.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-08T21:19:05.963Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: $10,000 in exe.dev credits valid for 12 months
+          duration:
+            kind: exact
+            value: P1Y
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 1000000
+            kind: exact
+        - benefit_id: ben_02
+          description: Direct access to the team building exe.dev
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirements_01
+        statement: Applicant must be a pre-Series B startup, be less than five years old, and must not have received exe.dev credits before.
+        reason: external-verification
+    roles:
+      terms_authority_entity_id: ent_01kzhkwt7gbafrgdjy4xvc4dhv
+      access_operator_entity_id: ent_01kzhkwt7gbafrgdjy4xvc4dhv
+    access:
+      availability: public
+      instructions: Complete the application form on the exe.dev Startup Program page; applications are reviewed manually on a rolling basis.
+      method: form
+      url: https://exe.dev/startup
+    source_ids:
+      - src_d86fa3270d9955fb45ac4ca0c13c894092d8e6353dc6d74e12be55deafcb4996


### PR DESCRIPTION
## What changed

Add exe.dev as a new vendor and document its $10,000 startup credit offer, valid for 12 months. Encode the published eligibility criteria and application route.

Closes #307

## Sources

- https://exe.dev/startup

## Certification

- [x] I changed only allowed repository content and did not mix vendor YAML with other paths.
- [x] Public sources substantiate every submitted factual value; any Sourcey-written prose is a neutral summary, not a fabricated vendor quote.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commits include a `Signed-off-by` line.