### PR TITLE
Add OPM Technologies Startup Program

### DIFF
--- a/vendors/op/opm-technologies.yaml
+++ b/vendors/op/opm-technologies.yaml
@@ -44,6 +44,7 @@ offers:
         value: P1Y
       kind: discount
       percentage:
+        kind: exact
         basis_points: 5000
   eligibility:
     rule:

--- a/vendors/op/opm-technologies.yaml
+++ b/vendors/op/opm-technologies.yaml
@@ -1,0 +1,80 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01m0d7m9q5k503epmypf85zeak
+slug: opm-technologies
+slug_aliases: []
+name: OPM Technologies
+domains:
+- value: opmtechnologies.com
+  role: primary
+  valid_from: '2026-08-19T00:00:00.000Z'
+category: productivity
+description: OPM Technologies provides integrated software for project management, HR, learning, finance, and commerce operations.
+links:
+  site: https://opmtechnologies.com
+sources:
+- source_id: src_1dbce6775a9f59b288a1ab201a389cf38fa10684c0260d1896d1e2acfa75d530
+  url: https://opmtechnologies.com/startups
+programs:
+- program_id: prg_01m0d7m9q5j7p0v72qbwv10zhq
+  program_slug: opm-startup-program
+  program_slug_aliases: []
+  title: OPM Startup Program
+  summary: OPM's startup program offers stage-based discounts on eligible OPM products to approved early-stage companies.
+  source_ids:
+  - src_1dbce6775a9f59b288a1ab201a389cf38fa10684c0260d1896d1e2acfa75d530
+offers:
+- offer_id: off_01m0d7m9q5a16hp2eczxnw9qcb
+  program_id: prg_01m0d7m9q5j7p0v72qbwv10zhq
+  offer_slug: startup-recognition-fifty-percent-off
+  offer_slug_aliases: []
+  title: 50% off OPM for up to 12 months
+  summary: Officially recognized early-stage startups can receive 50% off eligible OPM products for up to 12 months.
+  lifecycle:
+    status: active
+    effective_from: '2026-08-19T00:00:00.000Z'
+  economics:
+    consideration:
+      kind: unknown
+      description: The startup pays the remaining discounted subscription price; the public program page does not publish a fixed post-discount price.
+    benefits:
+    - benefit_id: ben_01
+      description: Officially recognized early-stage startups can receive 50% off eligible OPM products for up to 12 months.
+      duration:
+        kind: up-to
+        value: P1Y
+      kind: discount
+      percentage:
+        basis_points: 5000
+  eligibility:
+    rule:
+      kind: all
+      rules:
+      - criterion_id: cri_01
+        kind: manual
+        reason: not-machine-evaluable
+        statement: Applicant is an officially recognized startup with government startup-recognition certification for the 50% Startup Recognition tier.
+      - criterion_id: cri_02
+        kind: manual
+        reason: not-machine-evaluable
+        statement: Applicant is an early-stage company at pre-Series A stage.
+      - criterion_id: cri_03
+        kind: manual
+        reason: not-machine-evaluable
+        statement: Applicant has a valid certificate of incorporation and an active product or business in the market.
+      - criterion_id: cri_04
+        kind: manual
+        reason: vendor-discretion
+        statement: Applicant's revenue and funding are below OPM Technologies' published program threshold.
+      - criterion_id: cri_05
+        kind: manual
+        reason: not-machine-evaluable
+        statement: The startup discount is not combined with another enterprise or promotional discount.
+  roles:
+    terms_authority_entity_id: ent_01m0d7m9q5k503epmypf85zeak
+    access_operator_entity_id: ent_01m0d7m9q5k503epmypf85zeak
+  access:
+    availability: public
+    method: form
+    url: https://opmtechnologies.com/startups
+  source_ids:
+  - src_1dbce6775a9f59b288a1ab201a389cf38fa10684c0260d1896d1e2acfa75d530


### PR DESCRIPTION
Adds exactly one new vendor YAML for OPM Technologies with one startup-specific offer, backed by the first-party source https://opmtechnologies.com/startups.

Reservation: https://github.com/sourcey/startup-credits/issues/644
Frantic bounty: #120

The branch is data-only and the digest-pinned Sourcey Candidate Verifier passes locally.
