### PR TITLE
Add Unkey Startups Program

### DIFF
--- a/vendors/un/unkey.yaml
+++ b/vendors/un/unkey.yaml
@@ -39,7 +39,7 @@ offers:
     - benefit_id: ben_01
       description: $1,000 in monthly Unkey credits for one year ($12,000 total).
       duration:
-        kind: fixed
+        kind: exact
         value: P1Y
       kind: credit
       value:

--- a/vendors/un/unkey.yaml
+++ b/vendors/un/unkey.yaml
@@ -7,7 +7,7 @@ domains:
 - value: unkey.com
   role: primary
   valid_from: '2026-08-23T00:00:00.000Z'
-category: developer-tools
+category: apis-integration
 description: Unkey provides API infrastructure for developers, including API key management, rate limiting, and usage analytics.
 links:
   site: https://unkey.com

--- a/vendors/un/unkey.yaml
+++ b/vendors/un/unkey.yaml
@@ -47,12 +47,9 @@ offers:
           currency: USD
           minor_units: 100000
         kind: exact
-        recurrence: monthly
     - benefit_id: ben_02
       description: Priority support, concierge onboarding, and hands-on migration help.
       kind: other
-      value:
-        kind: non-monetary
     - benefit_id: ben_03
       description: Startups that have raised over $5 million receive 50% off their Unkey bill instead of credits.
       kind: discount

--- a/vendors/un/unkey.yaml
+++ b/vendors/un/unkey.yaml
@@ -1,0 +1,82 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01m0q32rp4hqsc15yk0q6eknn3
+slug: unkey
+slug_aliases: []
+name: Unkey
+domains:
+- value: unkey.com
+  role: primary
+  valid_from: '2026-08-23T00:00:00.000Z'
+category: developer-tools
+description: Unkey provides API infrastructure for developers, including API key management, rate limiting, and usage analytics.
+links:
+  site: https://unkey.com
+sources:
+- source_id: src_d430d0515fbdcbe4b4d192b77507b6ea597740055adf6523e46983fced6d1121
+  url: https://www.unkey.com/startups
+programs:
+- program_id: prg_01m0q32rp49t90948xd2nf4wj2
+  program_slug: unkey-startups-program
+  program_slug_aliases: []
+  title: Unkey Startups Program
+  summary: Unkey's Startups Program gives eligible startups $1,000 in monthly credits for a year, plus priority support, concierge onboarding, and migration help; startups that have raised over $5 million instead receive 50% off their bill.
+  source_ids:
+  - src_d430d0515fbdcbe4b4d192b77507b6ea597740055adf6523e46983fced6d1121
+offers:
+- offer_id: off_01m0q32rp40kjm43e76g28qbzj
+  program_id: prg_01m0q32rp49t90948xd2nf4wj2
+  offer_slug: thousand-monthly-credits-for-a-year
+  offer_slug_aliases: []
+  title: $1,000 in credits every month for a year
+  summary: Eligible startups receive $1,000 in Unkey credits every month for a year along with priority support and hands-on migration help; companies that no longer qualify (raised more than $5 million) get 50% off their bill.
+  lifecycle:
+    status: active
+    effective_from: '2026-08-23T00:00:00.000Z'
+  economics:
+    consideration:
+      kind: none
+    benefits:
+    - benefit_id: ben_01
+      description: $1,000 in monthly Unkey credits for one year ($12,000 total).
+      duration:
+        kind: fixed
+        value: P1Y
+      kind: credit
+      value:
+        amount:
+          currency: USD
+          minor_units: 100000
+        kind: exact
+        recurrence: monthly
+    - benefit_id: ben_02
+      description: Priority support, concierge onboarding, and hands-on migration help.
+      kind: other
+      value:
+        kind: non-monetary
+    - benefit_id: ben_03
+      description: Startups that have raised over $5 million receive 50% off their Unkey bill instead of credits.
+      kind: discount
+      percentage:
+        kind: exact
+        basis_points: 5000
+  eligibility:
+    rule:
+      kind: any
+      rules:
+      - criterion_id: cri_01
+        kind: manual
+        reason: not-machine-evaluable
+        statement: Applicant is an early-stage startup that has not raised more than $5 million; it receives $1,000 in monthly credits for a year.
+      - criterion_id: cri_02
+        kind: manual
+        reason: not-machine-evaluable
+        statement: Companies that have raised more than $5 million are not eligible for credits but receive 50% off their bill under the same program page terms.
+  roles:
+    terms_authority_entity_id: ent_01m0q32rp4hqsc15yk0q6eknn3
+    access_operator_entity_id: ent_01m0q32rp4hqsc15yk0q6eknn3
+  access:
+    availability: public
+    method: form
+    url: https://www.unkey.com/startups
+  source_ids:
+  - src_d430d0515fbdcbe4b4d192b77507b6ea597740055adf6523e46983fced6d1121


### PR DESCRIPTION
## Vendor: Unkey

**Program:** [Unkey Startups Program](https://www.unkey.com/startups)

- $1,000 in monthly credits for one year for eligible startups (not raised >$5M), plus priority support, concierge onboarding, and migration help
- Companies that have raised over $5M get 50% off their bill under the same program

**Source:** https://www.unkey.com/startups (first-party program page, live 2026-08-23)

Single data file: `vendors/un/unkey.yaml`. Signed-off-by: t460dream <t460dream@proton.me> (DCO).