### PR TITLE
Add Appsmith Startup Program

### DIFF
--- a/vendors/ap/appsmith.yaml
+++ b/vendors/ap/appsmith.yaml
@@ -1,0 +1,82 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01m0719yh5mxzhpm3vc3pgvkn7
+slug: appsmith
+slug_aliases: []
+name: Appsmith
+domains:
+  - value: appsmith.com
+    role: primary
+    valid_from: 2026-08-17T04:57:31.060Z
+category: no-code
+description: Appsmith is an open-source low-code platform for building internal tools such as admin panels, dashboards, CRUD frontends, portals, trackers, and support and operations apps.
+links:
+  site: https://www.appsmith.com
+sources:
+  - source_id: src_ca297040bb327bf13c623e05669f866e15dc5c0fb820af99415bd1a12d074e88
+    url: https://www.appsmith.com/startup-program
+programs: []
+offers:
+  - offer_id: off_01m0719yh63pjr3rsa68h7mjgb
+    offer_slug: appsmith-startup-program
+    offer_slug_aliases: []
+    title: Appsmith Startup Program
+    summary: Startups incorporated less than two years ago that have raised under $10M can receive $30,000 worth of Appsmith credits, all Business plan features, and access to Appsmith developer advocates.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-17T04:57:31.060Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: $30,000 worth of Appsmith credits
+          kind: credit
+          value:
+            kind: exact
+            amount:
+              currency: USD
+              minor_units: 3000000
+        - benefit_id: ben_02
+          description: All Business plan features
+          kind: other
+        - benefit_id: ben_03
+          description: Access to Appsmith developer advocates
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: The startup has raised less than $10M in funding.
+            value:
+              type: number
+              value: 10000000
+          - criterion_id: cri_02
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: The startup was incorporated less than two years ago.
+            value:
+              type: number
+              value: 24
+          - criterion_id: cri_03
+            kind: manual
+            reason: not-machine-evaluable
+            statement: The applicant plans to use Appsmith for their own startup.
+          - criterion_id: cri_04
+            kind: manual
+            reason: not-machine-evaluable
+            statement: The applicant is looking to host Appsmith on their own infrastructure.
+    roles:
+      terms_authority_entity_id: ent_01m0719yh5mxzhpm3vc3pgvkn7
+      access_operator_entity_id: ent_01m0719yh5mxzhpm3vc3pgvkn7
+    access:
+      availability: public
+      method: form
+      url: https://www.appsmith.com/startup-program
+      instructions: Apply through the enrolment form linked from the Appsmith Startup Program page.
+    source_ids:
+      - src_ca297040bb327bf13c623e05669f866e15dc5c0fb820af99415bd1a12d074e88


### PR DESCRIPTION
Adds one new vendor (`appsmith`) with exactly one offer: the **Appsmith Startup Program**.

Data-only: one new file, `vendors/ap/appsmith.yaml`.

## Offer

Qualifying startups receive $30,000 worth of Appsmith credits, all Business plan features, and access to Appsmith's developer advocates.

Requirements, as published: the applicant plans to use Appsmith for their own startup, has raised less than $10M in funding, was incorporated less than 2 years ago, and is looking to host Appsmith on their own infrastructure.

## First-party source

- <https://www.appsmith.com/startup-program> — Appsmith's own startup program page, carrying the offer ("$30,000 worth of Appsmith credits", "All Business plan features", "Get access to our dev advocates"), the four listed requirements, and the enrolment form.

Appsmith is named as both `terms_authority_entity_id` and `access_operator_entity_id`, and the only cited source is on `appsmith.com`.

## Qualification notes

- Not a generic free tier, trial, or coupon: it is a startup-gated credit grant with published eligibility requirements and an enrolment step.
- `appsmith` is not currently in the catalog.
- The two numeric requirements are modelled as predicates (`company.funding_raised_usd lt 10000000`, `company.age_months lt 24`); the two intent-based requirements are `manual` with `not-machine-evaluable`.
- Credit validity period is behind a collapsed FAQ on the page and is therefore not claimed in the record.

## Verification

Pinned Sourcey Catalog Verifier (`sha256:848bb5d1d6cb6c173cc460d34ec088c8ba603080670a0eb417af3ad6c01cb0e4`) run locally against `upstream/main`:

```
{"status":"valid","vendors":1,"programs":0,"offers":1}
```

DCO sign-off present.