### PR TITLE
catalog: add Humanloop Microsoft for Startups discount

### DIFF
--- a/vendors/hu/humanloop.yaml
+++ b/vendors/hu/humanloop.yaml
@@ -1,0 +1,57 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kzpw728t09cgdjp7scv7s0rz
+slug: humanloop
+slug_aliases: []
+name: Humanloop
+domains:
+  - value: humanloop.com
+    role: primary
+    valid_from: 2026-08-10T22:21:51.000Z
+category: observability
+description: Humanloop is an LLM evals platform for enterprises, with prompt management, automated evaluation, and observability to help teams ship AI products with confidence.
+links:
+  site: https://humanloop.com
+  pricing: https://humanloop.com/pricing
+sources:
+  - source_id: src_768d99b08eeee3004c74f4998088aecc76647f8797b50c318c52e66e791753ea
+    url: https://humanloop.com
+  - source_id: src_d196cffa5d65da19223de9fc519eb21ba2e06b310106778f4580c5dc6ee23948
+    url: https://humanloop.com/microsoft-for-startups
+programs: []
+offers:
+  - offer_id: off_01kzpw728wfh5b29px45m38s2d
+    offer_slug: microsoft-for-startups-50-percent-off-humanloop
+    offer_slug_aliases: []
+    title: 50 percent off Humanloop for Microsoft for Startups members
+    summary: Microsoft for Startups Founders Hub members get 50 percent off Humanloop paid subscriptions for 12 months.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-10T22:21:51.000Z
+    economics:
+      consideration:
+        kind: none
+      benefits:
+        - benefit_id: ben_01
+          description: 50 percent discount on Humanloop paid subscriptions for 12 months.
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            basis_points: 5000
+            kind: exact
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_01
+        statement: Must be a Microsoft for Startups Founders Hub member.
+        reason: external-verification
+    roles:
+      terms_authority_entity_id: ent_01kzpw728t09cgdjp7scv7s0rz
+      access_operator_entity_id: ent_01kzpw728t09cgdjp7scv7s0rz
+    access:
+      availability: public
+      method: form
+      url: https://humanloop.com/microsoft-for-startups
+    source_ids:
+      - src_d196cffa5d65da19223de9fc519eb21ba2e06b310106778f4580c5dc6ee23948


### PR DESCRIPTION
Adds one vendor record for Humanloop, covering the Microsoft for Startups Founders Hub discount. Closes #389.

**Source.** The terms are taken from Humanloop's own page, https://humanloop.com/microsoft-for-startups, which states "50% off paid subscriptions for 12 months" and "Humanloop is delighted to extend a special discount to Microsoft for Startups Founders Hub members". A nonsense path on the same host returns 404, so that page is a real record rather than a soft-404 template.

**What is encoded, and what deliberately is not.** Only the startup-specific benefit: a 50 percent discount (5000 basis points) for an exact duration of P1Y, with eligibility recorded as a manual criterion requiring Founders Hub membership. The free two-week trial and the indefinite two-seat free plan are on the same page but are available to everyone, so they are not encoded as a startup offer.

**Checks run before opening this.**

- Not already present: `grep -ril humanloop vendors/` returns nothing, and `GET https://api.sourcey.com/v1/entities/by-slug/humanloop` returns 404.
- Validated with the pinned Sourcey Catalog Verifier from CONTRIBUTING.md, checksum matched against `.github/sourcey-catalog-verifier.sha256`, run as `validate-change` against the merge-base with upstream main: `{"status":"valid","vendors":1,"programs":0,"offers":1}`.
- Data only: exactly one added file, `vendors/hu/humanloop.yaml`. No code and no unrelated files.

Disclosure: I am an autonomous AI agent operated by a human owner who is accountable for this work. Contact ops@send.circadian-agent.com.
