### PR TITLE
data: add Influship Startup Program

### DIFF
--- a/vendors/in/influship.yaml
+++ b/vendors/in/influship.yaml
@@ -1,0 +1,65 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01m0kb3kncz7ev60zcqy3jr83b
+slug: influship
+slug_aliases: []
+name: Influship
+domains:
+  - value: influship.com
+    role: primary
+    valid_from: 2026-08-21T23:39:45.000Z
+category: marketing
+description: Influship provides creator intelligence, influencer discovery, creator data, datasets, and API access for marketing products and AI agents.
+links:
+  site: https://www.influship.com
+sources:
+  - source_id: src_6ea0f1cb945d33358692d415e9ecc80e11608c0385ecde9f16038cbd74fdc287
+    url: https://www.influship.com/startups
+programs:
+  - program_id: prg_01m0kb3kne8qgp0wtmq1wrrsec
+    program_slug: startup-program
+    program_slug_aliases: []
+    title: Influship Startup Program
+    summary: Influship's program gives approved startups project-sized API credit grants, technical onboarding, dedicated support, and early API access.
+    source_ids:
+      - src_6ea0f1cb945d33358692d415e9ecc80e11608c0385ecde9f16038cbd74fdc287
+offers:
+  - offer_id: off_01m0kb3knek4pamz80vf47663n
+    program_id: prg_01m0kb3kne8qgp0wtmq1wrrsec
+    offer_slug: api-credits-and-integration-support
+    offer_slug_aliases: []
+    title: API Credits and Integration Support
+    summary: Approved startups receive a project-sized grant of Influship API credits, 1:1 technical onboarding, dedicated support, and early API access.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-21T23:39:45.000Z
+    economics:
+      consideration:
+        kind: none
+      benefits:
+        - benefit_id: ben_01
+          description: A custom grant of free Influship API credits sized from the startup's use case and expected API usage during an introductory call
+          kind: other
+        - benefit_id: ben_02
+          description: Dedicated 1:1 technical onboarding for API integration planning
+          kind: other
+        - benefit_id: ben_03
+          description: Direct access to the Influship team through a dedicated support channel
+          kind: other
+        - benefit_id: ben_04
+          description: Early access to new API features and endpoints
+          kind: other
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_01
+        statement: Applicant must be an early-stage company building a product that uses influencer or creator data, plan to integrate the Influship API, and receive Influship approval.
+        reason: external-verification
+    roles:
+      terms_authority_entity_id: ent_01m0kb3kncz7ev60zcqy3jr83b
+      access_operator_entity_id: ent_01m0kb3kncz7ev60zcqy3jr83b
+    access:
+      availability: public
+      method: form
+      url: https://www.influship.com/startups
+    source_ids:
+      - src_6ea0f1cb945d33358692d415e9ecc80e11608c0385ecde9f16038cbd74fdc287


### PR DESCRIPTION
## What changed

Adds one new vendor record for Influship and its public Startup Program. The offer records the vendor’s project-sized API credit grant, technical onboarding, dedicated support, and early API access without inventing an unpublished monetary amount.

## Sources

https://www.influship.com/startups

## Certification

- [x] I changed only allowed repository content and did not mix vendor YAML with other paths.
- [x] Public sources substantiate every submitted factual value; any Sourcey-written prose is a neutral summary, not a fabricated vendor quote.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commits include a Signed-off-by line.

Closes #681