### PR TITLE
data: add Youverify startup credits

### DIFF
--- a/vendors/yo/youverify.yaml
+++ b/vendors/yo/youverify.yaml
@@ -1,0 +1,60 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kzjxqmbkt6d9qbm3kap7rzzy
+slug: youverify
+slug_aliases: []
+name: Youverify
+domains:
+  - value: youverify.co
+    role: primary
+    valid_from: 2026-08-09T09:26:42.675Z
+category: auth-security
+description: Youverify provides identity, business, address, and document verification, fraud detection, compliance, and customer onboarding services.
+links:
+  site: https://youverify.co
+sources:
+  - source_id: src_818941cfcf60a7a65ae6455f067bf301ca21899dd86d81d648052ca8b6cd6b33
+    url: https://startup.youverify.co/
+programs: []
+offers:
+  - offer_id: off_01kzjxqmbpdpf5zzdwyhg13jsg
+    offer_slug: youverify-startup-program
+    offer_slug_aliases: []
+    title: Youverify Startup Program
+    summary: Selected startups receive up to $2,000 in Youverify OS credits for onboarding and verification, a dedicated technical adviser, and marketing and community support.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-09T09:26:42.675Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $2,000 in Youverify OS credits for onboarding and verifying up to 10,000 users
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 200000
+            kind: up-to
+        - benefit_id: ben_02
+          description: Dedicated technical adviser and one-on-one consulting
+          kind: free-service
+          service: Youverify startup technical advice
+        - benefit_id: ben_03
+          description: Brand spotlighting, co-marketing opportunities, and startup community access
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_requirement_01
+        kind: manual
+        reason: vendor-discretion
+        statement: Available to startups selected by Youverify for its Startup Program.
+    roles:
+      terms_authority_entity_id: ent_01kzjxqmbkt6d9qbm3kap7rzzy
+      access_operator_entity_id: ent_01kzjxqmbkt6d9qbm3kap7rzzy
+    access:
+      availability: public
+      method: form
+      url: https://startup.youverify.co/
+    source_ids:
+      - src_818941cfcf60a7a65ae6455f067bf301ca21899dd86d81d648052ca8b6cd6b33


### PR DESCRIPTION
## Summary
- add Youverify as a new identity and compliance vendor
- record the current first-party startup credit program as one offer
- cite only Youverify's public English-language startup program page

Closes #357

## Validation
- digest-pinned Sourcey Catalog Verifier: valid (1 vendor, 1 offer)
- DCO sign-off included