### PR TITLE
Add Futureproof Startup Program

### DIFF
--- a/vendors/fu/futureproof.yaml
+++ b/vendors/fu/futureproof.yaml
@@ -1,0 +1,58 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01m0m0vqnqkyft4agm601rvkzp
+slug: futureproof
+slug_aliases: []
+name: Futureproof
+domains:
+  - value: runfutureproof.com
+    role: primary
+    valid_from: 2026-08-22T06:00:40.935Z
+category: finance-accounting
+description: Futureproof provides an AI finance team covering bookkeeping, accounts receivable and payable, FP&A, revenue operations, and investor relations.
+links:
+  site: https://www.runfutureproof.com
+sources:
+  - source_id: src_a102f079cd093a3e8f438506d943ddb9f43a800decbed0adaf8dbfcd014ff5d1
+    url: https://www.runfutureproof.com/startup-program
+programs:
+  - program_id: prg_01m0m0vqnsw7ca42c5ndxjfxcj
+    program_slug: startup-program
+    program_slug_aliases: []
+    title: Futureproof Startup Program
+    summary: Eligible early-stage SaaS and ecommerce companies get Futureproof's six-agent finance team at startup pricing for up to 24 months.
+    source_ids:
+      - src_a102f079cd093a3e8f438506d943ddb9f43a800decbed0adaf8dbfcd014ff5d1
+offers:
+  - offer_id: off_01m0m0vqnsa7pbmh25w0bmxh7v
+    program_id: prg_01m0m0vqnsw7ca42c5ndxjfxcj
+    offer_slug: six-agent-finance-team-startup-pricing
+    offer_slug_aliases: []
+    title: Six-agent finance team at startup pricing for 24 months
+    summary: Eligible startups pay USD 200 per month in year one and USD 500 per month in year two for Futureproof's six-agent finance team.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-22T06:00:40.935Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Access to Futureproof's six-agent finance team at the Startup Program price for up to 24 months
+          kind: other
+      consideration:
+        kind: variable
+        description: Startup Program pricing is USD 200 per month in year one and USD 500 per month in year two; companies graduate earlier if revenue/GMV exceeds USD 200,000 or total funding exceeds USD 1 million.
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: external-verification
+        statement: Applicant must be a SaaS or ecommerce startup under USD 200,000 ARR or GMV and under USD 1 million total raised; application approval is required.
+    roles:
+      terms_authority_entity_id: ent_01m0m0vqnqkyft4agm601rvkzp
+      access_operator_entity_id: ent_01m0m0vqnqkyft4agm601rvkzp
+    access:
+      availability: public
+      method: form
+      url: https://www.runfutureproof.com/startup-program
+    source_ids:
+      - src_a102f079cd093a3e8f438506d943ddb9f43a800decbed0adaf8dbfcd014ff5d1
+


### PR DESCRIPTION
Closes #699

## Summary
- adds exactly one new vendor YAML and exactly one qualifying startup offer
- uses first-party vendor evidence only
- data-only contribution prepared for Frantic bounty #120

## Verification
- pinned Sourcey Catalog Verifier: `{"status":"valid","vendors":1,"programs":1,"offers":1}`
- DCO sign-off included
- one new vendor file only

First-party source: https://www.runfutureproof.com/startup-program