### PR TITLE
data: correct foundersuite name casing

### DIFF
--- a/vendors/fo/foundersuite.yaml
+++ b/vendors/fo/foundersuite.yaml
@@ -2,7 +2,7 @@ schema_version: sourcey.vendor-authoring/v1alpha1
 entity_id: ent_01kyyts97tv71kntfsyxy6e3pp
 slug: foundersuite
 slug_aliases: []
-name: foundersuite
+name: Foundersuite
 domains:
   - value: foundersuite.com
     role: primary


### PR DESCRIPTION
Vendor name as Foundersuite publishes it. The admission for this head also carries the signed offer.retired transitions for the remaining twenty-five aggregator-era offers already replaced by canonical records, completing the identity side of the re-sourcing.