### PR TITLE
data: add Cyso Cloud startup offer

### DIFF
--- a/vendors/cy/cyso-cloud.yaml
+++ b/vendors/cy/cyso-cloud.yaml
@@ -1,0 +1,83 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kzvbm001zcyyzv0j456ab0c8
+slug: cyso-cloud
+slug_aliases: []
+name: Cyso Cloud
+domains:
+  - value: cyso.cloud
+    role: primary
+    valid_from: 2026-08-12T16:00:00.000Z
+category: hosting-infra
+description: Cyso Cloud provides European cloud compute, managed Kubernetes, object storage, load balancing, and DNS services.
+links:
+  site: https://cyso.cloud
+sources:
+  - source_id: src_35dbf05c2954112174ea3ee3e2e876f8dbcdd2017542c6a917bc473bc2f1189a
+    url: https://cyso.cloud/startup-program
+programs:
+  - program_id: prg_01kzvbm00324jymswj4tasfc0g
+    program_slug: cyso-cloud-startup-program
+    program_slug_aliases: []
+    title: Cyso Cloud Startup Program
+    summary: Cyso Cloud's 18-month program gives eligible startups cloud credits, engineering onboarding, direct support, and growth-stage benefits.
+    source_ids:
+      - src_35dbf05c2954112174ea3ee3e2e876f8dbcdd2017542c6a917bc473bc2f1189a
+offers:
+  - offer_id: off_01kzvbm003z23q34h5sw9n38aw
+    program_id: prg_01kzvbm00324jymswj4tasfc0g
+    offer_slug: up-to-10000-eur-cloud-credits
+    offer_slug_aliases: []
+    title: Up to €10,000 in Cyso Cloud credits for 18 months
+    summary: Eligible startups receive €2,500, €5,000, or €10,000 in Cyso Cloud credits for 18 months, based on growth stage, plus 20 hours of engineering onboarding.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-12T16:00:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to €10,000 in credits for Cyso Cloud compute, storage, managed Kubernetes, load balancing, DNS, and other core services
+          duration:
+            kind: exact
+            value: P18M
+          kind: credit
+          value:
+            amount:
+              currency: EUR
+              minor_units: 1000000
+            kind: up-to
+        - benefit_id: ben_02
+          description: Twenty hours of onboarding help from Cyso Cloud engineers
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: The company is an officially registered business incorporated less than five years ago.
+          - criterion_id: cri_02
+            kind: manual
+            reason: external-verification
+            statement: The company has a functional professional website that explains its business, products, or services.
+          - criterion_id: cri_03
+            kind: manual
+            reason: vendor-discretion
+            statement: The company presents a clear growth plan and vision during application and assessment.
+          - criterion_id: cri_04
+            kind: manual
+            reason: vendor-discretion
+            statement: The company commits to European data sovereignty and understands GDPR compliance and digital autonomy.
+    roles:
+      terms_authority_entity_id: ent_01kzvbm001zcyyzv0j456ab0c8
+      access_operator_entity_id: ent_01kzvbm001zcyyzv0j456ab0c8
+    access:
+      availability: public
+      instructions: Submit the startup questionnaire. Cyso Cloud reviews applications within five to seven business days, then arranges an assessment interview and onboarding for accepted applicants.
+      method: form
+      url: https://cyso.cloud/startup-program
+    terms_url: https://cyso.cloud/startup-program
+    source_ids:
+      - src_35dbf05c2954112174ea3ee3e2e876f8dbcdd2017542c6a917bc473bc2f1189a


### PR DESCRIPTION
## What changed

Adds Cyso Cloud with one active Cyso Cloud Startup Program offer: eligible startups can receive €2,500, €5,000, or €10,000 in cloud credits for 18 months, plus 20 hours of engineer onboarding. The record includes eligibility, access, lifecycle, economics, and terms from the vendor-owned source.

Reservation: #481

## Sources

- https://cyso.cloud/startup-program

## Certification

- [x] I changed only allowed repository content and did not mix vendor YAML with other paths.
- [x] Public sources substantiate every submitted factual value; any Sourcey-written prose is a neutral summary, not a fabricated vendor quote.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commits include a `Signed-off-by` line.