### PR TITLE
data: add HyperComply Startup Package

### DIFF
--- a/vendors/hy/hypercomply.yaml
+++ b/vendors/hy/hypercomply.yaml
@@ -1,0 +1,62 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_6a1d23223a64d57274bad8e6eb
+slug: hypercomply
+slug_aliases: []
+name: HyperComply
+domains:
+  - value: hypercomply.com
+    role: primary
+    valid_from: 2026-08-14T14:43:48.471Z
+category: legal-compliance
+description: HyperComply helps companies respond to security questionnaires and share security documentation through Trust Pages and Data Rooms.
+links:
+  site: https://www.hypercomply.com
+sources:
+  - source_id: src_53ae0ad3209d7224c5f7ff468dd79c36c9b2c2f10d06fbdcd3dbf47afbbd9d75
+    url: https://www.hypercomply.com/startup
+programs:
+  - program_id: prg_5db0da5008d81d31cdb199c703
+    program_slug: hypercomply-startup-package
+    program_slug_aliases: []
+    title: HyperComply Startup Package
+    summary: HyperComply gives eligible startups discounted access to unlimited security questionnaire responses, a response SLA, a Trust Page, Data Rooms, and flexible payment terms.
+    source_ids:
+      - src_53ae0ad3209d7224c5f7ff468dd79c36c9b2c2f10d06fbdcd3dbf47afbbd9d75
+offers:
+  - offer_id: off_7e5d3ec877ba5d596130224a3a
+    program_id: prg_5db0da5008d81d31cdb199c703
+    offer_slug: startup-package-discount
+    offer_slug_aliases: []
+    title: 60% off the HyperComply Startup Package
+    summary: Eligible startups get 60% off a package with unlimited questionnaire responses, a 3-day response SLA, a public Trust Page, Data Rooms, and flexible payment terms.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-14T14:43:48.471Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: 60% off the HyperComply Startup Package
+          kind: discount
+          percentage:
+            kind: exact
+            basis_points: 6000
+          applies_to: HyperComply Startup Package
+      consideration:
+        kind: variable
+        description: Approved startups pay the remaining package price after the 60% discount.
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: vendor-discretion
+        statement: HyperComply determines which startups are eligible for the package through its application process.
+    roles:
+      terms_authority_entity_id: ent_6a1d23223a64d57274bad8e6eb
+      access_operator_entity_id: ent_6a1d23223a64d57274bad8e6eb
+    access:
+      availability: public
+      method: form
+      url: https://www.hypercomply.com/startup
+    terms_url: https://www.hypercomply.com/startup
+    source_ids:
+      - src_53ae0ad3209d7224c5f7ff468dd79c36c9b2c2f10d06fbdcd3dbf47afbbd9d75


### PR DESCRIPTION
## What changed

Adds HyperComply and its Startup Package, which gives eligible startups 60% off a package for security questionnaire responses and related trust-documentation features.

Closes #589.

## Sources

- https://www.hypercomply.com/startup

## Certification

- [x] I changed only allowed repository content and did not mix vendor YAML with other paths.
- [x] Public sources substantiate every submitted factual value; any Sourcey-written prose is a neutral summary, not a fabricated vendor quote.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commits include a `Signed-off-by` line.
