### PR TITLE
data: add Twelve Data startup program

### DIFF
--- a/vendors/tw/twelve-data.yaml
+++ b/vendors/tw/twelve-data.yaml
@@ -1,0 +1,82 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01m0rnkvjn7vw28w374qf437yd
+slug: twelve-data
+slug_aliases: []
+name: Twelve Data
+domains:
+  - value: twelvedata.com
+    role: primary
+    valid_from: 2026-08-24T01:22:00.000Z
+category: data-analytics
+description: Financial market data API delivering real-time and historical stock, forex, ETF, and cryptocurrency data through REST, WebSocket, and spreadsheet integrations.
+links:
+  site: https://twelvedata.com
+sources:
+  - source_id: src_b69d1b7920b1b07f4c6744436545b94422ab6634fdcbaca0886b8f005babce01
+    url: https://twelvedata.com/startups
+programs:
+  - program_id: prg_01m0rnkvjs7m7a1z78tj4pmbra
+    program_slug: twelve-data-for-startups
+    program_slug_aliases: []
+    title: Twelve Data for Startups
+    summary: Startup program from Twelve Data offering API plans designed and priced for early-stage company budgets across its financial market data platform.
+    source_ids:
+      - src_b69d1b7920b1b07f4c6744436545b94422ab6634fdcbaca0886b8f005babce01
+offers:
+  - offer_id: off_01m0rnkvjsbm5cafrgz8cc97dz
+    offer_slug: twelve-data-for-startups-plan
+    offer_slug_aliases: []
+    title: Twelve Data for Startups — Startup-Suited Plan Pricing
+    summary: Early-stage companies with up to $1 million raised, under two years old, and ten or fewer employees get robust API access on a plan priced for startup budgets.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-24T01:22:00.000Z
+    economics:
+      consideration:
+        kind: unknown
+        description: Specific plan pricing is determined upon application; the program page publishes no percentage or dollar figure.
+      benefits:
+        - benefit_id: ben_primary_plan
+          description: Access robust APIs with a plan of your choice, at a price that fits a startup budget.
+          kind: other
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lte
+            statement: Up to $1 million USD in funding.
+            value:
+              type: number
+              value: 1000000
+          - criterion_id: cri_02
+            fact: company.age_years
+            kind: predicate
+            operator: lt
+            statement: Less than two years old.
+            value:
+              type: number
+              value: 2
+          - criterion_id: cri_03
+            kind: manual
+            reason: not-machine-evaluable
+            statement: Single legal entity using the data for the same use as the domain.
+          - criterion_id: cri_04
+            fact: company.employee_count
+            kind: predicate
+            operator: lte
+            statement: Small team of ten employees or less.
+            value:
+              type: number
+              value: 10
+    roles:
+      terms_authority_entity_id: ent_01m0rnkvjn7vw28w374qf437yd
+      access_operator_entity_id: ent_01m0rnkvjn7vw28w374qf437yd
+    access:
+      availability: public
+      method: form
+      url: https://twelvedata.com/account/perks/2
+    source_ids:
+      - src_b69d1b7920b1b07f4c6744436545b94422ab6634fdcbaca0886b8f005babce01


### PR DESCRIPTION
## Summary

Adds one new vendor, **Twelve Data** (`vendors/tw/twelve-data.yaml`), with the vendor-run **Twelve Data for Startups** program: API plans designed and priced for early-stage company budgets on its financial market data platform.

Reservation issue: #743

## Facts and sourcing

All facts are taken from the single first-party source cited in the record:

- https://twelvedata.com/startups (verified live today)

Published facts captured in structured fields:

- Benefit: "Access robust APIs with a plan of your choice, at a price that fits your budget" ("Designed and priced for startups") → `kind: other` benefit; no percentage or dollar figure is published, so consideration stays `unknown`
- Eligibility, from the page's three stated requirements:
  - "Early stage: Up to $1M in funding and less than 2 years old" → `company.funding_raised_usd` lte 1,000,000 and `company.age_years` lt 2 (machine-evaluable predicates)
  - "Single structure: Legal entity and same use as domain" → manual rule (`not-machine-evaluable`)
  - "Small team: 10 employees or less" → `company.employee_count` lte 10
- Access: public application through the vendor's own perks form, linked as "Apply now" from the program page → https://twelvedata.com/account/perks/2

No amounts beyond what the page states. No dollar figure was invented for the plan pricing.

## Checklist

- [x] Data-only PR: exactly one new vendor YAML under `vendors/{shard}/` (shard `tw` from slug `twelve-data`)
- [x] Fresh ULIDs generated per CONTRIBUTING (`ent_`, `prg_`, `off_`, opaque `src_`)
- [x] Category from the pinned verifier taxonomy: `data-analytics`
- [x] Local preflight run with the digest-pinned Catalog Verifier: `{"status":"valid","vendors":1,"programs":1,"offers":1}`
- [x] DCO sign-off present on the commit
- [x] Vendor not present in catalog; searched open issues/PRs before starting (reservation #743)
