### PR TITLE
data: add Hume AI startup program

### DIFF
--- a/vendors/hu/hume-ai.yaml
+++ b/vendors/hu/hume-ai.yaml
@@ -1,0 +1,62 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01m0rnkwmsz6thjdqccwy2q7ym
+slug: hume-ai
+slug_aliases: []
+name: Hume AI
+domains:
+  - value: hume.ai
+    role: primary
+    valid_from: 2026-08-24T01:22:00.000Z
+category: ai-ml
+description: Research-driven AI company building empathic voice and expression models, offering APIs for conversational and emotional understanding in applications.
+links:
+  site: https://www.hume.ai
+sources:
+  - source_id: src_990f39301995ddcd61150dd48b647cb0e49a618bf50eda5a111f293c66192422
+    url: https://www.hume.ai/startup-program
+programs:
+  - program_id: prg_01m0rnkwmx0xcphhefqbgbq4pr
+    program_slug: hume-ai-startup-program
+    program_slug_aliases: []
+    title: Hume AI Startup Program
+    summary: Vendor-run program giving early-stage startups discounted API access, dedicated support and technical guidance, and resources for building with empathic AI.
+    source_ids:
+      - src_990f39301995ddcd61150dd48b647cb0e49a618bf50eda5a111f293c66192422
+offers:
+  - offer_id: off_01m0rnkwmx84hhdysj5nxn0q7h
+    offer_slug: hume-ai-startup-program-access
+    offer_slug_aliases: []
+    title: Hume AI Startup Program — Discounted API Access and Support
+    summary: Early-stage startups receive discounted API access to empathic AI models plus dedicated support, technical guidance, and build resources.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-24T01:22:00.000Z
+    economics:
+      consideration:
+        kind: unknown
+        description: The program page does not publish separate consideration terms; specific discounting is determined through contact with the vendor.
+      benefits:
+        - benefit_id: ben_discounted_api_access
+          description: Discounted API access for early-stage startups.
+          kind: other
+        - benefit_id: ben_support_guidance
+          description: Dedicated support and technical guidance.
+          kind: other
+        - benefit_id: ben_build_resources
+          description: Resources to help build with empathic AI.
+          kind: other
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_01
+        reason: vendor-discretion
+        statement: Must be an early-stage startup, subject to vendor evaluation.
+    roles:
+      terms_authority_entity_id: ent_01m0rnkwmsz6thjdqccwy2q7ym
+      access_operator_entity_id: ent_01m0rnkwmsz6thjdqccwy2q7ym
+    access:
+      availability: public
+      method: contact
+      url: https://www.hume.ai/startup-program
+    source_ids:
+      - src_990f39301995ddcd61150dd48b647cb0e49a618bf50eda5a111f293c66192422


### PR DESCRIPTION
## Summary

Adds one new vendor, **Hume AI** (`vendors/hu/hume-ai.yaml`), with the vendor-run **Hume AI Startup Program**: discounted API access for early-stage startups, plus dedicated support, technical guidance, and build resources.

Reservation issue: #744

## Facts and sourcing

All facts are taken from the single first-party source cited in the record:

- https://www.hume.ai/startup-program (verified live today)

Published facts captured in structured fields:

- Benefits (as published on the program page):
  - "Discounted API access for early-stage startups" → modeled as `kind: other`; the page publishes no percentage or dollar figure
  - "Dedicated support and technical guidance"
  - "Resources to help you build with empathic AI"
- Consideration: `unknown` — the page does not publish separate consideration terms; specific discounting is determined through contact with the vendor
- Eligibility: "early-stage startups" → manual rule (`vendor-discretion`), as the page publishes no machine-evaluable thresholds
- Access: public program page; the page's action channel is vendor contact ("Contact support" → `/contact`) → `method: contact`

No amounts were invented. The record states only what that page states.

## Checklist

- [x] Data-only PR: exactly one new vendor YAML under `vendors/{shard}/` (shard `hu` from slug `hume-ai`)
- [x] Fresh ULIDs generated per CONTRIBUTING (`ent_`, `prg_`, `off_`, opaque `src_`)
- [x] Category from the pinned verifier taxonomy: `ai-ml`
- [x] Local preflight run with the digest-pinned Catalog Verifier: `{"status":"valid","vendors":1,"programs":1,"offers":1}`
- [x] DCO sign-off present on the commit
- [x] Vendor not present in catalog; searched open issues/PRs before starting (reservation #744)
