### PR TITLE
Add Rails Cloud Startup Program Seed credits

### DIFF
--- a/vendors/ra/rails-cloud.yaml
+++ b/vendors/ra/rails-cloud.yaml
@@ -1,0 +1,57 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kzrrn3jwd8jn3h2f948t8cpt
+slug: rails-cloud
+slug_aliases: []
+name: Rails Cloud
+domains:
+  - value: railscloud.co
+    role: primary
+    valid_from: 2026-08-11T15:57:18.780Z
+category: hosting-infra
+description: Rails Cloud is Rails Net's infrastructure platform for VPS, managed databases, object storage, APIs, container workloads, and AI services in Africa.
+links:
+  site: https://railscloud.co/
+sources:
+  - source_id: src_88f9c0d455abfd28e75a355f78bf65eac18a7abe17b9187788ffeb69d0b9cb09
+    url: https://railscloud.co/
+  - source_id: src_a2d524b63a1920f03b967d2a03e618d9f5ba9f2350f9d94541e1a7da6b8564ea
+    url: https://pages.railscloud.co/startup
+programs:
+  - program_id: prg_01kzrrn3k1tkbsdv7dbkwrt571
+    program_slug: rails-cloud-startup-program
+    program_slug_aliases: []
+    title: Rails Cloud Startup Program
+    source_ids:
+      - src_a2d524b63a1920f03b967d2a03e618d9f5ba9f2350f9d94541e1a7da6b8564ea
+offers:
+  - offer_id: off_01kzrrn3k10sapgs84kp4zghee
+    program_id: prg_01kzrrn3k1tkbsdv7dbkwrt571
+    offer_slug: rails-cloud-startup-seed
+    offer_slug_aliases: []
+    title: Rails Cloud Startup Program - Seed
+    summary: Provides $1,000 in Rails Cloud credits, valid for 12 months, for pre-product technology startups serving African markets, with access across cloud infrastructure services.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-11T15:57:18.780Z
+    economics:
+      consideration:
+        kind: none
+      benefits:
+        - benefit_id: ben_primary
+          description: $1,000 in cloud credits valid for 12 months
+          kind: other
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Applicant must be new to Rails Cloud, be less than five years old, build a technology product serving African markets, have no other active cloud credits, and be a pre-product startup with a clear idea and founding team.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01kzrrn3jwd8jn3h2f948t8cpt
+      access_operator_entity_id: ent_01kzrrn3jwd8jn3h2f948t8cpt
+    access:
+      availability: public
+      method: form
+      url: https://pages.railscloud.co/register
+    source_ids:
+      - src_a2d524b63a1920f03b967d2a03e618d9f5ba9f2350f9d94541e1a7da6b8564ea

--- a/vendors/ra/rails-cloud.yaml
+++ b/vendors/ra/rails-cloud.yaml
@@ -8,7 +8,7 @@ domains:
     role: primary
     valid_from: 2026-08-11T15:57:18.780Z
 category: hosting-infra
-description: Rails Cloud is Rails Net's infrastructure platform for VPS, managed databases, object storage, APIs, container workloads, and AI services in Africa.
+description: Rails Cloud provides digital infrastructure for deploying applications, managed databases, object storage, container images, static sites, and developer APIs.
 links:
   site: https://railscloud.co/
 sources:

--- a/vendors/ra/rails-cloud.yaml
+++ b/vendors/ra/rails-cloud.yaml
@@ -16,6 +16,8 @@ sources:
     url: https://railscloud.co/
   - source_id: src_a2d524b63a1920f03b967d2a03e618d9f5ba9f2350f9d94541e1a7da6b8564ea
     url: https://pages.railscloud.co/startup
+  - source_id: src_2331aff282082bb60bb15a51e392e2435ac21a9ed388f5842b6fba979ab159ea
+    url: https://pages.railscloud.co/register
 programs:
   - program_id: prg_01kzrrn3k1tkbsdv7dbkwrt571
     program_slug: rails-cloud-startup-program
@@ -55,3 +57,4 @@ offers:
       url: https://pages.railscloud.co/register
     source_ids:
       - src_a2d524b63a1920f03b967d2a03e618d9f5ba9f2350f9d94541e1a7da6b8564ea
+      - src_2331aff282082bb60bb15a51e392e2435ac21a9ed388f5842b6fba979ab159ea


### PR DESCRIPTION
## Summary

- add Rails Cloud as a hosting infrastructure vendor
- add the publicly named Rails Cloud Startup Program
- add the Seed tier as one startup-specific offer: $1,000 in credits valid for 12 months

## Public evidence

- Vendor site: https://railscloud.co/
- Program details: https://pages.railscloud.co/startup
- Public application form: https://pages.railscloud.co/register

The program page states that the Seed tier is for pre-product technology startups with a clear idea and team. It also states the company-age, African-market, new-customer, and no-active-cloud-credit conditions, and says the program is credits-only with no equity or revenue share.

## Duplicate check

I searched the current repository, open pull requests, and issues for both `Rails Cloud` and `railscloud.co` before adding the record. The missing-record reservation is tracked in #432.

Closes #432

## Validation

Ran the repository's digest-pinned verifier documented in `CONTRIBUTING.md`.

```text
artifact hash: OK
{"status":"valid","vendors":1,"programs":1,"offers":1}
```

The commit includes the required DCO sign-off. AI assistance was used to research the public sources, prepare the YAML, and run the documented validation; the facts and resulting diff were manually checked against the cited first-party pages.
