### PR TITLE
Add Anyscale AI Startup Program

### DIFF
--- a/vendors/an/anyscale.yaml
+++ b/vendors/an/anyscale.yaml
@@ -1,0 +1,60 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01m071sv8qttmp2d59fy6t1xmr
+slug: anyscale
+slug_aliases: []
+name: Anyscale
+domains:
+  - value: anyscale.com
+    role: primary
+    valid_from: 2026-08-17T05:06:12.226Z
+category: ai-ml
+description: Anyscale is an AI compute platform from the creators of Ray for developing, training, and deploying AI and machine learning applications at scale.
+links:
+  site: https://anyscale.com
+sources:
+  - source_id: src_f2be911a5fb2304b25c6cef8e306224ffa0690267ac365bc8f0ecc4b83545179
+    url: https://anyscale.com/startup
+programs: []
+offers:
+  - offer_id: off_01m071sv8qr7ktnqptsgfrvyf7
+    offer_slug: anyscale-ai-startup-program
+    offer_slug_aliases: []
+    title: Anyscale AI Startup Program
+    summary: Early-stage AI teams can access up to $20K in Anyscale credits that run on their own cloud and stack with existing cloud provider credits, plus dedicated field engineers and the Anyscale Runtime.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-17T05:06:12.226Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Access up to $20K in Anyscale credits, which run on the company's own cloud and stack with its existing cloud provider credits.
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 2000000
+            kind: up-to
+        - benefit_id: ben_02
+          description: Dedicated field engineers supporting application architecture design, with hands-on technical support.
+          kind: other
+        - benefit_id: ben_03
+          description: Access to the Anyscale Runtime, a Ray-compatible runtime for running workloads on the Anyscale Platform.
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: vendor-discretion
+        statement: Eligibility is generally open to companies at various stages, though level of funding, technical maturity, and current cloud infrastructure may be considered during review.
+    roles:
+      terms_authority_entity_id: ent_01m071sv8qttmp2d59fy6t1xmr
+      access_operator_entity_id: ent_01m071sv8qttmp2d59fy6t1xmr
+    access:
+      availability: public
+      method: form
+      url: https://anyscale.com/startup
+      instructions: Submit the application form on the program page. The Anyscale team follows up within 24-48 hours with a qualification form, and qualified companies move into onboarding to access the benefits.
+    source_ids:
+      - src_f2be911a5fb2304b25c6cef8e306224ffa0690267ac365bc8f0ecc4b83545179


### PR DESCRIPTION
Adds one new vendor (`anyscale`) with exactly one offer: the **Anyscale AI Startup Program**.

Data-only: one new file, `vendors/an/anyscale.yaml`.

## Offer

Up to $20K in Anyscale credits, which run on the company's own cloud and stack with its existing cloud provider credits, plus dedicated field engineers for architecture design and hands-on support, and access to the Ray-compatible Anyscale Runtime.

## First-party source

- <https://anyscale.com/startup> — Anyscale's own AI Startup Program page, carrying the three program benefits ("Access up to \0K in Anyscale credits", "Dedicated Field Engineers…", "Anyscale Runtime"), the application form, and the FAQ entries quoted below.

Anyscale is named as both `terms_authority_entity_id` and `access_operator_entity_id`, and the only cited source is on `anyscale.com`.

## Modelling notes

- Credit value uses `kind: up-to` ($20,000), matching the page's "up to \0K" wording rather than asserting a fixed grant.
- **Eligibility is deliberately modelled as a single `manual` / `vendor-discretion` criterion.** Anyscale's own FAQ states only that "Eligibility is generally open to companies at various stages, though factors such as level of funding, technical maturity, and current cloud infrastructure may be considered during the review." There is no published funding cap, company age, or headcount test, so none is invented here.
- Access instructions follow the published process: form submission, sales follow-up within 24-48 hours, a qualification form, then onboarding.
- `anyscale` is not currently in the catalog.
- Not a generic free tier, trial, or coupon: it is a startup-gated credit grant behind an application and review step.

## Verification

Pinned Sourcey Catalog Verifier (`sha256:848bb5d1d6cb6c173cc460d34ec088c8ba603080670a0eb417af3ad6c01cb0e4`) run locally against `upstream/main`:

```
{"status":"valid","vendors":1,"programs":0,"offers":1}
```

DCO sign-off present.