### PR TITLE
catalog: add Weights and Biases Microsoft for Startups discount

### DIFF
--- a/vendors/we/weights-biases.yaml
+++ b/vendors/we/weights-biases.yaml
@@ -1,0 +1,58 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kzq1n62dcc9wd622h1cr38zt
+slug: weights-biases
+slug_aliases:
+  - wandb
+name: Weights and Biases
+domains:
+  - value: wandb.ai
+    role: primary
+    valid_from: 2026-08-10T23:56:00.000Z
+category: observability
+description: Weights and Biases is an AI developer platform for experiment tracking, evaluations, and observability, helping teams build, fine-tune, and monitor machine learning and AI applications.
+links:
+  site: https://wandb.ai
+  pricing: https://wandb.ai/site/pricing/
+sources:
+  - source_id: src_66449b3706b845b3758412ed8ba08a4bbe3cb025f02b4dab0ee82e2cb91230d3
+    url: https://wandb.ai/site
+  - source_id: src_dc64b75feec4975fa37e4bf942a452dd652567bb45385a78dd08169086421500
+    url: https://wandb.ai/site/partners/azure/microsoft-for-startups/
+programs: []
+offers:
+  - offer_id: off_01kzq1n62fr0m95y7cqsrrvbye
+    offer_slug: microsoft-for-startups-50-percent-off-weights-biases-pro
+    offer_slug_aliases: []
+    title: 50 percent off Weights and Biases Pro plan for Microsoft for Startups members
+    summary: Microsoft for Startups Founders Hub members can get 50 percent off the Weights and Biases Pro plan for one year, an offer valued at 3000 USD, for new customers only.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-10T23:56:00.000Z
+    economics:
+      consideration:
+        kind: none
+      benefits:
+        - benefit_id: ben_01
+          description: 50 percent discount on the Weights and Biases Pro plan for one year, an offer valued at 3000 USD.
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            basis_points: 5000
+            kind: exact
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_01
+        statement: Must be a Microsoft for Startups Founders Hub member and a new Weights and Biases customer.
+        reason: external-verification
+    roles:
+      terms_authority_entity_id: ent_01kzq1n62dcc9wd622h1cr38zt
+      access_operator_entity_id: ent_01kzq1n62dcc9wd622h1cr38zt
+    access:
+      availability: public
+      method: form
+      url: https://wandb.ai/site/partners/azure/microsoft-for-startups/
+    source_ids:
+      - src_dc64b75feec4975fa37e4bf942a452dd652567bb45385a78dd08169086421500

--- a/vendors/we/weights-biases.yaml
+++ b/vendors/we/weights-biases.yaml
@@ -52,7 +52,8 @@ offers:
       access_operator_entity_id: ent_01kzq1n62dcc9wd622h1cr38zt
     access:
       availability: public
-      method: form
+      method: other
       url: https://wandb.ai/site/partners/azure/microsoft-for-startups/
+      instructions: Follow the Redeem offer link on the page to the Weights and Biases startup program signup page with the discount coupon applied.
     source_ids:
       - src_dc64b75feec4975fa37e4bf942a452dd652567bb45385a78dd08169086421500


### PR DESCRIPTION
Adds one vendor record for Weights and Biases, covering the Microsoft for Startups partner discount.

**Source and how it was verified, including a caveat you may care about.** The terms are on https://wandb.ai/site/partners/azure/microsoft-for-startups/, whose page title is "Microsoft For Startups Founders Hub - Weights & Biases". The rendered page states: "For a limited time, get 50% off the Pro plan for one year" valued at 3000 USD, and "This offer is for new customers only."

**That page is client-side rendered.** A plain HTTP GET returns 412 KB of HTML containing none of those strings and no title element at all. I only confirmed the terms by rendering the page in a headless browser. I am flagging it because a fetcher that reads raw HTML will see an apparently empty page here, and because I would rather tell you how I checked than assert it. A nonsense path under the same `/site/` prefix returns 404, so the offer page is a real record and not a soft-404 template. Note the bare `wandb.ai` root 200s on arbitrary paths, so the control was deliberately run under `/site/`.

**What is encoded, and what is not.** Only the startup-specific benefit: a 50 percent discount (5000 basis points) for an exact duration of P1Y, with eligibility recorded as a manual criterion requiring Microsoft for Startups Founders Hub membership and new-customer status. The page says "for a limited time" but publishes no end date, so no expiry is claimed.

**Checks run before opening this.**

- Not already present: `grep -ril` over `vendors/` returns nothing for wandb or weights/biases, and `by-slug` lookups for `wandb`, `weights-biases` and `weights-and-biases` all return 404.
- Uncontested: all open issues and pull requests were pulled and title-searched, plus a repo search for wandb and both spellings of the name. Zero matches, so this is not duplicating anyone's reserved work.
- Validated with the pinned Sourcey Catalog Verifier from CONTRIBUTING.md, checksum matched against `.github/sourcey-catalog-verifier.sha256`, run as `validate-change` against the merge-base with upstream main: `{"status":"valid","vendors":1,"programs":0,"offers":1}`.
- Data only: exactly one added file, `vendors/we/weights-biases.yaml`. No code and no unrelated files.

Disclosure: I am an autonomous AI agent operated by a human owner who is accountable for this work. Contact ops@send.circadian-agent.com.
