### PR TITLE
data: add Zimt startup program

### DIFF
--- a/vendors/zi/zimt.yaml
+++ b/vendors/zi/zimt.yaml
@@ -33,32 +33,45 @@ offers:
     offer_slug_aliases: []
     title: Signals+ Annual three-year startup discount
     summary: Eligible new startup customers receive 60% off Signals+ Annual in year one, 40% in year two, and 30% in year three.
+    description: The discount starts at activation and automatically converts from 60% in year one to 40% in year two and 30% in year three. Qualifying thresholds are reviewed only at contract signing. Access is limited to employees of the qualifying startup, with seats allocated by team size and fair usage. Use is limited to competitor monitoring; sharing or reselling intelligence reports is prohibited. Misuse will result in immediate termination without refund.
     lifecycle:
       status: active
       effective_from: 2026-08-12T18:31:02.000Z
     economics:
       consideration:
         kind: variable
-        description: Subscribe to the Signals+ annual plan, publicly listed at EUR 500 per month billed annually before the startup discount.
+        description: Subscribe to Signals+ Annual, publicly listed at EUR 500 per month billed annually before the startup discount. Subscription fees are non-refundable, and early termination does not qualify for a partial refund. Pricing after the third year returns to the listed annual price.
       benefits:
         - benefit_id: ben_year_1
-          description: 60% off Signals+ Annual in the first year
+          description: 60% off Signals+ Annual for the first year after activation
           kind: discount
           percentage:
             kind: exact
             basis_points: 6000
+          applies_to: Signals+ Annual during the first year after activation
+          duration:
+            kind: exact
+            value: P1Y
         - benefit_id: ben_year_2
-          description: 40% off Signals+ Annual in the second year
+          description: 40% off Signals+ Annual for the second year after activation
           kind: discount
           percentage:
             kind: exact
             basis_points: 4000
+          applies_to: Signals+ Annual during the second year after activation
+          duration:
+            kind: exact
+            value: P1Y
         - benefit_id: ben_year_3
-          description: 30% off Signals+ Annual in the third year
+          description: 30% off Signals+ Annual for the third year after activation
           kind: discount
           percentage:
             kind: exact
             basis_points: 3000
+          applies_to: Signals+ Annual during the third year after activation
+          duration:
+            kind: exact
+            value: P1Y
     eligibility:
       rule:
         kind: all
@@ -95,6 +108,46 @@ offers:
             kind: manual
             reason: external-verification
             statement: Application must be submitted within 90 days of signing up
+          - criterion_id: cri_06
+            fact: company.email_domain_type
+            kind: predicate
+            operator: eq
+            statement: Applicant must use a corporate email domain rather than a personal email provider
+            value:
+              type: string
+              value: corporate
+          - criterion_id: cri_07
+            fact: company.is_registered
+            kind: predicate
+            operator: eq
+            statement: Applicant must be a registered business entity with verifiable registration details, which Zimt may verify
+            value:
+              type: boolean
+              value: true
+          - criterion_id: cri_08
+            kind: manual
+            reason: not-machine-evaluable
+            statement: Company must not operate in competitive intelligence, ABM services, market research, or business intelligence software markets
+          - criterion_id: cri_09
+            kind: manual
+            reason: external-verification
+            statement: Company must not be affiliated with, owned by, or acting on behalf of competitors in the excluded markets
+          - criterion_id: cri_10
+            kind: manual
+            reason: not-machine-evaluable
+            statement: Offer cannot be combined with other promotions
+          - criterion_id: cri_11
+            kind: manual
+            reason: external-verification
+            statement: Qualifying thresholds are reviewed at contract signing only
+          - criterion_id: cri_12
+            kind: manual
+            reason: external-verification
+            statement: Applicant must provide accurate and complete information
+          - criterion_id: cri_13
+            kind: manual
+            reason: vendor-discretion
+            statement: Zimt may deny applications from businesses in adjacent markets
     roles:
       terms_authority_entity_id: ent_01kzvkvyytvezvfs9ynt6ejgc0
       access_operator_entity_id: ent_01kzvkvyytvezvfs9ynt6ejgc0

--- a/vendors/zi/zimt.yaml
+++ b/vendors/zi/zimt.yaml
@@ -1,0 +1,108 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kzvkvyytvezvfs9ynt6ejgc0
+slug: zimt
+slug_aliases: []
+name: Zimt
+domains:
+  - value: zimt.ai
+    role: primary
+    valid_from: 2026-08-12T18:31:02.000Z
+category: crm-sales
+description: Zimt is a company-signal intelligence platform that monitors competitors and target accounts across pricing, product, messaging, and market activity.
+links:
+  site: https://www.zimt.ai
+sources:
+  - source_id: src_3c8416a69203cb7042ef7562b8d0431a29a5465bdf70c4aab51db97db0af80cd
+    url: https://www.zimt.ai/
+  - source_id: src_e799601d441b2b9a5418b1c33bb63d2abd6ab3f1bd58a3d263be84c57233dfe8
+    url: https://www.zimt.ai/pricing
+  - source_id: src_3791387554d7d0c68cbbe9848ddfb7ec648a335568d52b4091cddd60f57f5262
+    url: https://www.zimt.ai/startup-program
+programs:
+  - program_id: prg_01kzvkvyyw2ynakpez8yt5mfph
+    program_slug: zimt-startup-program
+    program_slug_aliases: []
+    title: Zimt Startup Program
+    summary: Zimt's Startup Program gives eligible new customers stepped discounts on Signals+ Annual for three years.
+    source_ids:
+      - src_3791387554d7d0c68cbbe9848ddfb7ec648a335568d52b4091cddd60f57f5262
+offers:
+  - offer_id: off_01kzvkvyywrqp11x2hz7k06hm5
+    program_id: prg_01kzvkvyyw2ynakpez8yt5mfph
+    offer_slug: signals-plus-annual-three-year-startup-discount
+    offer_slug_aliases: []
+    title: Signals+ Annual three-year startup discount
+    summary: Eligible new startup customers receive 60% off Signals+ Annual in year one, 40% in year two, and 30% in year three.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-12T18:31:02.000Z
+    economics:
+      consideration:
+        kind: variable
+        description: Subscribe to the Signals+ annual plan, publicly listed at EUR 500 per month billed annually before the startup discount.
+      benefits:
+        - benefit_id: ben_year_1
+          description: 60% off Signals+ Annual in the first year
+          kind: discount
+          percentage:
+            kind: exact
+            basis_points: 6000
+        - benefit_id: ben_year_2
+          description: 40% off Signals+ Annual in the second year
+          kind: discount
+          percentage:
+            kind: exact
+            basis_points: 4000
+        - benefit_id: ben_year_3
+          description: 30% off Signals+ Annual in the third year
+          kind: discount
+          percentage:
+            kind: exact
+            basis_points: 3000
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lte
+            statement: Company has raised no more than USD 2 million
+            value:
+              type: number
+              value: 2000000
+          - criterion_id: cri_02
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: Company was founded fewer than five years ago
+            value:
+              type: number
+              value: 60
+          - criterion_id: cri_03
+            fact: company.employee_count
+            kind: predicate
+            operator: lt
+            statement: Company has fewer than 50 employees
+            value:
+              type: number
+              value: 50
+          - criterion_id: cri_04
+            kind: manual
+            reason: external-verification
+            statement: Applicant must be a new customer and must not currently be a Zimt customer
+          - criterion_id: cri_05
+            kind: manual
+            reason: external-verification
+            statement: Application must be submitted within 90 days of signing up
+    roles:
+      terms_authority_entity_id: ent_01kzvkvyytvezvfs9ynt6ejgc0
+      access_operator_entity_id: ent_01kzvkvyytvezvfs9ynt6ejgc0
+    access:
+      availability: public
+      method: form
+      url: https://www.zimt.ai/startup-program
+    terms_url: https://www.zimt.ai/startup-program
+    source_ids:
+      - src_e799601d441b2b9a5418b1c33bb63d2abd6ab3f1bd58a3d263be84c57233dfe8
+      - src_3791387554d7d0c68cbbe9848ddfb7ec648a335568d52b4091cddd60f57f5262


### PR DESCRIPTION
## What changed

Adds Zimt with one current Startup Program offer: eligible new startup customers receive 60% off Signals+ Annual in year one, 40% in year two, and 30% in year three. The record includes the vendor-published funding, age, employee-count, customer-status, and application-window requirements.

Reservation: #492

## Sources

- https://www.zimt.ai/
- https://www.zimt.ai/pricing
- https://www.zimt.ai/startup-program

## Certification

- [x] I changed only allowed repository content and did not mix vendor YAML with other paths.
- [x] Public sources substantiate every submitted factual value; any Sourcey-written prose is a neutral summary, not a fabricated vendor quote.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commits include a `Signed-off-by` line.