### PR TITLE
data: add RemotePass startup program

### DIFF
--- a/vendors/re/remotepass.yaml
+++ b/vendors/re/remotepass.yaml
@@ -64,8 +64,7 @@ offers:
             basis_points: 1500
             kind: exact
       consideration:
-        kind: variable
-        description: Purchase contractor management or Employer of Record service at the applicable discounted price; public pricing starts at $39 per contractor per month and $349 per employee per month.
+        kind: none
     eligibility:
       rule:
         criterion_id: cri_01

--- a/vendors/re/remotepass.yaml
+++ b/vendors/re/remotepass.yaml
@@ -1,0 +1,88 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kzqs12z5zsyn4da3zny7r1pd
+slug: remotepass
+slug_aliases: []
+name: RemotePass
+domains:
+  - value: remotepass.com
+    role: primary
+    valid_from: 2026-08-11T06:44:15.000Z
+category: hr-people
+description: RemotePass provides global payroll, contractor management, employer-of-record, and HR services for distributed teams.
+links:
+  site: https://www.remotepass.com
+sources:
+  - source_id: src_272f0ee0dc2d5fc9e68944f626dfbe68e59062ddb328163a1a366078fa109a87
+    url: https://www.remotepass.com/startup-program
+  - source_id: src_5291aa0ef306253940e885d55ced55f4ec686762886d3e1b62cc54af8d1b96e5
+    url: https://www.remotepass.com/pricing
+programs:
+  - program_id: prg_01kzqs12z7175s8y5dm0kqdbrc
+    program_slug: remotepass-startup-program
+    program_slug_aliases: []
+    title: RemotePass Startup Program
+    summary: RemotePass gives early-stage startups discounted contractor management and employee services when they have raised less than $5 million.
+    source_ids:
+      - src_272f0ee0dc2d5fc9e68944f626dfbe68e59062ddb328163a1a366078fa109a87
+offers:
+  - offer_id: off_01kzqs12z8r0ps1c5r6p8x4q2w
+    program_id: prg_01kzqs12z7175s8y5dm0kqdbrc
+    offer_slug: early-stage-startup-discount
+    offer_slug_aliases: []
+    title: Early-stage startup discount
+    summary: Startups with less than $5 million in funding get contractor services free for one month, then 33% off for nine months, plus 15% off employee services for one year.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-11T06:44:15.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: RemotePass contractor services free for the first month.
+          duration:
+            kind: exact
+            value: P1M
+          kind: free-service
+          service: RemotePass contractor services
+        - applies_to: RemotePass contractor services after the first free month
+          benefit_id: ben_02
+          description: 33% off RemotePass contractor services for the following nine months.
+          duration:
+            kind: exact
+            value: P9M
+          kind: discount
+          percentage:
+            basis_points: 3300
+            kind: exact
+        - applies_to: RemotePass employee services
+          benefit_id: ben_03
+          description: 15% off RemotePass employee services for one year.
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            basis_points: 1500
+            kind: exact
+      consideration:
+        kind: variable
+        description: Purchase contractor management or Employer of Record service at the applicable discounted price; public pricing starts at $39 per contractor per month and $349 per employee per month.
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        fact: company.funding_raised_usd
+        kind: predicate
+        operator: lt
+        statement: Startup has raised less than $5 million in funding.
+        value:
+          type: number
+          value: 5000000
+    roles:
+      terms_authority_entity_id: ent_01kzqs12z5zsyn4da3zny7r1pd
+      access_operator_entity_id: ent_01kzqs12z5zsyn4da3zny7r1pd
+    access:
+      availability: public
+      method: form
+      url: https://www.remotepass.com/demo-request
+    source_ids:
+      - src_272f0ee0dc2d5fc9e68944f626dfbe68e59062ddb328163a1a366078fa109a87
+      - src_5291aa0ef306253940e885d55ced55f4ec686762886d3e1b62cc54af8d1b96e5


### PR DESCRIPTION
## What changed

- Added RemotePass as one new vendor record.
- Added its public early-stage startup discount as one bundled offer.

## Sources

- https://www.remotepass.com/startup-program
- https://www.remotepass.com/pricing

## Certification

- [x] I changed only allowed repository content and did not mix vendor YAML with other paths.
- [x] Public sources substantiate every submitted factual value; any Sourcey-written prose is a neutral summary, not a fabricated vendor quote.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commits include a `Signed-off-by` line.

## Validation

- Pinned Sourcey Catalog Verifier: `{"status":"valid","vendors":1,"programs":1,"offers":1}`
- Exactly one new vendor YAML
- DCO sign-off included

Closes #416