### PR TITLE
Add Lightdash for Startups

### DIFF
--- a/vendors/li/lightdash.yaml
+++ b/vendors/li/lightdash.yaml
@@ -1,0 +1,89 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01m072vm4nws1463n7kdyt0dd6
+slug: lightdash
+slug_aliases: []
+name: Lightdash
+domains:
+  - value: lightdash.com
+    role: primary
+    valid_from: 2026-08-17T05:24:39.038Z
+category: data-analytics
+description: Lightdash is an open-source business intelligence platform that turns a dbt project into a self-serve BI stack with a semantic layer for defining shared metrics.
+links:
+  site: https://lightdash.com
+sources:
+  - source_id: src_cf62c2ede5b77e77a0cd9e0a0158cbd26a4529132e3044c18e637868295558cb
+    url: https://lightdash.com/startups
+programs: []
+offers:
+  - offer_id: off_01m072vm4psfa3w3xrgp12rrhd
+    offer_slug: lightdash-for-startups
+    offer_slug_aliases: []
+    title: Lightdash for Startups
+    summary: Startups under five years old with less than $7.5M raised get 50% off Lightdash Cloud or Pro for 12 months, worth up to $18,000 in credits, plus onboarding calls and a dedicated support channel.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-17T05:24:39.038Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: 50% off Lightdash Cloud or Pro for 12 months.
+          kind: discount
+          duration:
+            kind: exact
+            value: P12M
+          percentage:
+            kind: exact
+            basis_points: 5000
+        - benefit_id: ben_02
+          description: Up to $18,000 in Lightdash credits.
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 1800000
+            kind: up-to
+        - benefit_id: ben_03
+          description: Personalized onboarding, with kickoff and training calls run by the Lightdash data team.
+          kind: other
+        - benefit_id: ben_04
+          description: The 50% discount can be extended by a further 6 months by referring other startups to the program.
+          kind: other
+        - benefit_id: ben_05
+          description: A dedicated support channel giving direct access to the product team, including feedback and beta features.
+          kind: other
+        - benefit_id: ben_06
+          description: Lightdash merchandise for the team.
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: The company is less than 5 years old.
+            value:
+              type: number
+              value: 60
+          - criterion_id: cri_02
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: The company has less than $7.5M in funding.
+            value:
+              type: number
+              value: 7500000
+    roles:
+      terms_authority_entity_id: ent_01m072vm4nws1463n7kdyt0dd6
+      access_operator_entity_id: ent_01m072vm4nws1463n7kdyt0dd6
+    access:
+      availability: public
+      method: form
+      url: https://lightdash.com/startups
+      instructions: Apply to the program from the Lightdash for Startups page, or contact the Lightdash team from the same page.
+    source_ids:
+      - src_cf62c2ede5b77e77a0cd9e0a0158cbd26a4529132e3044c18e637868295558cb


### PR DESCRIPTION
Adds one new vendor (`lightdash`) with exactly one offer: **Lightdash for Startups**.

Data-only: one new file, `vendors/li/lightdash.yaml`.

## Offer

50% off Lightdash Cloud or Pro for 12 months — stated as worth up to $18,000 in Lightdash credits — plus personalized onboarding with kickoff and training calls, a dedicated support channel with direct product-team access, a referral extension that adds a further 6 months of the discount, and team merchandise.

Published eligibility: the company must be **less than 5 years old** and have **less than $7.5M in funding**.

## First-party source

- <https://lightdash.com/startups> — Lightdash's own startup program page, carrying the headline ("50% off Lightdash Cloud for a year, plus hands-on expert support"), the two "To qualify, your company must" bullets, the "up to \8,000 in Lightdash credits" figure, and each listed benefit.

Lightdash is named as both `terms_authority_entity_id` and `access_operator_entity_id`, and the only cited source is on `lightdash.com`.

## Modelling notes

- The discount is modelled with `kind: discount` and `percentage.basis_points: 5000`, with `duration P12M` — matching "50% off … for 12 months".
- The $18,000 figure is modelled as a **separate `credit` benefit with `kind: up-to`**, because the page presents it as the ceiling value of the discount ("up to \8,000"), not a guaranteed grant.
- Both qualification bullets are machine-evaluable and are modelled as predicates: `company.age_months lt 60` and `company.funding_raised_usd lt 7500000`.
- The referral extension is recorded as a benefit rather than folded into the discount duration, since it is conditional on referring other startups.
- `lightdash` is not currently in the catalog.
- Not a generic free tier, trial, or coupon: it is a startup-gated discount with published eligibility thresholds and an application step.

## Verification

Pinned Sourcey Catalog Verifier (`sha256:848bb5d1d6cb6c173cc460d34ec088c8ba603080670a0eb417af3ad6c01cb0e4`) run locally against `upstream/main`:

```
{"status":"valid","vendors":1,"programs":0,"offers":1}
```

DCO sign-off present.