### PR TITLE
data: add Confidence by Spotify startup credits

### DIFF
--- a/vendors/co/confidence-by-spotify.yaml
+++ b/vendors/co/confidence-by-spotify.yaml
@@ -1,0 +1,66 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01m0he4xhfszyksrmwk8dcncwh
+slug: confidence-by-spotify
+slug_aliases: []
+name: Confidence by Spotify
+domains:
+  - value: confidence.spotify.com
+    role: primary
+    valid_from: 2026-08-21T05:54:21.000Z
+category: data-analytics
+description: Confidence by Spotify provides warehouse-native experimentation, feature flagging, rollout controls, and analysis for product teams.
+links:
+  site: https://confidence.spotify.com/
+sources:
+  - source_id: src_c2182c35f4b830667faf0361860dddba119dad83348fb4c39768cfd3e073fad2
+    url: https://confidence.spotify.com/pricing
+programs:
+  - program_id: prg_01m0he4xhjth8w8tp8acbkdgsz
+    program_slug: confidence-for-startups
+    program_slug_aliases: []
+    title: Confidence for startups
+    summary: Confidence by Spotify's application-reviewed program provides product experimentation credits and expanded platform capabilities to early-stage startups.
+    source_ids:
+      - src_c2182c35f4b830667faf0361860dddba119dad83348fb4c39768cfd3e073fad2
+offers:
+  - offer_id: off_01m0he4xhjsnrnexpks2e99p31
+    program_id: prg_01m0he4xhjth8w8tp8acbkdgsz
+    offer_slug: up-to-75000-confidence-credits
+    offer_slug_aliases: []
+    title: Up to $75,000 in Confidence credits
+    summary: Approved early-stage startups can receive up to $75,000 in Confidence credits with Growth features, expanded controls, 12-month audit logs, and onboarding support.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-21T05:54:21.000Z
+    economics:
+      consideration:
+        kind: unknown
+        description: The public source does not state whether the startup credits require separate payment or other consideration.
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $75,000 in Confidence product credits
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 7500000
+            kind: up-to
+        - benefit_id: ben_02
+          description: Growth-plan capabilities plus role-based access control, 12-month audit logs, unlimited surfaces, and migration and onboarding support
+          kind: other
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: vendor-discretion
+        statement: Applicant must be an early-stage startup and receive approval from Confidence by Spotify.
+    roles:
+      terms_authority_entity_id: ent_01m0he4xhfszyksrmwk8dcncwh
+      access_operator_entity_id: ent_01m0he4xhfszyksrmwk8dcncwh
+    access:
+      availability: public
+      method: contact
+      url: https://confidence.spotify.com/pricing
+    terms_url: https://confidence.spotify.com/pricing
+    source_ids:
+      - src_c2182c35f4b830667faf0361860dddba119dad83348fb4c39768cfd3e073fad2


### PR DESCRIPTION
Closes #655

## What changed

Adds Confidence by Spotify as one new vendor with exactly one startup offer: up to $75,000 in product credits for approved early-stage startups. The record also captures the published Growth capabilities, expanded controls, audit-log retention, unlimited surfaces, support, public contact route, and vendor-discretion eligibility.

## Source

- https://confidence.spotify.com/pricing

## Validation

- Pinned Sourcey Catalog Verifier: `{"status":"valid","vendors":1,"programs":1,"offers":1}`
- Data-only change: exactly `vendors/co/confidence-by-spotify.yaml`
- DCO sign-off included

## Certification

- [x] I changed only allowed repository content and did not mix vendor YAML with other paths.
- [x] Public sources substantiate every submitted factual value; Sourcey-written prose is a neutral summary, not a fabricated vendor quote.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commit includes a `Signed-off-by` line.