### PR TITLE
data: add Inngest YC Deal

### DIFF
--- a/vendors/in/inngest.yaml
+++ b/vendors/in/inngest.yaml
@@ -1,0 +1,81 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01m00110wgxafza4pf2am3ftz3
+slug: inngest
+slug_aliases: []
+name: Inngest
+domains:
+  - value: inngest.com
+    role: primary
+    valid_from: 2026-08-14T11:37:57Z
+category: devtools-other
+description: Inngest helps teams build reliable background jobs, workflows, and AI agents without extra infrastructure.
+links:
+  site: https://www.inngest.com
+sources:
+  - source_id: src_356d15277c0b0c06e23e0aa20d9c6492134612848fa7423feaa6f06b53f9e3f1
+    url: https://www.inngest.com
+  - source_id: src_435228e4e8c2c663ee87e24f71f389c3849cbf7f92fcbf990c53ccd2c1e7379b
+    url: https://www.inngest.com/yc
+programs:
+  - program_id: prg_01m00110wpy67dd0f0dap069wa
+    program_slug: yc-deal
+    program_slug_aliases: []
+    title: YC Deal
+    summary: Inngest offers Y Combinator companies and alumni the Cloud Pro plan free for the first year.
+    source_ids:
+      - src_435228e4e8c2c663ee87e24f71f389c3849cbf7f92fcbf990c53ccd2c1e7379b
+offers:
+  - offer_id: off_01m00110wpxc7kdhtwn5fv249w
+    program_id: prg_01m00110wpy67dd0f0dap069wa
+    offer_slug: yc-pro-plan-first-year
+    offer_slug_aliases: []
+    title: Pro plan free for the first year
+    summary: Y Combinator companies and alumni can request the Inngest Cloud Pro plan free for the first year through Inngest's YC Deal form.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-14T11:37:57Z
+    economics:
+      consideration:
+        kind: none
+      benefits:
+        - benefit_id: ben_01
+          applies_to: Inngest Cloud Pro
+          description: The Inngest Cloud Pro plan is free for the first year.
+          kind: discount
+          percentage:
+            kind: exact
+            basis_points: 10000
+          duration:
+            kind: exact
+            value: P1Y
+    eligibility:
+      rule:
+        kind: any
+        rules:
+          - criterion_id: cri_01
+            fact: company.partner_memberships
+            kind: predicate
+            operator: contains
+            statement: Must be a Y Combinator company.
+            value:
+              type: string
+              value: Y Combinator
+          - criterion_id: cri_02
+            fact: company.partner_memberships
+            kind: predicate
+            operator: contains
+            statement: Must be a Y Combinator alumni company.
+            value:
+              type: string
+              value: YC alumni
+    roles:
+      terms_authority_entity_id: ent_01m00110wgxafza4pf2am3ftz3
+      access_operator_entity_id: ent_01m00110wgxafza4pf2am3ftz3
+    access:
+      availability: membership
+      instructions: Submit your name, company email, and YC verification badge URL on the Inngest YC Deal form.
+      method: form
+      url: https://www.inngest.com/yc
+    terms_url: https://www.inngest.com/yc
+    source_ids:
+      - src_435228e4e8c2c663ee87e24f71f389c3849cbf7f92fcbf990c53ccd2c1e7379b


### PR DESCRIPTION
## Summary

- add Inngest as a new devtools vendor
- add the named YC Deal program with exactly one offer
- model the Inngest Cloud Pro plan as free for the first year for Y Combinator companies and alumni

## Evidence

The current first-party English-language YC Deal page states that Y Combinator companies and alumni can request the Pro plan free for the first year, and it exposes the application form plus YC verification-badge field. The Inngest homepage supports the vendor description and primary domain.

## Validation

- Sourcey digest-pinned verifier: status valid, vendors 1, programs 1, offers 1
- both first-party source URLs return HTTP 200
- git diff --check passes
- DCO sign-off present

Closes #563

Made with [Cursor](https://cursor.com)