### PR TITLE
data: add Memberstack startup discount

### DIFF
--- a/vendors/me/memberstack.yaml
+++ b/vendors/me/memberstack.yaml
@@ -1,0 +1,76 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kzqazztr5gd2sr6ekwamwr9s
+slug: memberstack
+slug_aliases: []
+name: Memberstack
+domains:
+  - value: memberstack.com
+    role: primary
+    valid_from: 2026-08-11T02:38:59.422Z
+category: no-code
+description: Memberstack provides authentication, membership, and payment infrastructure for websites and web applications.
+links:
+  site: https://www.memberstack.com
+sources:
+  - source_id: src_6802c9f183c8ad9f4c5d576693a543c9cb4aed8f87fe896cf1d3922775980204
+    url: https://docs.memberstack.com/hc/en-us/articles/13707369368987-Memberstack-Discount-Programs
+  - source_id: src_aaee3362e0650234b170222b9fa19e0789d2eca92fe9f3efc41e012a3ec7aba7
+    url: https://www.memberstack.com
+programs:
+  - program_id: prg_01kzqazztyxwevm08d28r0pk73
+    program_slug: memberstack-discount-programs
+    program_slug_aliases: []
+    title: Memberstack Discount Programs
+    summary: Memberstack offers reviewed discount programs for eligible startups and other qualifying groups.
+    source_ids:
+      - src_6802c9f183c8ad9f4c5d576693a543c9cb4aed8f87fe896cf1d3922775980204
+offers:
+  - offer_id: off_01kzqazztyc9p9f38vxk53bq84
+    program_id: prg_01kzqazztyxwevm08d28r0pk73
+    offer_slug: startup-discounted-pricing
+    offer_slug_aliases: []
+    title: Memberstack Startup Discounted Pricing
+    summary: Eligible startups get a $249 monthly plan with 0% transaction fees and 10,000 members, or $199 per month when paid yearly.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-11T02:38:59.422Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: $249 per month with 0% transaction fees and 10,000 members included
+          kind: other
+        - benefit_id: ben_02
+          applies_to: Startup discounted pricing paid yearly
+          description: 20% off when paid yearly, reducing the published startup price to $199 per month
+          kind: discount
+          percentage:
+            basis_points: 2000
+            kind: exact
+      consideration:
+        description: Subscription to the Memberstack startup plan at the published discounted price.
+        kind: unknown
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: Startup has attended a startup program such as Y Combinator, 500 Startups, or Launch.
+          - criterion_id: cri_02
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: Startup has raised less than $1 million in funding.
+            value:
+              type: number
+              value: 1000000
+    roles:
+      terms_authority_entity_id: ent_01kzqazztr5gd2sr6ekwamwr9s
+      access_operator_entity_id: ent_01kzqazztr5gd2sr6ekwamwr9s
+    access:
+      availability: public
+      method: form
+      url: https://airtable.com/appwPshdcaEL6kE1K/shrNSQBbXPlFlc0Ly
+    source_ids:
+      - src_6802c9f183c8ad9f4c5d576693a543c9cb4aed8f87fe896cf1d3922775980204


### PR DESCRIPTION
## What changed

Added Memberstack as a new vendor with its published startup-specific pricing: $249/month with 0% transaction fees and 10,000 members included, or $199/month when paid yearly, for qualifying startups.

Closes #406

## Sources

- https://docs.memberstack.com/hc/en-us/articles/13707369368987-Memberstack-Discount-Programs
- https://www.memberstack.com

## Certification

- [x] I changed only allowed repository content and did not mix vendor YAML with other paths.
- [x] Public sources substantiate every submitted factual value; any Sourcey-written prose is a neutral summary, not a fabricated vendor quote.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commits include a Signed-off-by line.