### PR TITLE
data: add Future AGI startup program

### DIFF
--- a/vendors/fu/future-agi.yaml
+++ b/vendors/fu/future-agi.yaml
@@ -1,0 +1,97 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01m0aacw3fj8w3atz3e4dfv50j
+slug: future-agi
+slug_aliases: []
+name: Future AGI
+domains:
+  - value: futureagi.com
+    role: primary
+    valid_from: 2026-08-18T11:40:00.000Z
+category: ai-ml
+description: Future AGI is an AI reliability platform for evaluating, protecting, optimizing, and monitoring applications built with language models and AI agents.
+links:
+  site: https://futureagi.com/
+sources:
+  - source_id: src_b57ca0a8fdfbe3610de49564f581253bbd6293c1e09b196421f160f5520312e7
+    url: https://futureagi.com/startups/
+programs:
+  - program_id: prg_01m0aacw3je986gf2t4pe9zykr
+    program_slug: future-agi-startup-program
+    program_slug_aliases: []
+    title: Future AGI Startup Program v2.0
+    summary: Future AGI's startup program provides eligible early-stage AI companies with $6,000 in platform credits, six months of Pro access, engineering support, and founder office hours.
+    source_ids:
+      - src_b57ca0a8fdfbe3610de49564f581253bbd6293c1e09b196421f160f5520312e7
+offers:
+  - offer_id: off_01m0aacw3jdgcx284wcxjxh2ek
+    program_id: prg_01m0aacw3je986gf2t4pe9zykr
+    offer_slug: six-thousand-dollars-future-agi-credits-and-six-months-pro
+    offer_slug_aliases: []
+    title: $6,000 in Future AGI credits and six months of Pro
+    summary: Eligible AI startups receive $6,000 in Future AGI platform credits for one year, six months of Pro access, private engineering Slack, and weekly founder office hours.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-18T11:40:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: $6,000 in Future AGI platform credits for one year
+          duration:
+            kind: exact
+            value: P1Y
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 600000
+            kind: exact
+        - benefit_id: ben_02
+          description: Future AGI Pro plan access at no cost for six months with every feature unlocked
+          duration:
+            kind: exact
+            value: P6M
+          kind: free-service
+          service: Future AGI Pro plan
+        - benefit_id: ben_03
+          description: Private engineering Slack access and weekly founder office hours
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: Company has raised less than $10,000,000 in total funding
+            value:
+              type: number
+              value: 10000000
+          - criterion_id: cri_02
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: Company is less than five years old
+            value:
+              type: number
+              value: 60
+          - criterion_id: cri_03
+            kind: manual
+            reason: not-machine-evaluable
+            statement: Company is building a product using language models or AI agents
+          - criterion_id: cri_04
+            kind: manual
+            reason: not-machine-evaluable
+            statement: Company has a live product or working prototype
+    roles:
+      terms_authority_entity_id: ent_01m0aacw3fj8w3atz3e4dfv50j
+      access_operator_entity_id: ent_01m0aacw3fj8w3atz3e4dfv50j
+    access:
+      availability: public
+      method: form
+      url: https://futureagi.com/startups/
+    terms_url: https://futureagi.com/startups/
+    source_ids:
+      - src_b57ca0a8fdfbe3610de49564f581253bbd6293c1e09b196421f160f5520312e7


### PR DESCRIPTION
## What changed

Adds Future AGI and its active Startup Program v2.0 as one data-only vendor record with exactly one offer. The offer captures $6,000 in platform credits for one year, six months of Pro access, private engineering Slack, weekly founder office hours, and the published eligibility criteria.

Resolves #634

## Sources

- https://futureagi.com/startups/

## Certification

- [x] I changed only allowed repository content and did not mix vendor YAML with other paths.
- [x] Public sources substantiate every submitted factual value; any Sourcey-written prose is a neutral summary, not a fabricated vendor quote.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commits include a `Signed-off-by` line.