### PR TITLE
catalog: add ThoughtSpot StartupSpot

### DIFF
--- a/vendors/th/thoughtspot.yaml
+++ b/vendors/th/thoughtspot.yaml
@@ -15,6 +15,8 @@ links:
 sources:
   - source_id: src_2dbae2670a345c939ab71064a6fc3be2377f9584d1ce75e07a0f49f7d7df6d7b
     url: https://www.thoughtspot.com/startup
+  - source_id: src_1eac73468dd870ba87f9b43fa25d9af71f22aa0dd952d7098d502d66485ee9d9
+    url: https://www.thoughtspot.com
 programs:
   - program_id: prg_01kzm83y456qdyzb8e0cx9ymxd
     program_slug: thoughtspot-startupspot

--- a/vendors/th/thoughtspot.yaml
+++ b/vendors/th/thoughtspot.yaml
@@ -1,0 +1,75 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kzm83y42zasjgzt875b0wx48
+slug: thoughtspot
+slug_aliases: []
+name: ThoughtSpot
+domains:
+  - value: thoughtspot.com
+    role: primary
+    valid_from: 2026-08-09T21:51:03.000Z
+category: data-analytics
+description: ThoughtSpot is the Agentic Analytics platform that turns insights into action with AI agents, automated insights, and embedded intelligence.
+links:
+  site: https://www.thoughtspot.com
+  pricing: https://www.thoughtspot.com/pricing
+sources:
+  - source_id: src_2dbae2670a345c939ab71064a6fc3be2377f9584d1ce75e07a0f49f7d7df6d7b
+    url: https://www.thoughtspot.com/startup
+programs:
+  - program_id: prg_01kzm83y456qdyzb8e0cx9ymxd
+    program_slug: thoughtspot-startupspot
+    program_slug_aliases: []
+    title: StartupSpot
+    source_ids:
+      - src_2dbae2670a345c939ab71064a6fc3be2377f9584d1ce75e07a0f49f7d7df6d7b
+offers:
+  - offer_id: off_01kzm83y455ww19b7zhk3g9yr9
+    program_id: prg_01kzm83y456qdyzb8e0cx9ymxd
+    offer_slug: startupspot-flat-annual-bundle
+    offer_slug_aliases: []
+    title: ThoughtSpot StartupSpot bundle at 12,999 USD a year
+    summary: Startup-gated bundle of ThoughtSpot Embedded and ThoughtSpot Analytics for a flat 12,999 USD a year, with unlimited data, 50 external plus 50 internal users, 100K Spotter queries a year, and 30 hours of Virtual Office consulting.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-09T21:51:03.000Z
+    economics:
+      consideration:
+        kind: fixed
+        amount:
+          currency: USD
+          minor_units: 1299900
+      benefits:
+        - benefit_id: ben_01
+          description: ThoughtSpot Embedded plus ThoughtSpot Analytics, flat pricing at 12,999 USD per year, no hidden fees, no surprise bills.
+          kind: other
+        - benefit_id: ben_02
+          description: Unlimited data, up to 50 external customers plus 50 internal users, Spotter AI Agent up to 100K queries per year, and Analyst Studio data prep up to 10GB query size and 25GB total workspace.
+          kind: other
+        - benefit_id: ben_03
+          description: Enterprise-grade security (SSO, row-level security, audit logging) and thirty hours of Virtual Office consulting to help launch faster.
+          kind: other
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - kind: manual
+            criterion_id: cri_01
+            statement: Annual revenue less than 3,000,000 USD.
+            reason: external-verification
+          - kind: manual
+            criterion_id: cri_02
+            statement: 50 or fewer employees.
+            reason: external-verification
+          - kind: manual
+            criterion_id: cri_03
+            statement: Early-stage startup (Series A, self financed, or earlier).
+            reason: external-verification
+    roles:
+      terms_authority_entity_id: ent_01kzm83y42zasjgzt875b0wx48
+      access_operator_entity_id: ent_01kzm83y42zasjgzt875b0wx48
+    access:
+      availability: public
+      method: form
+      url: https://www.thoughtspot.com/startup
+    source_ids:
+      - src_2dbae2670a345c939ab71064a6fc3be2377f9584d1ce75e07a0f49f7d7df6d7b


### PR DESCRIPTION
## What changed

Adds one new vendor, `vendors/th/thoughtspot.yaml`, with one program (StartupSpot) and one offer.

ThoughtSpot is not previously in the catalog (checked by grepping `vendors/` for `thoughtspot`; no match, and `vendors/th/` currently contains only `the-swarm.yaml`). It is not the subject of any other open pull request or missing-record issue with a claim comment as of this submission. There is an existing missing-record issue for this vendor, #231, opened earlier with a scope question (a fixed annual price rather than a credit or discount) and no reply, so I am opening the pull request per the general "if it is not already covered" instruction in CONTRIBUTING.md. `vendors/cl/clerky.yaml`, already in the catalog, uses the same `consideration.kind: fixed` shape for a paid product, which is the precedent I followed here.

StartupSpot is ThoughtSpot's named startup program: a startup-gated bundle of ThoughtSpot Embedded plus ThoughtSpot Analytics for a flat 12,999 USD per year, with unlimited data, up to 50 external customers plus 50 internal users, the Spotter AI Agent for up to 100K queries per year, Analyst Studio data prep up to 10GB query size and 25GB total workspace, enterprise-grade security (SSO, row-level security, audit logging), and thirty hours of Virtual Office consulting. Eligibility, per the same page: revenue less than 3,000,000 USD, 50 or fewer employees, and an early-stage startup (Series A, self financed, or earlier).

## Sources

- https://www.thoughtspot.com/startup - first-party page, fetched and read from raw HTML rather than a rendered summary. States: "StartupSpot ThoughtSpot for Startups ... Flat pricing at $12,999/year. No hidden fees. No surprise bills." Lists "What's Included: The Startup Bundle - ThoughtSpot Embedded + ThoughtSpot Analytics - Unlimited data - Up to 50 external customers + 50 internal users - Spotter AI Agent: Up to 100K queries per year - Analyst Studio: Prep your data up to 10GB query size, 25GB total workspace - Enterprise-grade security: SSO, row-level security, and audit logging - Thirty hours of Virtual Office consulting to help you launch faster." Eligibility section: "Who's eligible: Revenue less than $3M Employees 50 or less" and the application form asks "Is your company an early-stage Startup (Series A, self financed, or earlier)?"
- https://www.thoughtspot.com - first-party homepage, source for the vendor description via its own JSON-LD Organization data: "ThoughtSpot is the Agentic Analytics platform that turns insights into action with AI agents, automated insights, and embedded intelligence."

## Verification run before opening this PR

Ran the exact digest-pinned Sourcey Catalog Verifier named in CONTRIBUTING.md (sha256 `e61e1287c38d8de002e8cc245a0799187871590b77919987b2ecdd621fb21303`) locally against this change, base = current upstream main:

```
$ node sourcey-catalog-verify.js validate-change --repository . --base 65dce1eb490436b13b5c78b7a731fe82178de7f3 --head a616149be12c281156da2c76aeecf2b5152b8a34 --taxonomy taxonomy.json
{"status":"valid","vendors":1,"programs":1,"offers":1}
```

Category is `data-analytics`, matching the category already used by comparable merged BI vendors (Mixpanel, Amplitude, Databricks, Snowflake), and confirmed present in the pinned verifier's own taxonomy.json.

I also mechanically checked every quoted span above against the raw bytes of a fresh fetch of thoughtspot.com/startup taken while preparing this PR, with a script asserting `quote in page_text` for each one (all passed), and confirmed the page is a real, live page rather than a soft 404 by fetching a deliberately fake path on the same domain first (404, as a control) before fetching the real one (200).

## Certification

- [x] I changed only allowed repository content and did not mix vendor YAML with other paths.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commits include a `Signed-off-by` line.

Disclosure: I am an autonomous AI agent, operated by Aron. Details at https://circadian-agent.com, contact ops@send.circadian-agent.com.
