### PR TITLE
catalog: add Directus Open Innovation Grant

### DIFF
--- a/vendors/di/directus.yaml
+++ b/vendors/di/directus.yaml
@@ -1,0 +1,80 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kz5ecprnkxergwvpj19bcn8r
+slug: directus
+slug_aliases: []
+name: Directus
+domains:
+  - value: directus.com
+    role: primary
+    valid_from: 2026-08-04T03:52:54.000Z
+category: devtools-other
+description: Directus can be run self-hosted or on Directus Cloud, a separate managed hosting offering.
+links:
+  site: https://directus.com
+sources:
+  - source_id: src_7c4e5082f8723da8f1b83ef5d597faa4c9373c5caaac66ef4457d506546acdca
+    url: https://directus.com/oig
+  - source_id: src_34c398eebe130630bd895752b0d4590ffdaccc8621bbc0dffd9595f47bf78c66
+    url: https://directus.com/docs/licensing/open-innovation-grant
+programs:
+  - program_id: prg_01kz5ecprqrskdzwp5y9swdbb4
+    program_slug: directus-open-innovation-grant
+    program_slug_aliases: []
+    title: Directus Open Innovation Grant
+    summary: The Open Innovation Grant is Directus's named program giving qualifying organizations free commercial use of self-hosted Directus under a published grant usage agreement.
+    source_ids:
+      - src_7c4e5082f8723da8f1b83ef5d597faa4c9373c5caaac66ef4457d506546acdca
+      - src_34c398eebe130630bd895752b0d4590ffdaccc8621bbc0dffd9595f47bf78c66
+offers:
+  - offer_id: off_01kz5ecprqex26evhyfsc29d0a
+    program_id: prg_01kz5ecprqrskdzwp5y9swdbb4
+    offer_slug: open-innovation-grant-free-directus
+    offer_slug_aliases: []
+    title: Free Directus access for startups under $5M in revenue
+    summary: Directus's Open Innovation Grant gives qualifying startups, non-profits, and small teams under $5M in annual revenue and 50 employees free commercial use of self-hosted Directus for one year, renewable annually.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-04T03:52:54.000Z
+    economics:
+      consideration:
+        kind: none
+      benefits:
+        - benefit_id: ben_01
+          description: Full commercial use of self-hosted Directus, including SSO, custom access policies, and unlimited seats, at no software cost for one year
+          kind: free-service
+          service: Directus self-hosted Open Innovation Grant license
+          duration:
+            kind: exact
+            value: P1Y
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.annual_revenue_usd
+            kind: predicate
+            operator: lt
+            statement: Entity has less than $5 million in annual revenue
+            value:
+              type: number
+              value: 5000000
+          - criterion_id: cri_02
+            fact: company.employee_count
+            kind: predicate
+            operator: lt
+            statement: Entity has fewer than 50 employees
+            value:
+              type: number
+              value: 50
+    roles:
+      terms_authority_entity_id: ent_01kz5ecprnkxergwvpj19bcn8r
+      access_operator_entity_id: ent_01kz5ecprnkxergwvpj19bcn8r
+    access:
+      availability: public
+      method: form
+      url: https://directus.com/oig
+      instructions: Submit the multi-step application form on the Open Innovation Grant page; an approved applicant receives a license key by email.
+    terms_url: https://directus.com/terms/open-innovation-grant
+    source_ids:
+      - src_7c4e5082f8723da8f1b83ef5d597faa4c9373c5caaac66ef4457d506546acdca
+      - src_34c398eebe130630bd895752b0d4590ffdaccc8621bbc0dffd9595f47bf78c66


### PR DESCRIPTION
Resubmission of #140. Same single file, `vendors/di/directus.yaml`, same content that was reviewed there. Opening it fresh because #140 cannot go green no matter what is pushed to it, and the reason is worth flagging for the rest of your backlog.

**Why #140 is stuck**

`validate-catalog-change` checks out `github.event.pull_request.base.sha` into `trusted/`, then reads `trusted/.github/sourcey-catalog-verifier.sha256`. That pin file first landed on main in 3654b2e on 2026-08-06T01:37. #140 was opened 2026-08-04, so its base.sha is 7d5ed3a, which predates the pin file. The "Install the exact Sourcey Catalog Verifier" step reads a path that does not exist at that base and exits, so "Validate only the changed identity closure" never runs. The red status on #140 is not a verdict on its content, because its content was never looked at.

base.sha is frozen at PR creation and does not refresh when the head is pushed. I pushed a fix to #140 on 08-09 and its base.sha is still 7d5ed3a. So rebasing or force-pushing the old branch does not help either. A new PR off current main is the only thing that moves it.

This is not specific to us. Every open PR in this repo that was created before 2026-08-06 is failing at that same step for that same reason, independent of what it contains.

**What is in this one**

Unchanged from the reviewed state of #140, including the `description` fix auscaster asked for in https://github.com/sourcey/startup-credits/pull/140#issuecomment-5223172312. The old description asserted "open source", "headless CMS", "SQL database", "REST and GraphQL APIs" and "no-code admin interface", none of which appear on either cited page. It now reads:

> Directus can be run self-hosted or on Directus Cloud, a separate managed hosting offering.

which is backed by the licensing docs page.

Sources, all first-party and re-checked:

- https://directus.com/oig
- https://directus.com/docs/licensing/open-innovation-grant
- https://directus.com/terms/open-innovation-grant (the `terms_url`)

**Verification before opening**

I read the pinned digest from `.github/sourcey-catalog-verifier.sha256` on current main (`79a42fe6...f6`), downloaded that exact Catalog Verifier, checked its published sha256, and ran `sourcey-catalog-verify.js validate-change` against a clone of current main with this file applied, the same way `validate.yml` invokes it. Result:

```
{"status":"valid","vendors":1,"programs":1,"offers":1}
```

I also checked this record against vendor files merged on 08-08 for schema drift and found none, so no fields were changed for CI's benefit.

#140 can be closed in favour of this one.

Signed-off-by is on the commit.
