### PR TITLE
data: add GameAnalytics startup program

### DIFF
--- a/entities/ga/gameanalytics.yaml
+++ b/entities/ga/gameanalytics.yaml
@@ -1,16 +1,18 @@
-schema_version: sourcey.vendor-authoring/v1alpha1
-entity_id: ent_01m0qq36a8m8hb043cmd5s8a60
-slug: gameanalytics
-slug_aliases: []
-name: GameAnalytics
-domains:
-  - value: gameanalytics.com
-    role: primary
-    valid_from: 2026-08-23T16:26:09.096Z
-category: data-analytics
-description: GameAnalytics provides analytics, data management, and market intelligence tools for game developers, studios, and publishers.
-links:
-  site: https://www.gameanalytics.com
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m0qq36a8m8hb043cmd5s8a60
+  slug: gameanalytics
+  slug_aliases: []
+  name: GameAnalytics
+  domains:
+    - value: gameanalytics.com
+      role: primary
+      valid_from: 2026-08-23T16:26:09.096Z
+  category: data-analytics
+profile:
+  description: GameAnalytics provides analytics, data management, and market intelligence tools for game developers, studios, and publishers.
+  links:
+    site: https://www.gameanalytics.com
 sources:
   - source_id: src_adb002ea8df618c73ece6833d5750f4a090afc8ad37ad6b1e8d876b0bb799a27
     url: https://www.gameanalytics.com/pricing/startup
@@ -67,5 +69,6 @@ offers:
       availability: public
       method: form
       url: https://www.gameanalytics.com/pricing/startup
+    terms_url: https://www.gameanalytics.com/pricing/startup
     source_ids:
       - src_adb002ea8df618c73ece6833d5750f4a090afc8ad37ad6b1e8d876b0bb799a27

--- a/vendors/ga/gameanalytics.yaml
+++ b/vendors/ga/gameanalytics.yaml
@@ -1,0 +1,71 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01m0qq36a8m8hb043cmd5s8a60
+slug: gameanalytics
+slug_aliases: []
+name: GameAnalytics
+domains:
+  - value: gameanalytics.com
+    role: primary
+    valid_from: 2026-08-23T16:26:09.096Z
+category: data-analytics
+description: GameAnalytics provides analytics, data management, and market intelligence tools for game developers, studios, and publishers.
+links:
+  site: https://www.gameanalytics.com
+sources:
+  - source_id: src_adb002ea8df618c73ece6833d5750f4a090afc8ad37ad6b1e8d876b0bb799a27
+    url: https://www.gameanalytics.com/pricing/startup
+programs:
+  - program_id: prg_01m0qq36a8cf29bhdws25ee1z5
+    program_slug: startup-program
+    program_slug_aliases: []
+    title: GameAnalytics Startup Program
+    summary: GameAnalytics supports qualifying VC-backed game studios with product credits, discounted market intelligence, onboarding, and direct support.
+    source_ids:
+      - src_adb002ea8df618c73ece6833d5750f4a090afc8ad37ad6b1e8d876b0bb799a27
+offers:
+  - offer_id: off_01m0qq36a86phhdax51z5x46sc
+    program_id: prg_01m0qq36a8cf29bhdws25ee1z5
+    offer_slug: startup-program
+    offer_slug_aliases: []
+    title: GameAnalytics Startup Program
+    summary: Qualifying studios receive $6,000 in Analytics and Data Management credits, 50% off annual MarketIQ Pro, premium onboarding, and direct Slack support.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-23T16:26:09.096Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: $6,000 in Analytics and Data Management credits, issued as $500 per month for 12 months
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 600000
+            kind: exact
+        - benefit_id: ben_02
+          description: 50% off an annual MarketIQ Pro subscription
+          kind: discount
+          percentage:
+            kind: exact
+            basis_points: 5000
+        - benefit_id: ben_03
+          description: Premium onboarding and a dedicated Slack support channel
+          kind: other
+      consideration:
+        kind: unknown
+        description: The source does not establish a separate price to join the startup program.
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_01
+        statement: The studio must be backed by a GameAnalytics partner VC, be pre-Series B, have a GameAnalytics account, and have integrated the SDK.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m0qq36a8m8hb043cmd5s8a60
+      access_operator_entity_id: ent_01m0qq36a8m8hb043cmd5s8a60
+    access:
+      availability: public
+      method: form
+      url: https://www.gameanalytics.com/pricing/startup
+    source_ids:
+      - src_adb002ea8df618c73ece6833d5750f4a090afc8ad37ad6b1e8d876b0bb799a27


### PR DESCRIPTION
Closes #741

## What changed

- Added a new GameAnalytics vendor record.
- Recorded the current startup offer: $6,000 in Analytics and Data Management credits, 50% off annual MarketIQ Pro, premium onboarding, and direct Slack support.
- Captured the published eligibility requirements for VC backing, funding stage, account signup, and SDK integration.

## Sources

- https://www.gameanalytics.com/pricing/startup

## Validation

- Ran the repository's exact digest-pinned Sourcey Catalog Verifier against this change.
- Result: `{"status":"valid","vendors":1,"programs":1,"offers":1}`

## AI disclosure

AI assisted with source discovery and drafting. The submitted facts were reviewed against the cited first-party page before submission.

## Certification

- [x] I changed only allowed repository content and did not mix vendor YAML with other paths.
- [x] Public sources substantiate every submitted factual value; any Sourcey-written prose is a neutral summary, not a fabricated vendor quote.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commits include a `Signed-off-by` line.
