### PR TITLE
data: retain retired offer routes as aliases

### DIFF
--- a/vendors/as/assemblyai.yaml
+++ b/vendors/as/assemblyai.yaml
@@ -18,7 +18,8 @@ programs: []
 offers:
   - offer_id: off_01kyh8fpe19tbgz9qesnr0wd3x
     offer_slug: assemblyai-startup-program
-    offer_slug_aliases: []
+    offer_slug_aliases:
+      - up-to-150-000-in-speech-ai-api-credits-with-assemblyai-for-startups
     title: AssemblyAI Startup Program
     summary: Eligible early-stage startups receive 12 months of recurring free credits and discounted pricing on AssemblyAI models, along with co-marketing opportunities and feature access.
     lifecycle:

--- a/vendors/cl/cloudflare.yaml
+++ b/vendors/cl/cloudflare.yaml
@@ -25,7 +25,8 @@ offers:
   - offer_id: off_01kyh8jtf6rzp78sqz25kvpe3v
     program_id: prg_01kyh8jtf667atcvk4kp9spgx9
     offer_slug: cloudflare-for-startups-tier-1
-    offer_slug_aliases: []
+    offer_slug_aliases:
+      - free-cloud-credits-with-cloudflare-for-startups-250-000-usd
     title: Cloudflare for Startups - Tier 1
     summary: Provides $350,000 in credits valid for one year, priority technical support, account manager, and Solutions Architect office hours for startups with $5M+ raised.
     lifecycle:
@@ -57,7 +58,8 @@ offers:
   - offer_id: off_01kyh8jtf6cfhz4gyznfpy5mfa
     program_id: prg_01kyh8jtf667atcvk4kp9spgx9
     offer_slug: cloudflare-for-startups-tier-2
-    offer_slug_aliases: []
+    offer_slug_aliases:
+      - free-cloud-credits-with-cloudflare-for-startups-early-stage-tier
     title: Cloudflare for Startups - Tier 2
     summary: Provides $100,000 in credits valid for one year, technical sessions, and an account manager for startups with under $5M raised from affiliated partners.
     lifecycle:
@@ -89,7 +91,8 @@ offers:
   - offer_id: off_01kyh8jtf667atcvk4kp9spgx9
     program_id: prg_01kyh8jtf667atcvk4kp9spgx9
     offer_slug: cloudflare-for-startups-tier-3
-    offer_slug_aliases: []
+    offer_slug_aliases:
+      - free-cloud-credits-with-cloudflare-for-startups-bootstrapped-tier
     title: Cloudflare for Startups - Tier 3
     summary: Provides $10,000 in credits valid for one year to bootstrapped or self-funded early-stage startups with under $1M raised to build and launch products on Cloudflare.
     lifecycle:

--- a/vendors/de/deel.yaml
+++ b/vendors/de/deel.yaml
@@ -31,7 +31,8 @@ programs:
 offers:
   - offer_id: off_01kyh8fpe2r151y0shvrzcmkwt
     offer_slug: first-5-seats-free-for-life-for-venture-backed-startups
-    offer_slug_aliases: []
+    offer_slug_aliases:
+      - 50-off-year-1-with-deel-for-startups-via-brex
     title: First 5 seats free for life for venture-backed startups
     summary: Venture-backed startups that have raised at least $500k in funding can get their first 5 seats free for life on Deel.
     lifecycle:

--- a/vendors/di/digitalocean.yaml
+++ b/vendors/di/digitalocean.yaml
@@ -18,7 +18,10 @@ programs: []
 offers:
   - offer_id: off_01kyh8fpe2dwqnfrbb6nejb5zz
     offer_slug: digitalocean-startups-program
-    offer_slug_aliases: []
+    offer_slug_aliases:
+      - up-to-100-000-in-compute-credits-via-digitalocean-hatch-ai-ml-tier
+      - up-to-1-000-in-credits-via-digitalocean-hatch-direct-tier
+      - 20-000-in-cloud-credits-and-partner-perks-via-digitalocean-hatch-partner-tier
     title: DigitalOcean Startups Program
     summary: Eligible early-stage startups receive DigitalOcean cloud infrastructure credits for 12 months, 15 months of free Standard-tier paid support, expert one-on-one guidance, and startup community perks.
     lifecycle:

--- a/vendors/gi/github.yaml
+++ b/vendors/gi/github.yaml
@@ -18,7 +18,8 @@ programs: []
 offers:
   - offer_id: off_01kyh8fpe3fe0s7ef65e5fj1p5
     offer_slug: github-for-startups-offer
-    offer_slug_aliases: []
+    offer_slug_aliases:
+      - 50-off-with-github-for-startups-year-2
     title: GitHub for Startups Offer
     summary: Eligible startups receive $10,000 in GitHub credits valid for up to 12 months to use toward GitHub Enterprise licenses, GitHub Copilot, GitHub Advanced Security, and eligible metered products.
     lifecycle:

--- a/vendors/go/google-cloud.yaml
+++ b/vendors/go/google-cloud.yaml
@@ -33,6 +33,7 @@ offers:
     program_id: prg_01kyh8fpe243m25ep0wtvz068s
     offer_slug: google-for-startups-cloud-program-scale
     offer_slug_aliases:
+      - google-cloud-for-startups-credits-and-usage-coverage
       - google-for-startups-cloud-program-early-stage
     title: Google Cloud Scale tier
     summary: VC-funded startups ready to grow and scale can receive up to $100,000 in Google Cloud credits in year one, then 20% up to another $100,000 in year two.

--- a/vendors/ma/make.yaml
+++ b/vendors/ma/make.yaml
@@ -26,7 +26,8 @@ offers:
   - offer_id: off_01kyxthgpyakq6wbdhypr9wn51
     program_id: prg_01kyxthgpy4wnbhzr8b5hv4nz8
     offer_slug: make-partner-startup-tier
-    offer_slug_aliases: []
+    offer_slug_aliases:
+      - 1-year-free-teams-plan-with-make-for-startups-partner-tier
     title: Make Startup Program - Partner Startup Tier
     summary: Qualifying startups associated with a Make Startup Partner receive 6 months free plus a 50% discount on Pro or Teams plans with 480k credits (valued at over $1,500).
     lifecycle:

--- a/vendors/mi/miro.yaml
+++ b/vendors/mi/miro.yaml
@@ -31,7 +31,8 @@ offers:
   - offer_id: off_01kyyts97xm14v7h68xprfng2a
     program_id: prg_01kyh8fpe335dxj6tsyk7tb78w
     offer_slug: free-credits-with-miro-startup-program-individual-tier
-    offer_slug_aliases: []
+    offer_slug_aliases:
+      - miro-early-startups-free-credits
     title: $500 in Miro credits
     summary: Early startups that are not linked with a Miro global partner organization can apply directly and receive $500 in Miro credits.
     lifecycle:

--- a/vendors/mi/mixpanel.yaml
+++ b/vendors/mi/mixpanel.yaml
@@ -18,7 +18,8 @@ programs: []
 offers:
   - offer_id: off_01kyh8fpe47c34p80tmwstfc3a
     offer_slug: startup-program
-    offer_slug_aliases: []
+    offer_slug_aliases:
+      - 1-year-free-startup-plan-with-mixpanel-for-startups
     title: Startup Program
     summary: Startups get their first year of Mixpanel free, including 1 billion events, 1 million Session Replays, and access to the full analytics suite.
     lifecycle:

--- a/vendors/mo/modal.yaml
+++ b/vendors/mo/modal.yaml
@@ -18,7 +18,8 @@ programs: []
 offers:
   - offer_id: off_01kyh8fpe4fyz5pxzv154ah0y4
     offer_slug: modal-for-startups
-    offer_slug_aliases: []
+    offer_slug_aliases:
+      - 25-000-in-modal-compute-credits
     title: Modal for Startups
     summary: Eligible VC-funded startups can unlock thousands of free GPU credits on Modal's serverless compute platform; the tier depends on funding stage.
     lifecycle:

--- a/vendors/ne/nebius.yaml
+++ b/vendors/ne/nebius.yaml
@@ -28,7 +28,8 @@ offers:
   - offer_id: off_01kyyts97wajf01q9g41ztvarp
     program_id: prg_01kyyts97wfw7w8brz2xw4psa6
     offer_slug: free-compute-credits-with-nebius-for-startups-base-tier
-    offer_slug_aliases: []
+    offer_slug_aliases:
+      - free-compute-credits-with-nebius-for-startups-high-growth-tier
     title: Nebius credits and discounts via VC partners
     summary: Credit offerings are currently available exclusively through Nebius venture capital partners; portfolio startups access credits through their fund's platform team.
     lifecycle:

--- a/vendors/no/notion.yaml
+++ b/vendors/no/notion.yaml
@@ -31,7 +31,8 @@ offers:
   - offer_id: off_01kyyts97ws635fv7kpb4ce6qh
     program_id: prg_01kyyts97wr01a0f3as5qcgatc
     offer_slug: 6-months-free-with-notion-for-startups-partner-tier
-    offer_slug_aliases: []
+    offer_slug_aliases:
+      - free-credits-with-notion-for-startups-direct-apply
     title: Up to 6 months of Notion Business free with Notion AI
     summary: Eligible startups get up to 6 months free of the Notion Business plan with Notion AI included, with the tier depending on the startup's profile.
     lifecycle:

--- a/vendors/sa/salesforce.yaml
+++ b/vendors/sa/salesforce.yaml
@@ -25,7 +25,11 @@ programs:
 offers:
   - offer_id: off_01kyh8fpe5a27280hssp9jdt7q
     offer_slug: salesforce-launchpad-free-and-discounted-solutions
-    offer_slug_aliases: []
+    offer_slug_aliases:
+      - 50-off-sales-cloud-enterprise-with-salesforce-launchpad
+      - 50-off-pro-suite-with-salesforce-launchpad
+      - 25-off-slack-pro-or-business-with-salesforce-launchpad
+      - 12-months-free-starter-suite-with-salesforce-launchpad
     title: Free and discounted Salesforce solutions
     summary: Salesforce Launchpad offers venture-backed startups free and discounted Salesforce solutions, including special offers on Starter Suite, Pro Suite, Sales Cloud Enterprise Edition, Agentforce, Tableau, and Slack.
     lifecycle:

--- a/vendors/wi/wiz.yaml
+++ b/vendors/wi/wiz.yaml
@@ -18,7 +18,8 @@ programs: []
 offers:
   - offer_id: off_01kyygma830fgn90asc8pctkj3
     offer_slug: wiz-go-for-startups
-    offer_slug_aliases: []
+    offer_slug_aliases:
+      - 50-off-cloud-security-bundle-with-wiz-go
     title: Wiz Go for Startups
     summary: Wiz Go is a tailored cloud security bundle for startups, combining Wiz Code, Wiz Cloud, and Wiz Defend & Runtime Sensor with startup-friendly pricing.
     lifecycle:

--- a/vendors/wo/workos.yaml
+++ b/vendors/wo/workos.yaml
@@ -18,7 +18,8 @@ programs: []
 offers:
   - offer_id: off_01kyygma82eet0aqhpceg6n1ba
     offer_slug: workos-user-management-free-tier
-    offer_slug_aliases: []
+    offer_slug_aliases:
+      - 12-months-free-with-workos-for-startups
     title: WorkOS User Management Free Tier
     summary: WorkOS provides free user management and auth backend services for up to 1 million monthly active users (MAUs).
     lifecycle:

--- a/vendors/xe/xero.yaml
+++ b/vendors/xe/xero.yaml
@@ -18,7 +18,8 @@ programs: []
 offers:
   - offer_id: off_01kyypqp9xt0zcgfjvpyncvejs
     offer_slug: xero-plans-80-off-first-3-months
-    offer_slug_aliases: []
+    offer_slug_aliases:
+      - 90-off-for-6-months-with-xero-for-startups
     title: Xero Plans 80% Off First 3 Months
     summary: Get 80% off Xero plans for the first 3 months.
     lifecycle:

--- a/vendors/ze/zendesk.yaml
+++ b/vendors/ze/zendesk.yaml
@@ -18,7 +18,8 @@ programs: []
 offers:
   - offer_id: off_01kyh8fpe6brkee6gvymyykky4
     offer_slug: zendesk-for-startups-programme
-    offer_slug_aliases: []
+    offer_slug_aliases:
+      - 30-off-first-year-with-zendesk-for-startups-50-to-250-employees
     title: Zendesk for Startups Programme
     summary: Eligible early-stage startups can get up to 2 years of free access to the Zendesk Resolution Platform, including Professional Suite and Copilot for up to 50 agents.
     lifecycle:

--- a/vendors/zo/zoho.yaml
+++ b/vendors/zo/zoho.yaml
@@ -18,7 +18,8 @@ programs: []
 offers:
   - offer_id: off_01kyh8fpe6qasefesj77p6h5ww
     offer_slug: zoho-for-startups
-    offer_slug_aliases: []
+    offer_slug_aliases:
+      - free-wallet-credits-with-zoho-startup-program-standard-tier
     title: Zoho for Startups
     summary: Eligible startups can receive Zoho Wallet Credits valid for 360 days to access over 55 integrated Zoho applications, available in two stages including an option for domain hosting credits.
     lifecycle:


### PR DESCRIPTION
Route continuity for the canonical re-sourcing: every removed offer whose vendor still carries a surviving offer keeps its public route as an alias of that offer. Offers on now-offerless vendors are retired through the identity lane in the same admission.