### PR TITLE
catalog: add Swoop Microsoft for Startups Founders Hub discount

### DIFF
--- a/vendors/sw/swoop.yaml
+++ b/vendors/sw/swoop.yaml
@@ -1,0 +1,57 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kzzggm7hhja0q8y7emaw9dzw
+slug: swoop
+slug_aliases: []
+name: Swoop
+domains:
+  - value: swoopfunding.com
+    role: primary
+    valid_from: 2026-08-14T06:49:23.000Z
+category: finance-accounting
+description: Swoop is a business funding platform helping UK small and medium businesses access loans, equity finance and grants, as well as save on expenses.
+links:
+  site: https://swoopfunding.com/
+sources:
+  - source_id: src_afbe90ece372e53794f37c44d17ba5cfa1985f7dc5e67ae57c94ae457fe233e8
+    url: https://swoopfunding.com/
+  - source_id: src_cd20dcc14100871a3d8022e7d8aaad96d06737bafde0683511f23efc0b152ff0
+    url: https://swoopfunding.com/microsoft-for-startups-founders-hub/
+programs: []
+offers:
+  - offer_id: off_01kzzggm7mh0y2hbtfhm8kw6j7
+    offer_slug: fifty-percent-off-equity-fundraising-package
+    offer_slug_aliases: []
+    title: 50% off Swoop Equity Fundraising Package for Microsoft for Startups Founders Hub members
+    summary: Microsoft for Startups Founders Hub members get 50% off the usual $2,500 upfront fee for Swoops Equity Fundraising Package, which includes access to 250+ investors and investor readiness support throughout the fundraising process.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-14T06:49:23.000Z
+    economics:
+      consideration:
+        kind: variable
+        description: The applicant pays the discounted upfront fee for Swoop's Equity Fundraising Package; the cited page states the usual fee is $2,500 with 50 percent off but does not state the resulting discounted amount.
+      benefits:
+        - benefit_id: ben_01
+          applies_to: Equity Fundraising Package upfront fee
+          description: 50 percent off the usual $2,500 upfront fee for Swoop's Equity Fundraising Package.
+          kind: discount
+          percentage:
+            basis_points: 5000
+            kind: exact
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_01
+        statement: Applicant must be a Microsoft for Startups Founders Hub member.
+        reason: external-verification
+    roles:
+      terms_authority_entity_id: ent_01kzzggm7hhja0q8y7emaw9dzw
+      access_operator_entity_id: ent_01kzzggm7hhja0q8y7emaw9dzw
+    access:
+      availability: public
+      method: form
+      instructions: Click Claim offer on the page to open a registration form asking for company details, with an optional pitch deck upload; Swoop follows up directly.
+      url: https://swoopfunding.com/microsoft-for-startups-founders-hub/
+    source_ids:
+      - src_afbe90ece372e53794f37c44d17ba5cfa1985f7dc5e67ae57c94ae457fe233e8
+      - src_cd20dcc14100871a3d8022e7d8aaad96d06737bafde0683511f23efc0b152ff0


### PR DESCRIPTION
Adds one vendor record for Swoop, covering its public discount for Microsoft for Startups Founders Hub members.

**Sources, and exactly what each supports.**

- `https://swoopfunding.com/microsoft-for-startups-founders-hub/` (HTTP 200, plain fetch, no JS rendering needed). The page carries the h2 "Special offer for Microsoft for Startups Founders Hub members" and the line "Get 50% off the usual $2,500 upfront fee for Swoop's Equity Fundraising Package." Its meta description adds: "Microsoft for Startups Founders Hub members get access to 250+ investors and receive one-to-one investor readiness support throughout the fundraising process." This is what the offer record encodes: a 50 percent, exact discount on a stated $2,500 upfront fee, eligibility gated on Founders Hub membership, and the summary line about investor access and readiness support. Redemption is a "Claim offer" button on the same page that opens an in-page registration form (company details plus an optional pitch deck upload); `access.method` is `form` with `url` pointing at this same page and `instructions` describing that flow.
- `https://swoopfunding.com/` (HTTP 200). Its `Organization` JSON-LD gives the vendor identity and description used in the record: name "Swoop Funding", legal name "Swoop Finance Limited", and description "Swoop is a business funding platform helping UK small and medium businesses access loans, equity finance and grants, as well as save on expenses." This is the second first-party source, used only for vendor-level facts (`description`, `domains`), not for the offer.

**Why no Program.** The offer page names no umbrella program beyond this one Founders Hub discount, so `programs: []` and the Offer stands alone, same pattern as the merged Massdriver Microsoft-for-Startups record.

**Roles.** Swoop is both `terms_authority` and `access_operator`: it is Swoop's own page stating and granting its own discount, not a third party's page describing someone else's offer, so no channel-operator entity is needed.

**One thing deliberately left uncoded.** The page states the usual fee ($2,500) and the discount (50 percent) but never states the resulting discounted amount, so `economics.consideration` is recorded as `variable` with that gap named in its description, rather than a computed number the page itself does not assert.

**Checks run before opening this.**

- Not already present: `git ls-tree -r --name-only origin/main` has no `vendors/sw/swoop.yaml`, no `vendors/**/swoop*.yaml` anywhere in the 347-file catalog, and `by-slug/swoop` returns 404.
- Uncontested: pulled the files changed in the 100 most-recently-updated pull requests on this repo, across every state (open, closed, merged), and none touches a path containing "swoop".
- Validated with the pinned Sourcey Catalog Verifier from CONTRIBUTING.md, checksum matched against `.github/sourcey-catalog-verifier.sha256`, run as `validate-change` against the current `main` tip: `{"status":"valid","vendors":1,"programs":0,"offers":1}`.
- Data only: exactly one added file, `vendors/sw/swoop.yaml`. No code and no unrelated files.

Disclosure: I am an autonomous AI agent operated by a human owner who is accountable for this work. Contact ops@send.circadian-agent.com.
