### PR TITLE
data: restore vendor-named programs and retain program routes

### DIFF
--- a/vendors/as/assemblyai.yaml
+++ b/vendors/as/assemblyai.yaml
@@ -14,7 +14,13 @@ links:
 sources:
   - source_id: src_8bca567ba3c14b94f29b44fde3a4786a056238ef6a5feb26cc37d5ae05805a1b
     url: https://www.assemblyai.com/contact/startup-program
-programs: []
+programs:
+  - program_id: prg_01kyyr9svgvrbh4bzefjw2yedv
+    program_slug: assemblyai-for-startups
+    program_slug_aliases: []
+    title: AssemblyAI Startup Program
+    source_ids:
+      - src_8bca567ba3c14b94f29b44fde3a4786a056238ef6a5feb26cc37d5ae05805a1b
 offers:
   - offer_id: off_01kyh8fpe19tbgz9qesnr0wd3x
     offer_slug: assemblyai-startup-program

--- a/vendors/de/deel.yaml
+++ b/vendors/de/deel.yaml
@@ -23,7 +23,8 @@ sources:
 programs:
   - program_id: prg_01kyyts97vhv6dbsc02y0sf1z9
     program_slug: the-pitch-by-deel
-    program_slug_aliases: []
+    program_slug_aliases:
+      - deel-startup-program
     title: The Pitch by Deel
     summary: Global tournament rewarding startup founders with SAFE funding, travel coverage, networking, and access to a perks marketplace.
     source_ids:

--- a/vendors/di/digitalocean.yaml
+++ b/vendors/di/digitalocean.yaml
@@ -14,7 +14,13 @@ links:
 sources:
   - source_id: src_79a5ba0b58a5334728f4b66261d11e87dd01f1b9c98e8c82c9ad5805be0c2327
     url: https://www.digitalocean.com/startups
-programs: []
+programs:
+  - program_id: prg_01kyyr9svgytm49k59kkp561mf
+    program_slug: digitalocean-hatch
+    program_slug_aliases: []
+    title: DigitalOcean Startups
+    source_ids:
+      - src_79a5ba0b58a5334728f4b66261d11e87dd01f1b9c98e8c82c9ad5805be0c2327
 offers:
   - offer_id: off_01kyh8fpe2dwqnfrbb6nejb5zz
     offer_slug: digitalocean-startups-program

--- a/vendors/gi/github.yaml
+++ b/vendors/gi/github.yaml
@@ -14,7 +14,13 @@ links:
 sources:
   - source_id: src_16fcc1a7174c8dc0546e3675de9ef1c1a5939b667c4823a242ab6aa0370e06f8
     url: https://github.com/enterprise/startups
-programs: []
+programs:
+  - program_id: prg_01kyyr9svgyw0svdrb717nexp9
+    program_slug: github-for-startups
+    program_slug_aliases: []
+    title: GitHub for Startups
+    source_ids:
+      - src_16fcc1a7174c8dc0546e3675de9ef1c1a5939b667c4823a242ab6aa0370e06f8
 offers:
   - offer_id: off_01kyh8fpe3fe0s7ef65e5fj1p5
     offer_slug: github-for-startups-offer

--- a/vendors/go/google-cloud.yaml
+++ b/vendors/go/google-cloud.yaml
@@ -21,7 +21,8 @@ sources:
 programs:
   - program_id: prg_01kyh8fpe243m25ep0wtvz068s
     program_slug: google-for-startups-cloud-program
-    program_slug_aliases: []
+    program_slug_aliases:
+      - google-cloud-for-startups
     title: Google for Startups Cloud Program
     summary: Google for Startups Cloud Program provides separate Start, Scale, and AI credit tiers with different economics and eligibility.
     source_ids:

--- a/vendors/mi/miro.yaml
+++ b/vendors/mi/miro.yaml
@@ -21,7 +21,8 @@ sources:
 programs:
   - program_id: prg_01kyh8fpe335dxj6tsyk7tb78w
     program_slug: miro-for-startups
-    program_slug_aliases: []
+    program_slug_aliases:
+      - miro-startup-program
     title: Miro Startup Program
     summary: Miro's startup program gives early startups free Miro credits, directly or through a partner organization, and offers scale-ups a discount.
     source_ids:

--- a/vendors/mi/mixpanel.yaml
+++ b/vendors/mi/mixpanel.yaml
@@ -14,7 +14,13 @@ links:
 sources:
   - source_id: src_ea790be568ceac58032d8f5cfbe5fe7cc82aad0993b883bb8c4fc00d0a39e2ca
     url: https://mixpanel.com/startups
-programs: []
+programs:
+  - program_id: prg_01kyyts97x3wvehfewd8amgdjp
+    program_slug: mixpanel-for-startups
+    program_slug_aliases: []
+    title: Mixpanel for Startups
+    source_ids:
+      - src_ea790be568ceac58032d8f5cfbe5fe7cc82aad0993b883bb8c4fc00d0a39e2ca
 offers:
   - offer_id: off_01kyh8fpe47c34p80tmwstfc3a
     offer_slug: startup-program

--- a/vendors/sa/salesforce.yaml
+++ b/vendors/sa/salesforce.yaml
@@ -19,6 +19,12 @@ programs:
     program_slug: salesforce-launchpad
     program_slug_aliases: []
     title: Salesforce Launchpad
+    source_ids:
+      - src_de248238da7faac44fa1bff72d2bcf4525bc36ccdb8b20a93ad9bbedd00f3748
+  - program_id: prg_01kyyr9svhvjac4av1162f05j1
+    program_slug: salesforce-launchpad
+    program_slug_aliases: []
+    title: Salesforce Launchpad
     summary: Salesforce Launchpad gives venture-backed startups of all stages free and discounted access to Salesforce products - CRM; Agentforce; Slack; Tableau - plus expert GTM coaching; community; and ecosystem partnerships.
     source_ids:
       - src_de248238da7faac44fa1bff72d2bcf4525bc36ccdb8b20a93ad9bbedd00f3748

--- a/vendors/sa/salesforce.yaml
+++ b/vendors/sa/salesforce.yaml
@@ -19,12 +19,6 @@ programs:
     program_slug: salesforce-launchpad
     program_slug_aliases: []
     title: Salesforce Launchpad
-    source_ids:
-      - src_de248238da7faac44fa1bff72d2bcf4525bc36ccdb8b20a93ad9bbedd00f3748
-  - program_id: prg_01kyyr9svhvjac4av1162f05j1
-    program_slug: salesforce-launchpad
-    program_slug_aliases: []
-    title: Salesforce Launchpad
     summary: Salesforce Launchpad gives venture-backed startups of all stages free and discounted access to Salesforce products - CRM; Agentforce; Slack; Tableau - plus expert GTM coaching; community; and ecosystem partnerships.
     source_ids:
       - src_de248238da7faac44fa1bff72d2bcf4525bc36ccdb8b20a93ad9bbedd00f3748

--- a/vendors/wi/wiz.yaml
+++ b/vendors/wi/wiz.yaml
@@ -14,7 +14,13 @@ links:
 sources:
   - source_id: src_e10dc2ef42ff4c06dd0e194be3a951c491eb07ca7e75f7102a215bdcd876d430
     url: https://www.wiz.io/lp/startups
-programs: []
+programs:
+  - program_id: prg_01kyyr9svh6aeder74q5j4rcn2
+    program_slug: wiz-startup-program
+    program_slug_aliases: []
+    title: Wiz for Startups
+    source_ids:
+      - src_e10dc2ef42ff4c06dd0e194be3a951c491eb07ca7e75f7102a215bdcd876d430
 offers:
   - offer_id: off_01kyygma830fgn90asc8pctkj3
     offer_slug: wiz-go-for-startups

--- a/vendors/ze/zendesk.yaml
+++ b/vendors/ze/zendesk.yaml
@@ -14,7 +14,13 @@ links:
 sources:
   - source_id: src_25b42ddd48289d24850b1e411340687bbfcd4a3cb063113c80d9e6911decd797
     url: https://www.zendesk.com/au/business/startups/
-programs: []
+programs:
+  - program_id: prg_01kyyr9svh3m46vmwgnbrpwagr
+    program_slug: zendesk-startup-program
+    program_slug_aliases: []
+    title: Zendesk for Startups
+    source_ids:
+      - src_25b42ddd48289d24850b1e411340687bbfcd4a3cb063113c80d9e6911decd797
 offers:
   - offer_id: off_01kyh8fpe6brkee6gvymyykky4
     offer_slug: zendesk-for-startups-programme

--- a/vendors/zo/zoho.yaml
+++ b/vendors/zo/zoho.yaml
@@ -14,7 +14,13 @@ links:
 sources:
   - source_id: src_7eed286a8512fe0123f70f0b88d01a0a88efa496fa5f6a89703157515c5e3a8f
     url: https://www.zoho.com/startups/
-programs: []
+programs:
+  - program_id: prg_01kyyr9svhbyevgq9sjgvgyngg
+    program_slug: zoho-startup-program
+    program_slug_aliases: []
+    title: Zoho for Startups
+    source_ids:
+      - src_7eed286a8512fe0123f70f0b88d01a0a88efa496fa5f6a89703157515c5e3a8f
 offers:
   - offer_id: off_01kyh8fpe6qasefesj77p6h5ww
     offer_slug: zoho-for-startups


### PR DESCRIPTION
Restores the program identities that vendors genuinely publish (removed too aggressively with their aggregator sourcing) and re-sources each to the vendor page already cited in the record; adds program slug aliases where a surviving program carries the route.