### PR TITLE
catalog: add RevOps.ai for Startups vendor record

### DIFF
--- a/vendors/re/revops-ai.yaml
+++ b/vendors/re/revops-ai.yaml
@@ -1,0 +1,106 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kzzhc9f67tzjeqt8kfeefxgq
+slug: revops-ai
+slug_aliases: []
+name: RevOps.ai
+domains:
+  - value: revops.ai
+    role: primary
+    valid_from: 2026-08-14T00:00:00.000Z
+category: crm-sales
+description: RevOps.ai is an AI-native revenue operations platform with a built-in CRM, power dialer, and AI revenue agents for inbound conversion, pipeline reactivation, and customer expansion.
+links:
+  site: https://revops.ai
+sources:
+  - source_id: src_2e490b0d2b7521af57540adf96f507850690d22056f1a4bb3da7b937c6fb10fd
+    url: https://revops.ai/startups
+programs:
+  - program_id: prg_01kzzhc9f8s96kcpkfzy0yggte
+    program_slug: revops-ai-for-startups
+    program_slug_aliases: []
+    title: RevOps.ai for Startups
+    summary: RevOps.ai's Startups program gives eligible pre-seed through Series A companies platform credits, full access to all AI agents, priority onboarding, and priority support.
+    source_ids:
+      - src_2e490b0d2b7521af57540adf96f507850690d22056f1a4bb3da7b937c6fb10fd
+offers:
+  - offer_id: off_01kzzhc9f8zvxpthf886pw2zms
+    program_id: prg_01kzzhc9f8s96kcpkfzy0yggte
+    offer_slug: 25000-in-platform-credits-for-six-months
+    offer_slug_aliases: []
+    title: $25,000 in RevOps.ai credits for six months
+    summary: Eligible pre-seed through Series A startups with under $10M raised, under 5 years old, and fewer than 50 employees receive $25,000 in RevOps.ai platform credits valid for six months.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-14T00:00:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: $25,000 in RevOps.ai platform credits, usable across all AI agents and plans
+          duration:
+            kind: exact
+            value: P6M
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 2500000
+            kind: exact
+        - benefit_id: ben_02
+          description: Full platform access to all AI agents, priority onboarding, and priority support
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.stage
+            kind: predicate
+            operator: in
+            statement: Company is at pre-seed, seed, or Series A stage.
+            value:
+              type: string-set
+              values:
+                - pre-seed
+                - seed
+                - series-a
+          - criterion_id: cri_02
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: Company has raised less than $10 million in total funding.
+            value:
+              type: number
+              value: 10000000
+          - criterion_id: cri_03
+            fact: company.age_years
+            kind: predicate
+            operator: lt
+            statement: Company is less than five years old.
+            value:
+              type: number
+              value: 5
+          - criterion_id: cri_04
+            fact: company.employee_count
+            kind: predicate
+            operator: lt
+            statement: Company has fewer than 50 employees.
+            value:
+              type: number
+              value: 50
+          - criterion_id: cri_05
+            fact: company.partner_memberships
+            kind: predicate
+            operator: present
+            statement: Company is affiliated with an approved VC, accelerator, or incubator partner.
+    roles:
+      terms_authority_entity_id: ent_01kzzhc9f67tzjeqt8kfeefxgq
+      access_operator_entity_id: ent_01kzzhc9f67tzjeqt8kfeefxgq
+    access:
+      availability: public
+      method: form
+      url: https://revops.ai/startups
+    terms_url: https://revops.ai/startups
+    source_ids:
+      - src_2e490b0d2b7521af57540adf96f507850690d22056f1a4bb3da7b937c6fb10fd


### PR DESCRIPTION
## Summary

Adds one new vendor: RevOps.ai (revops.ai), with one named program
(RevOps.ai for Startups) and one offer ($25,000 in RevOps.ai credits for
six months). This is a fresh record; `revops-ai` does not exist under
`vendors/` on main and no open pull request currently targets it. A prior
attempt, #185, was closed unmerged after admission flagged the `category`
and `description` fields as uncovered by the cited source; this submission
uses fresh IDs and corrects both, plus one factual correction (the credit
validity period is six months, not three, per the vendor's current FAQ
text).

## Evidence

Single first-party source for every asserted fact: https://revops.ai/startups

Quoted directly from the fetched page:

- Eligibility (FAQ, "Who is eligible for the RevOps.ai Startups program?"):
  "The RevOps.ai for Startups program is for early-stage companies
  (Pre-Seed through Series A) that have raised under $10M in total
  funding, are less than 5 years old, and have fewer than 50 employees.
  You must be affiliated with an approved VC, accelerator, or incubator
  partner."
- Benefit amount and duration (FAQ, "How much do we get?" section):
  "Accepted startups receive $25,000 in platform credits that can be used
  across all AI agents and plans. Credits are valid for 6 months from
  activation."
- Access method: an "Apply Now" button leads to an application form; the
  page states "Fill out a quick application with your company details."
- Vendor description (page JSON-LD `description`, same page): "AI-native
  revenue operations platform with a built-in CRM, power dialer, and AI
  revenue agents. Manage contacts, deal pipeline, unified inbox, calendar
  and reporting in one place, and run inbound conversion, pipeline
  reactivation and customer expansion across SMS, WhatsApp, voice, email
  and web chat." Used to support `category: crm-sales` (built-in CRM,
  deal pipeline) and the vendor `description` field.
- Support-benefit items ("Priority onboarding", "Priority support",
  "dedicated support") appear as plan-comparison list items and page copy
  on the same page, supporting the second benefit entry.

Closes #184 (reservation comment posted before this PR was opened:
https://github.com/sourcey/startup-credits/issues/184#issuecomment-5290517867).

## Validation

Ran the exact pinned Catalog Verifier (digest
`ab88ab8a9343e6c6b2c19d3933aed429982b650e08bdb8bbd5f990b72c1fc953`, checksum
verified) locally against a fresh clone at current main before opening:

```
{"status":"valid","vendors":1,"programs":1,"offers":1}
```

- The cited source URL returns HTTP 200.
- Commit carries a DCO `Signed-off-by` trailer.
- One file changed: `vendors/re/revops-ai.yaml`.
