### PR TITLE
data: correct vendor name casing for notion and nebius

### DIFF
--- a/vendors/ne/nebius.yaml
+++ b/vendors/ne/nebius.yaml
@@ -2,7 +2,7 @@ schema_version: sourcey.vendor-authoring/v1alpha1
 entity_id: ent_01kyyts97t7e1mjd9afe1c2b6k
 slug: nebius
 slug_aliases: []
-name: nebius
+name: Nebius
 domains:
   - value: nebius.com
     role: primary

--- a/vendors/no/notion.yaml
+++ b/vendors/no/notion.yaml
@@ -2,7 +2,7 @@ schema_version: sourcey.vendor-authoring/v1alpha1
 entity_id: ent_01kyyts97tbppvx69rh3v86sk2
 slug: notion
 slug_aliases: []
-name: notion
+name: Notion
 domains:
   - value: notion.so
     role: primary


### PR DESCRIPTION
Vendor names as the vendors publish them. The admission for this head also carries the signed program.retired transitions for the sixteen aggregator-fabricated program identities, so their routes tombstone to the vendor pages and publication converges.