### PR TITLE
data: add Yotta Rudra Launch Tier

### DIFF
--- a/vendors/yo/yotta-data-services.yaml
+++ b/vendors/yo/yotta-data-services.yaml
@@ -1,0 +1,95 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01m0jvkj72n2ek0pprqb9gwhaj
+slug: yotta-data-services
+slug_aliases:
+  - yotta
+name: Yotta Data Services
+domains:
+  - value: yotta.com
+    role: primary
+    valid_from: 2026-08-21T19:08:48.376Z
+category: hosting-infra
+description: Yotta Data Services provides sovereign cloud, AI compute, hyperscale data centers, cybersecurity, and managed infrastructure services.
+links:
+  site: https://yotta.com/
+sources:
+  - source_id: src_fbc682cb997a3ee52fa354b29aafda3416378971dade4c79334154c7238f984a
+    url: https://yotta.com/
+  - source_id: src_04552e70b2762d90cf7e47f94144c2662c4bebddbd0bd15070c2a7a122473767
+    url: https://yotta.com/rudra/
+  - source_id: src_46e5eec176b68ebb7da603968a3b7d3cbf44fb99461cb714856632236490b115
+    url: https://yotta.com/rudra/eligibility-criteria.html
+  - source_id: src_05232409a4051cad33bb605e3b2010d07b29e6d224ebb51534c2ef0b997cd462
+    url: https://yotta.com/rudra/program-structure.html
+programs:
+  - program_id: prg_01m0jvkj7a1jf2r1aegqg2b7bk
+    program_slug: rudra-startup-accelerator
+    program_slug_aliases: []
+    title: Rudra Startup Accelerator
+    summary: Rudra is Yotta's startup accelerator for companies building in AI, machine learning, data science, cloud, and high-performance computing.
+    source_ids:
+      - src_04552e70b2762d90cf7e47f94144c2662c4bebddbd0bd15070c2a7a122473767
+offers:
+  - offer_id: off_01m0jvkj7aaeeqamxn4ets6a76
+    program_id: prg_01m0jvkj7a1jf2r1aegqg2b7bk
+    offer_slug: rudra-launch-tier
+    offer_slug_aliases: []
+    title: Rudra Launch Tier
+    summary: Eligible startups admitted to Rudra's Launch stage can receive up to $10,000 in Yotta cloud credits, valid for six months from stage entry, with access to Shakti Cloud.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-21T19:08:48.376Z
+    economics:
+      consideration:
+        kind: none
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $10,000 in Yotta cloud credits for Rudra's Launch stage, valid for six months from stage entry and associated with Shakti Cloud access
+          duration:
+            kind: exact
+            value: P6M
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 1000000
+            kind: up-to
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: not-machine-evaluable
+            statement: Applicant works on innovative projects in AI, machine learning, data science, or high-performance computing and demonstrates commitment to scaling with Yotta technologies.
+          - criterion_id: cri_02
+            kind: manual
+            reason: external-verification
+            statement: Applicant has an active company website and existing LinkedIn profiles for both the applicant and startup company.
+          - criterion_id: cri_03
+            kind: manual
+            reason: external-verification
+            statement: Applicant is bootstrapped or funded at the Pre-Seed, Angel, Seed, Debt Financing, or Series A stage.
+          - criterion_id: cri_04
+            kind: manual
+            reason: external-verification
+            statement: Applicant has not previously received Yotta credits of an eligible or greater value under another program.
+          - criterion_id: cri_05
+            kind: manual
+            reason: external-verification
+            statement: The Launch stage is for a concept-stage product, a business under one year old, and annual revenue or funding under $50,000.
+          - criterion_id: cri_06
+            kind: manual
+            reason: vendor-discretion
+            statement: Yotta assigns the entry stage based on product maturity and other applicable criteria and may offer more credits or close the credit account.
+    roles:
+      terms_authority_entity_id: ent_01m0jvkj72n2ek0pprqb9gwhaj
+      access_operator_entity_id: ent_01m0jvkj72n2ek0pprqb9gwhaj
+    access:
+      availability: public
+      method: form
+      url: https://yotta.com/rudra/apply-now.html
+    source_ids:
+      - src_04552e70b2762d90cf7e47f94144c2662c4bebddbd0bd15070c2a7a122473767
+      - src_46e5eec176b68ebb7da603968a3b7d3cbf44fb99461cb714856632236490b115
+      - src_05232409a4051cad33bb605e3b2010d07b29e6d224ebb51534c2ef0b997cd462


### PR DESCRIPTION
Closes #669

## What changed

- Adds exactly one new file: `vendors/yo/yotta-data-services.yaml`.
- Models one vendor, one named Rudra program, and exactly one Offer: `Rudra Launch Tier`.
- Represents up to $10,000 in Yotta cloud credits for the Launch stage, valid for six months from stage entry, with Rudra access to Shakti Cloud.
- Keeps the pull request data-only and excludes every other Rudra stage.

The published eligibility requires relevant AI, machine learning, data science, or high-performance computing work; commitment to use Yotta technologies; an active company website and applicant/company LinkedIn profiles; bootstrapped or listed funding stages through Series A; no prior Yotta credits of an eligible-or-greater value; and the published Launch-stage maturity and financial criteria. Yotta assigns the entry stage under its published conditions.

## Sources

- https://yotta.com/
- https://yotta.com/rudra/
- https://yotta.com/rudra/eligibility-criteria.html
- https://yotta.com/rudra/program-structure.html

## Validation

- Pinned verifier digest: `848bb5d1d6cb6c173cc460d34ec088c8ba603080670a0eb417af3ad6c01cb0e4`
- Artifact checksum: `OK`
- Exact `validate-change` result: `{"status":"valid","vendors":1,"programs":1,"offers":1}`
- YAML parsing and structured one-offer assertions: passed
- Changed-identity closure: passed
- `git diff --check`: passed
- Changed-file count: exactly one new vendor YAML
- Commit DCO sign-off: confirmed for `FundzCMS <231497948+FundzCMS@users.noreply.github.com>`

AI-assisted research and preparation were performed by Codex under FundzCMS operator review.

This contribution is being prepared for Frantic bounty #120. It makes no payment or acceptance claim, and no Frantic claim or delivery has been submitted.

## Certification

- [x] I changed only allowed repository content and did not mix vendor YAML with other paths.
- [x] Public sources substantiate every submitted factual value; any Sourcey-written prose is a neutral summary, not a fabricated vendor quote.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commits include a `Signed-off-by` line.
