### PR TITLE
data: add Liveblocks startup offer

### DIFF
--- a/vendors/li/liveblocks.yaml
+++ b/vendors/li/liveblocks.yaml
@@ -14,6 +14,8 @@ links:
 sources:
   - source_id: src_58b051cd546cbd5ed1e3dc946735572c6800f87df5c46366520385100da54856
     url: https://liveblocks.io/startups
+  - source_id: src_3584a0636b99ca380ad6bfc2c84ac0acd94e470107a488fe47d21d07e04bb497
+    url: https://liveblocks.io
 programs: []
 offers:
   - offer_id: off_01kzybxx41a9tkr0zpcxe79p73

--- a/vendors/li/liveblocks.yaml
+++ b/vendors/li/liveblocks.yaml
@@ -8,7 +8,7 @@ domains:
     role: primary
     valid_from: 2026-08-13T21:15:00.000Z
 category: devtools-other
-description: Liveblocks is a realtime collaboration infrastructure platform that lets teams build multiplayer presence, storage, and commenting features into their products.
+description: Liveblocks provides realtime infrastructure for handling concurrent edits on shared data, letting teams build multiplayer presence, storage, and commenting into their products.
 links:
   site: https://liveblocks.io
 sources:
@@ -16,6 +16,8 @@ sources:
     url: https://liveblocks.io/startups
   - source_id: src_3584a0636b99ca380ad6bfc2c84ac0acd94e470107a488fe47d21d07e04bb497
     url: https://liveblocks.io
+  - source_id: src_e09bdb3f0b9722fe562c94d8b3e95f4b3976b131c0fa96405d27b920bf95adcd
+    url: https://liveblocks.io/docs
 programs: []
 offers:
   - offer_id: off_01kzybxx41a9tkr0zpcxe79p73

--- a/vendors/li/liveblocks.yaml
+++ b/vendors/li/liveblocks.yaml
@@ -1,0 +1,49 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kzybxx3nhg9e72nwjj5fg2wm
+slug: liveblocks
+slug_aliases: []
+name: Liveblocks
+domains:
+  - value: liveblocks.io
+    role: primary
+    valid_from: 2026-08-13T21:15:00.000Z
+category: devtools-other
+description: Liveblocks is a realtime collaboration infrastructure platform that lets teams build multiplayer presence, storage, and commenting features into their products.
+links:
+  site: https://liveblocks.io
+sources:
+  - source_id: src_58b051cd546cbd5ed1e3dc946735572c6800f87df5c46366520385100da54856
+    url: https://liveblocks.io/startups
+programs: []
+offers:
+  - offer_id: off_01kzybxx41a9tkr0zpcxe79p73
+    offer_slug: liveblocks-for-startups
+    offer_slug_aliases: []
+    title: Liveblocks for Startups
+    summary: Eligible early-stage startups and nonprofits get a discounted Liveblocks Team plan to ship realtime collaboration features, for new customers with fewer than 5 employees and up to $2M raised / $500K ARR.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-13T21:15:00.000Z
+    economics:
+      consideration:
+        kind: unknown
+        description: The source record did not establish a separate consideration amount for the discounted plan.
+      benefits:
+        - benefit_id: ben_primary
+          description: Discounted Liveblocks Team plan pricing to ship realtime collaboration features at scale
+          kind: other
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Must be a new Liveblocks customer with fewer than 5 employees, and (for startups) up to $2M raised and $500K ARR; early-stage startups and nonprofits are eligible.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01kzybxx3nhg9e72nwjj5fg2wm
+      access_operator_entity_id: ent_01kzybxx3nhg9e72nwjj5fg2wm
+    access:
+      availability: public
+      method: form
+      url: https://liveblocks.io/startups
+    source_ids:
+      - src_58b051cd546cbd5ed1e3dc946735572c6800f87df5c46366520385100da54856


### PR DESCRIPTION
## Summary
Adds a new vendor record for **Liveblocks** (liveblocks.io) to the startup-credits catalog.

Liveblocks is not currently in the catalog. This is a data-only PR.

## Offer
**Liveblocks for Startups** — eligible early-stage startups and nonprofits receive a discounted Team plan to ship realtime collaboration features at scale.

- **Canonical source:** https://liveblocks.io/startups
- **Eligibility (per source page):** new Liveblocks customers; fewer than 5 employees; for startups, up to $2M raised and $500K ARR; open to early-stage startups and nonprofits.
- Access via application form on the source page.

## Notes
- The vendor page does not publish an explicit percentage off, so the benefit is modeled as `kind: other` with a source-backed description rather than inventing a discount value.
- Validated locally with the pinned Sourcey Catalog Verifier (validate-change) — status valid, 1 vendor / 1 offer.