### PR TITLE
data: point zoho site link at the vendor root

### DIFF
--- a/vendors/zo/zoho.yaml
+++ b/vendors/zo/zoho.yaml
@@ -10,7 +10,7 @@ domains:
 category: productivity
 description: The Zoho for Startups program aims to empower startups with access to Zoho's suite of apps through Zoho Wallet credits.
 links:
-  site: https://www.zoho.com/startups/
+  site: https://www.zoho.com
 sources:
   - source_id: src_7eed286a8512fe0123f70f0b88d01a0a88efa496fa5f6a89703157515c5e3a8f
     url: https://www.zoho.com/startups/


### PR DESCRIPTION
The canonical site link is the vendor's root, not its program page. The admission also carries the final three signed program.retired transitions (google cloud, miro, deel aggregator programs), completing identity continuity for the re-sourcing.