### PR TITLE
data: add Daily Startup Program offer

### DIFF
--- a/vendors/da/daily.yaml
+++ b/vendors/da/daily.yaml
@@ -1,0 +1,71 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kzhwv7xd6w0d8zrdh5s1zejn
+slug: daily
+slug_aliases: []
+name: Daily
+domains:
+  - value: daily.co
+    role: primary
+    valid_from: 2026-08-09T00:00:00Z
+category: communication
+description: Daily provides programmable video and audio APIs, SDKs, live streaming, recording, and real-time communications infrastructure.
+links:
+  site: https://www.daily.co
+sources:
+  - source_id: src_84ed4dc6f166e4444081393963671f0c1c3409b82f373c56f917375253d10462
+    url: https://www.daily.co/products/live-streaming/
+  - source_id: src_eeb3a711979e62d4836e084a645b20cbdd4941ae37576a0ef6dfcab280834988
+    url: https://www.daily.co/blog/announcing-our-new-pricing/
+programs:
+  - program_id: prg_01kzhwv7xfajfb3bf3p144nbc5
+    program_slug: startup-program
+    program_slug_aliases: []
+    title: Daily Startup Program
+    summary: Daily's Startup Program provides eligible startups with product credits and dedicated support for building video and audio experiences.
+    source_ids:
+      - src_84ed4dc6f166e4444081393963671f0c1c3409b82f373c56f917375253d10462
+      - src_eeb3a711979e62d4836e084a645b20cbdd4941ae37576a0ef6dfcab280834988
+offers:
+  - offer_id: off_01kzhwv7xfvctdcyb7jgk6vf9b
+    program_id: prg_01kzhwv7xfajfb3bf3p144nbc5
+    offer_slug: startup-program-credits
+    offer_slug_aliases: []
+    title: Daily Startup Program Credits
+    summary: Startups can receive $1,000 in free Daily credits plus dedicated support for building and growing video products.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-09T00:00:00Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: $1,000 in free Daily credits.
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 100000
+            kind: exact
+        - benefit_id: ben_02
+          description: Dedicated support to build video and grow the startup's product.
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: not-machine-evaluable
+            statement: Applicant must be a startup seeking to build video or audio functionality with Daily.
+    roles:
+      terms_authority_entity_id: ent_01kzhwv7xd6w0d8zrdh5s1zejn
+      access_operator_entity_id: ent_01kzhwv7xd6w0d8zrdh5s1zejn
+    access:
+      availability: public
+      method: contact
+      instructions: Contact Daily using the help address published in the program announcement to ask about Startup Program credits.
+      url: https://www.daily.co/blog/announcing-our-new-pricing/
+    source_ids:
+      - src_84ed4dc6f166e4444081393963671f0c1c3409b82f373c56f917375253d10462
+      - src_eeb3a711979e62d4836e084a645b20cbdd4941ae37576a0ef6dfcab280834988


### PR DESCRIPTION
## What changed
Adds one new Daily vendor record with one Startup Program offer: $1,000 in free credits plus dedicated support.

## Sources
- https://www.daily.co/products/live-streaming/
- https://www.daily.co/blog/announcing-our-new-pricing/

Closes #333

## Certification
- [x] I changed only allowed repository content and did not mix vendor YAML with other paths.
- [x] Public sources substantiate every submitted factual value; any Sourcey-written prose is a neutral summary, not a fabricated vendor quote.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commits include a Signed-off-by line.