### PR TITLE
data: add monday.com monday dev Startup Program

### DIFF
--- a/vendors/mo/monday.yaml
+++ b/vendors/mo/monday.yaml
@@ -1,0 +1,51 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01kzzmrac37brqxhmgs72hh479
+slug: monday
+slug_aliases: []
+name: monday.com
+domains:
+  - value: monday.com
+    role: primary
+    valid_from: 2026-08-14T08:03:56.000Z
+category: productivity
+description: monday.com is a Work OS platform for project management, CRM, and software development, including monday dev, its tool for agile product and engineering teams.
+links:
+  site: https://monday.com
+sources:
+  - source_id: src_7283993ec581bca5cc38a4a954e318699693e76746385ab21274cc0fc5562399
+    url: https://monday.com/l/miscellaneous/startup/
+programs: []
+offers:
+  - offer_id: off_01kzzmrac5bh3gddvr6280pxbw
+    offer_slug: monday-dev-startup-program
+    offer_slug_aliases: []
+    title: monday dev Startup Program
+    summary: Eligible early-stage startups can buy a one-year, 10-seat monday dev Pro plan for a one-off payment of $240 USD.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-14T08:03:56.000Z
+    economics:
+      consideration:
+        kind: fixed
+        amount:
+          currency: USD
+          minor_units: 24000
+      benefits:
+        - benefit_id: ben_primary
+          kind: other
+          description: One-year, 10-seat monday dev Pro plan for a one-off payment of $240 USD
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Organization has up to 50 employees, was formed within the last two years, is supported by a venture capital firm, startup accelerator, or incubator, and is not already a paying monday.com customer.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01kzzmrac37brqxhmgs72hh479
+      access_operator_entity_id: ent_01kzzmrac37brqxhmgs72hh479
+    access:
+      availability: public
+      method: other
+    terms_url: https://monday.com/l/miscellaneous/startup/
+    source_ids:
+      - src_7283993ec581bca5cc38a4a954e318699693e76746385ab21274cc0fc5562399


### PR DESCRIPTION
## Summary

Adds `vendors/mo/monday.yaml`: monday.com, with one Offer, the monday dev
Startup Program.

Eligible early-stage startups can purchase a one-year, 10-seat monday dev
Pro plan for a one-off payment of 240 USD.

Eligibility (quoted from the source): "The Program is only applicable to
organizations that: (i) are comprised of up to fifty (50) employees, (ii)
have been duly formed and/or established within the last two years from
applying to the Program, (iii) are supported by a venture capital, startup
accelerator or incubator, and (iv) are not monday.com paying customers at
the time of applying to the Program."

Benefit (quoted from the source): "Eligible Startups will be able to
purchase a one-year subscription for a 10-seat monday dev Pro plan at a
one-off payment of $240 USD."

## Evidence

https://monday.com/l/miscellaneous/startup/

## Validation

Ran the pinned Sourcey Catalog Verifier locally against this branch at the
current `origin/main` merge base:

```
{"status":"valid","vendors":1,"programs":0,"offers":1}
```

Source URL returns HTTP 200. Commit includes DCO sign-off.

Closes #81
