### PR TITLE
data: add Uniblock startup credits

### DIFF
--- a/vendors/un/uniblock.yaml
+++ b/vendors/un/uniblock.yaml
@@ -8,7 +8,7 @@ domains:
     role: primary
     valid_from: 2026-08-08T13:37:07.362Z
 category: devtools-other
-description: Uniblock provides a unified interface, routing, and one credit balance for blockchain data services across multiple providers.
+description: Uniblock provides unified routing, a shared interface, and one credit balance for blockchain data services across multiple providers.
 links:
   site: https://uniblock.website
 sources:

--- a/vendors/un/uniblock.yaml
+++ b/vendors/un/uniblock.yaml
@@ -4,16 +4,18 @@ slug: uniblock
 slug_aliases: []
 name: Uniblock
 domains:
-  - value: uniblock.website
+  - value: uniblock.dev
     role: primary
     valid_from: 2026-08-08T13:37:07.362Z
 category: devtools-other
 description: Uniblock provides unified routing, a shared interface, and one credit balance for blockchain data services across multiple providers.
 links:
-  site: https://uniblock.website
+  site: https://uniblock.dev
 sources:
   - source_id: src_1e3e1af7692636d3b3d9fe564ceb8d6dfea798230b34a858f5bf3e9986d70f37
     url: https://uniblock.website/startup-program
+  - source_id: src_9c2165c16f15354a363b73401f9d4824fd07c032e2f8004240b8bd822efe85d8
+    url: https://uniblock.website/legal/terms-of-service
 programs:
   - program_id: prg_01kzgsex92gxjwvjjvnjwzt9j2
     program_slug: uniblock-startup-program
@@ -22,6 +24,7 @@ programs:
     summary: Uniblock's startup program provides early-stage Web3 teams with credits for an annual plan spanning its routed blockchain-data provider stack.
     source_ids:
       - src_1e3e1af7692636d3b3d9fe564ceb8d6dfea798230b34a858f5bf3e9986d70f37
+      - src_9c2165c16f15354a363b73401f9d4824fd07c032e2f8004240b8bd822efe85d8
 offers:
   - offer_id: off_01kzgsex92217e13he5fwjty6a
     program_id: prg_01kzgsex92gxjwvjjvnjwzt9j2
@@ -63,3 +66,4 @@ offers:
       url: https://uniblock.website/startup-program
     source_ids:
       - src_1e3e1af7692636d3b3d9fe564ceb8d6dfea798230b34a858f5bf3e9986d70f37
+      - src_9c2165c16f15354a363b73401f9d4824fd07c032e2f8004240b8bd822efe85d8

--- a/vendors/un/uniblock.yaml
+++ b/vendors/un/uniblock.yaml
@@ -13,35 +13,32 @@ links:
   site: https://uniblock.dev
 sources:
   - source_id: src_1e3e1af7692636d3b3d9fe564ceb8d6dfea798230b34a858f5bf3e9986d70f37
-    url: https://uniblock.website/startup-program
-  - source_id: src_9c2165c16f15354a363b73401f9d4824fd07c032e2f8004240b8bd822efe85d8
-    url: https://uniblock.website/legal/terms-of-service
+    url: https://uniblock.dev/startup-program
 programs:
   - program_id: prg_01kzgsex92gxjwvjjvnjwzt9j2
     program_slug: uniblock-startup-program
     program_slug_aliases: []
     title: Uniblock Startup Program
-    summary: Uniblock's startup program provides early-stage Web3 teams with credits for an annual plan spanning its routed blockchain-data provider stack.
+    summary: Uniblock's startup program provides early-stage blockchain-data teams with credits for its routed provider stack.
     source_ids:
       - src_1e3e1af7692636d3b3d9fe564ceb8d6dfea798230b34a858f5bf3e9986d70f37
-      - src_9c2165c16f15354a363b73401f9d4824fd07c032e2f8004240b8bd822efe85d8
 offers:
   - offer_id: off_01kzgsex92217e13he5fwjty6a
     program_id: prg_01kzgsex92gxjwvjjvnjwzt9j2
     offer_slug: up-to-10000-in-uniblock-credits
     offer_slug_aliases: []
     title: Up to $10,000 in Uniblock credits
-    summary: Eligible early-stage teams building on blockchain data receive up to $10,000 in credits for Uniblock's annual plan, with engineering support.
+    summary: Eligible early-stage blockchain-data teams can receive up to $10,000 in Uniblock credits, sized to their stage on a short call, with engineering support.
     lifecycle:
       status: active
       effective_from: 2026-08-08T13:37:07.362Z
     economics:
       consideration:
         kind: unknown
-        description: The public page says credits are included with the annual plan, while final terms and the credit amount are set on a call.
+        description: The public page does not state whether payment is required; the credit amount is scoped on a short call.
       benefits:
         - benefit_id: ben_01
-          description: Up to $10,000 in credits for the annual Uniblock plan.
+          description: Up to $10,000 in credits applied to the team's Uniblock plan.
           kind: credit
           value:
             amount:
@@ -55,7 +52,7 @@ offers:
       rule:
         kind: manual
         criterion_id: cri_01
-        statement: Must be an early-stage team building on blockchain data with a product live or in active development; a call confirms fit and sets the credit amount and terms.
+        statement: Must be an early-stage team building on blockchain data with a product live or in active development; a short call confirms fit and scopes the credits.
         reason: vendor-discretion
     roles:
       terms_authority_entity_id: ent_01kzgsex92c83d4ymd2gp1s9x8
@@ -63,7 +60,6 @@ offers:
     access:
       availability: public
       method: form
-      url: https://uniblock.website/startup-program
+      url: https://uniblock.dev/startup-program
     source_ids:
       - src_1e3e1af7692636d3b3d9fe564ceb8d6dfea798230b34a858f5bf3e9986d70f37
-      - src_9c2165c16f15354a363b73401f9d4824fd07c032e2f8004240b8bd822efe85d8

--- a/vendors/un/uniblock.yaml
+++ b/vendors/un/uniblock.yaml
@@ -1,0 +1,65 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kzgsex92c83d4ymd2gp1s9x8
+slug: uniblock
+slug_aliases: []
+name: Uniblock
+domains:
+  - value: uniblock.website
+    role: primary
+    valid_from: 2026-08-08T13:37:07.362Z
+category: devtools-other
+description: Uniblock provides a unified interface, routing, and one credit balance for blockchain data services across multiple providers.
+links:
+  site: https://uniblock.website
+sources:
+  - source_id: src_1e3e1af7692636d3b3d9fe564ceb8d6dfea798230b34a858f5bf3e9986d70f37
+    url: https://uniblock.website/startup-program
+programs:
+  - program_id: prg_01kzgsex92gxjwvjjvnjwzt9j2
+    program_slug: uniblock-startup-program
+    program_slug_aliases: []
+    title: Uniblock Startup Program
+    summary: Uniblock's startup program provides early-stage Web3 teams with credits for an annual plan spanning its routed blockchain-data provider stack.
+    source_ids:
+      - src_1e3e1af7692636d3b3d9fe564ceb8d6dfea798230b34a858f5bf3e9986d70f37
+offers:
+  - offer_id: off_01kzgsex92217e13he5fwjty6a
+    program_id: prg_01kzgsex92gxjwvjjvnjwzt9j2
+    offer_slug: up-to-10000-in-uniblock-credits
+    offer_slug_aliases: []
+    title: Up to $10,000 in Uniblock credits
+    summary: Eligible early-stage teams building on blockchain data receive up to $10,000 in credits for Uniblock's annual plan, with engineering support.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-08T13:37:07.362Z
+    economics:
+      consideration:
+        kind: unknown
+        description: The public page says credits are included with the annual plan, while final terms and the credit amount are set on a call.
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $10,000 in credits for the annual Uniblock plan.
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 1000000
+            kind: up-to
+        - benefit_id: ben_02
+          description: Engineering support for routing and provider issues.
+          kind: other
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_01
+        statement: Must be an early-stage team building on blockchain data with a product live or in active development; a call confirms fit and sets the credit amount and terms.
+        reason: vendor-discretion
+    roles:
+      terms_authority_entity_id: ent_01kzgsex92c83d4ymd2gp1s9x8
+      access_operator_entity_id: ent_01kzgsex92c83d4ymd2gp1s9x8
+    access:
+      availability: public
+      method: form
+      url: https://uniblock.website/startup-program
+    source_ids:
+      - src_1e3e1af7692636d3b3d9fe564ceb8d6dfea798230b34a858f5bf3e9986d70f37


### PR DESCRIPTION
Resolves #343

## What changed
- Adds Uniblock as a new startup-credit vendor.
- Records the startup program with up to $10,000 in annual-plan credits, its early-stage eligibility, and engineering support.

## Sources
- https://uniblock.website/startup-program

## Validation
{"status":"valid","vendors":1,"programs":1,"offers":1}

## Certification
- [x] I changed only allowed repository content and did not mix vendor YAML with other paths.
- [x] Public sources substantiate every submitted factual value; any Sourcey-written prose is a neutral summary, not a fabricated vendor quote.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commits include a Signed-off-by line.