### PR TITLE
data: add SendPulse startup grant

### DIFF
--- a/vendors/se/sendpulse.yaml
+++ b/vendors/se/sendpulse.yaml
@@ -1,0 +1,75 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01m0k8z4dcnxdwvfkn087mymvq
+slug: sendpulse
+slug_aliases: []
+name: SendPulse
+domains:
+  - value: sendpulse.com
+    role: primary
+    valid_from: 2026-08-21T23:02:24.327Z
+category: marketing
+description: SendPulse is an all-in-one platform for marketing, sales automation, customer support, CRM, websites, online courses, and chatbots.
+links:
+  site: https://sendpulse.com
+sources:
+  - source_id: src_fe4a2b9b372bc2f166db757a587677cae27b406afcf444e46a8aaf4a3b760de8
+    url: https://sendpulse.com/startup
+programs: []
+offers:
+  - offer_id: off_01m0k8z4dfnamtff6c2rn56mpw
+    offer_slug: sendpulse-startup-grant
+    offer_slug_aliases: []
+    title: SendPulse Startup Grant
+    summary: Eligible startups receive $5,000 in SendPulse credits for 12 months, excluding email verification, SMS marketing, and WhatsApp or Viber campaigns.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-21T23:02:24.327Z
+    economics:
+      consideration:
+        kind: none
+      benefits:
+        - benefit_id: ben_01
+          description: $5,000 in SendPulse credits valid for one year, usable for SendPulse tools except email verification, SMS marketing, and WhatsApp or Viber campaigns.
+          duration:
+            kind: exact
+            value: P1Y
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 500000
+            kind: exact
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.age_months
+            kind: predicate
+            operator: lte
+            statement: The startup must have launched within the past three years.
+            value:
+              type: number
+              value: 36
+          - criterion_id: cri_02
+            kind: manual
+            reason: vendor-discretion
+            statement: The startup must offer an innovative product.
+          - criterion_id: cri_03
+            kind: manual
+            reason: not-machine-evaluable
+            statement: The applicant must not be an eCommerce project or online business.
+          - criterion_id: cri_04
+            kind: manual
+            reason: external-verification
+            statement: The applicant must have no history of using paid SendPulse pricing plans; prior free-plan use is allowed.
+    roles:
+      terms_authority_entity_id: ent_01m0k8z4dcnxdwvfkn087mymvq
+      access_operator_entity_id: ent_01m0k8z4dcnxdwvfkn087mymvq
+    access:
+      availability: public
+      method: form
+      url: https://sendpulse.com/startup
+    terms_url: https://sendpulse.com/startup
+    source_ids:
+      - src_fe4a2b9b372bc2f166db757a587677cae27b406afcf444e46a8aaf4a3b760de8


### PR DESCRIPTION
Closes #676

## What changed

Added SendPulse and its public Startup Grant to the catalog. The record covers the $5,000 credit amount, one-year duration, tool exclusions, all four published eligibility criteria, and the public application route.

The repository's pinned official validator reports `valid` with exactly 1 vendor, 0 programs, and 1 offer.

## Source

- https://sendpulse.com/startup

## Certification

- [x] I changed only allowed repository content and did not mix vendor YAML with other paths.
- [x] Public sources substantiate every submitted factual value; any Sourcey-written prose is a neutral summary, not a fabricated vendor quote.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commit includes a `Signed-off-by` line.
