### PR TITLE
catalog: add OpenMetal Startup eXcelerator Program

### DIFF
--- a/vendors/op/openmetal.yaml
+++ b/vendors/op/openmetal.yaml
@@ -1,0 +1,68 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kztx0h07d4ver3kehs3xsep6
+slug: openmetal
+slug_aliases: []
+name: OpenMetal
+domains:
+  - value: openmetal.io
+    role: primary
+    valid_from: 2026-08-12T00:00:00.000Z
+category: hosting-infra
+description: OpenMetal provides dedicated private cloud infrastructure built on OpenStack and Ceph.
+links:
+  site: https://openmetal.io
+sources:
+  - source_id: src_b8f30588bdc8226858519caefcc7d602e6f5a42f4998b0ff1c43fb6535e171e2
+    url: https://openmetal.io/programs/startup-excelerator-program-cloud-credits/
+programs:
+  - program_id: prg_01kztx0h07hq558cn0ra4vq3cg
+    program_slug: startup-excelerator-program
+    program_slug_aliases: []
+    title: OpenMetal Startup eXcelerator Program
+    summary: OpenMetal's startup program provides cloud credits, technical support, account management, and joint marketing opportunities for startups using dedicated private cloud infrastructure.
+    source_ids:
+      - src_b8f30588bdc8226858519caefcc7d602e6f5a42f4998b0ff1c43fb6535e171e2
+offers:
+  - offer_id: off_01kztx0h074gvxktqks68vdkh1
+    program_id: prg_01kztx0h07hq558cn0ra4vq3cg
+    offer_slug: up-to-100000-in-openmetal-cloud-credits
+    offer_slug_aliases: []
+    title: Up to $100,000 in OpenMetal cloud credits
+    summary: Approved startups receive up to $100,000 in credits that discount monthly dedicated private cloud infrastructure costs.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-12T00:00:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $100,000 in cloud credits
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 10000000
+            kind: up-to
+      consideration:
+        kind: unknown
+        description: The program applies credits as a discount toward paid OpenMetal infrastructure, but the public page does not specify the resulting price.
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: not-machine-evaluable
+            statement: Applicants must be a startup applying directly to the OpenMetal Startup eXcelerator Program.
+          - criterion_id: cri_02
+            kind: manual
+            reason: vendor-discretion
+            statement: The program is best suited for startups with cloud spending of $4,000 per month or more.
+    roles:
+      terms_authority_entity_id: ent_01kztx0h07d4ver3kehs3xsep6
+      access_operator_entity_id: ent_01kztx0h07d4ver3kehs3xsep6
+    access:
+      availability: public
+      method: form
+      url: https://openmetal.io/programs/startup-excelerator-program-cloud-credits/
+    source_ids:
+      - src_b8f30588bdc8226858519caefcc7d602e6f5a42f4998b0ff1c43fb6535e171e2


### PR DESCRIPTION
## What changed

Adds a data-only OpenMetal vendor record with the named Startup eXcelerator Program and one consolidated offer for up to $100,000 in credits applied as infrastructure discounts. It also records the published $4,000/month suitability threshold, application route, support, guidance, and joint marketing benefits.

Closes #453.

## Sources

- https://openmetal.io/programs/startup-excelerator-program-cloud-credits/

## Certification

- [x] I changed only allowed repository content and did not mix vendor YAML with other paths.
- [x] Public sources substantiate every submitted factual value; any Sourcey-written prose is a neutral summary, not a fabricated vendor quote.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commits include a `Signed-off-by` line.
