### PR TITLE
data: add Agora VC Jumpstart credits

### DIFF
--- a/vendors/ag/agora.yaml
+++ b/vendors/ag/agora.yaml
@@ -1,0 +1,74 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kzy6p6zs4ytd7b0syw4dt0f6
+slug: agora
+slug_aliases: []
+name: Agora
+domains:
+  - value: agora.io
+    role: primary
+    valid_from: 2026-08-13T18:38:33Z
+category: communication
+description: Agora provides APIs and infrastructure for real-time voice, video, chat, and conversational AI experiences.
+links:
+  site: https://www.agora.io/en/
+sources:
+  - source_id: src_2ce1a212eb702d9be75326182ab6f6a4576ceb18d28ab79a61e4c5f38aacee86
+    url: https://www.agora.io/en/
+  - source_id: src_cd68c6e66e17e06fe24fd7d51291d063a09330467e48ba04beaef478652d72b6
+    url: https://explore.agora.io/vc-ai-jumpstart-program
+programs:
+  - program_id: prg_01kzy6p6zwxc1cx7vh4k01cyvw
+    program_slug: vc-conversational-ai-jumpstart
+    program_slug_aliases: []
+    title: VC Conversational AI Jumpstart Program
+    summary: Agora's program gives venture capital firms a route to obtain product credits for portfolio companies building voice AI and real-time communication experiences.
+    source_ids:
+      - src_cd68c6e66e17e06fe24fd7d51291d063a09330467e48ba04beaef478652d72b6
+offers:
+  - offer_id: off_01kzy6p6zw0hzg10gc8enkaga9
+    program_id: prg_01kzy6p6zwxc1cx7vh4k01cyvw
+    offer_slug: vc-conversational-ai-jumpstart-credits
+    offer_slug_aliases: []
+    title: VC Conversational AI Jumpstart Credits
+    summary: Eligible VC portfolio companies can receive up to $50,000 in Agora credits for voice AI and real-time communication products, with approval and amount at Agora's discretion.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-13T18:38:33Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $50,000 in credits toward any Agora product.
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 5000000
+            kind: up-to
+      consideration:
+        kind: unknown
+        description: The program page does not state separate fees or other consideration for applying.
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: The applicant must be a venture capital firm seeking credits for one or more of its portfolio companies.
+          - criterion_id: cri_02
+            kind: manual
+            reason: external-verification
+            statement: Credits must be used by the portfolio company or companies of the venture capital firm applying to the program.
+          - criterion_id: cri_03
+            kind: manual
+            reason: vendor-discretion
+            statement: Acceptance and the credit amount are at Agora's sole discretion, and acceptance does not guarantee the maximum $50,000 credit.
+    roles:
+      terms_authority_entity_id: ent_01kzy6p6zs4ytd7b0syw4dt0f6
+      access_operator_entity_id: ent_01kzy6p6zs4ytd7b0syw4dt0f6
+    access:
+      availability: public
+      method: form
+      url: https://explore.agora.io/vc-ai-jumpstart-program
+    source_ids:
+      - src_cd68c6e66e17e06fe24fd7d51291d063a09330467e48ba04beaef478652d72b6


### PR DESCRIPTION
## Summary

- add one new Agora vendor record
- capture the VC Conversational AI Jumpstart Program as exactly one offer
- model the published up-to-$50,000 credit benefit, VC portfolio-company route, and Agora discretion terms from first-party sources

## Evidence

- https://explore.agora.io/vc-ai-jumpstart-program
- https://www.agora.io/en/

## Validation

- Sourcey digest-pinned Catalog Verifier: `{"status":"valid","vendors":1,"programs":1,"offers":1}`
- both first-party source URLs return HTTP 200
- commit includes DCO sign-off

Closes #544
