### PR TITLE
data: add Strix startup program

### DIFF
--- a/vendors/st/strix.yaml
+++ b/vendors/st/strix.yaml
@@ -1,0 +1,54 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01m0t1szzc12kzxa0jgwg7mbqm
+slug: strix
+slug_aliases: []
+name: Strix
+domains:
+  - value: strix.ai
+    role: primary
+    valid_from: 2026-08-24T13:45:00.000Z
+category: auth-security
+description: Autonomous AI penetration testing platform for continuous security reviews, vulnerability discovery, and auto-fix across applications and infrastructure.
+links:
+  site: https://www.strix.ai
+sources:
+  - source_id: src_d65c96b7bcdc5f40c3522776df7bcd0d76461e74bebc73e4d4b01cc7384267b2
+    url: https://www.strix.ai/startups
+programs: []
+offers:
+  - offer_id: off_01m0t1szzgb2jemhjc1phe6jeh
+    offer_slug: 50-off-pro-for-6-months
+    offer_slug_aliases: []
+    title: 50% off Pro for 6 months
+    summary: Eligible early-stage startups get 50% off the Strix Pro plan for 6 months. Applications (pre-seed to Series A, work email required) are reviewed manually.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-24T13:45:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: 50% discount on the Strix Pro plan for 6 months
+          duration:
+            kind: exact
+            value: P6M
+          kind: discount
+          percentage:
+            basis_points: 5000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Eligible startups are pre-seed to Series A; a work email is required and each application is manually reviewed by OmniSecure, Inc.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m0t1szzc12kzxa0jgwg7mbqm
+      access_operator_entity_id: ent_01m0t1szzc12kzxa0jgwg7mbqm
+    access:
+      availability: public
+      method: form
+      url: https://www.strix.ai/startups
+    source_ids:
+      - src_d65c96b7bcdc5f40c3522776df7bcd0d76461e74bebc73e4d4b01cc7384267b2


### PR DESCRIPTION
## Summary

Data-only PR adding the **Strix** vendor record (`vendors/st/strix.yaml`) with its startup program, resolving #770. Reservation: #773.

## Facts and sourcing

All facts verified live against the first-party page `https://www.strix.ai/startups` (HTTP 200 at capture time):

| Fact | Source on page | Field |
|---|---|---|
| Vendor is Strix (OmniSecure, Inc.), autonomous AI pentesting platform | Page header/footer ("© 2026 Strix", "OmniSecure, Inc."), Features sections | `name`, `description`, `links.site` |
| 50% off Pro for 6 months for eligible early-stage startups | "Startup program Strix for Startups — 50% off Pro for 6 months for eligible early-stage startups" | offer title/summary; `economics.benefits[0]` (discount, basis_points 5000 exact, duration P6M) |
| Eligibility: pre-seed to Series A, work email required, manual review | "Eligible startups are pre-seed to Series A, we require a work email, and each application is manually reviewed" | `eligibility.rule` (manual / not-machine-evaluable) |
| Application via on-page form | "Apply for Startup pricing" form fields (company name, work email, website, funding stage, amount raised, team size) | `access.method: form`, `access.url` |

Not captured (not stated on the source page): standalone monetary value of the Pro plan; no separate consideration requirement is established.

## Checklist

- [x] Data-only change: one new vendor file, no code
- [x] Fresh ULID-style IDs generated per CONTRIBUTING (`ent_01m0t1szz…`, `prg_…` unused, `off_01m0t1szz…`, `src_d65c96b7…`)
- [x] Category from canonical taxonomy: `auth-security`
- [x] Local preflight passes: `{"status":"valid","vendors":1,"programs":0,"offers":1}`
- [x] DCO signed
- [x] Reservation issue opened (#773)
