### PR TITLE
Add Semgrep startup pricing offer

### DIFF
--- a/vendors/se/semgrep.yaml
+++ b/vendors/se/semgrep.yaml
@@ -1,0 +1,49 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01m00bj7he002p6e4drdvye5ch
+slug: semgrep
+slug_aliases: []
+name: Semgrep
+domains:
+  - value: semgrep.dev
+    role: primary
+    valid_from: 2026-08-14T14:42:15Z
+category: auth-security
+description: Semgrep provides application security tools for finding and remediating vulnerabilities in code, open source dependencies, and secrets.
+links:
+  site: https://semgrep.dev/
+sources:
+  - source_id: src_2064f53d2d7318632fd15259c9cdd55693cc8882ec6d1857ed29cdfc87a56928
+    url: https://semgrep.dev/contact/contact-us-startups/
+programs: []
+offers:
+  - offer_id: off_01m00bj7hf8jb4rknvpnks0z06
+    offer_slug: semgrep-startup-pricing
+    offer_slug_aliases: []
+    title: Semgrep Startup Pricing
+    summary: Qualifying startups receive special pricing on Semgrep's full product suite, with unlimited scans and repositories, AI-assisted security, and premium 8x5 support.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-14T14:42:15Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Special startup pricing on Semgrep's full product suite.
+          kind: other
+      consideration:
+        description: Specific startup pricing is determined after contacting Semgrep and qualifying for the plan.
+        kind: unknown
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: vendor-discretion
+        statement: Applicant must be a startup that Semgrep determines qualifies for its special startup pricing.
+    roles:
+      terms_authority_entity_id: ent_01m00bj7he002p6e4drdvye5ch
+      access_operator_entity_id: ent_01m00bj7he002p6e4drdvye5ch
+    access:
+      availability: public
+      method: form
+      url: https://semgrep.dev/contact/contact-us-startups/
+    source_ids:
+      - src_2064f53d2d7318632fd15259c9cdd55693cc8882ec6d1857ed29cdfc87a56928


### PR DESCRIPTION
## What changed

Adds Semgrep as a new vendor with its currently available startup pricing offer.

The record captures the vendor's first-party startup program page, eligibility as vendor-discretion, public form access, and the advertised benefits without inventing a fixed discount amount.

## Sources

- https://semgrep.dev/contact/contact-us-startups/
- https://semgrep.dev/

## Validation

Ran the repository's pinned verifier against the changed vendor file:

{"status":"valid","vendors":1,"programs":0,"offers":1}

The file uploaded to this branch matches the locally verified file byte-for-byte (SHA-256: f6fdb36c5db0dcae6255f28a5e84d8157495ed8b3facaecce622781697a77235).

## Risk

Low. This is a data-only addition. The pricing amount is intentionally not quantified because Semgrep determines startup pricing after qualification.

Closes #591

## Certification

- [x] I changed only allowed repository content and did not mix vendor YAML with other paths.
- [x] Public sources substantiate every submitted factual value; any Sourcey-written prose is a neutral summary, not a fabricated vendor quote.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commits include a Signed-off-by line.