### PR TITLE
data: add Rhetorik startup credits

### DIFF
--- a/vendors/rh/rhetorik.yaml
+++ b/vendors/rh/rhetorik.yaml
@@ -1,0 +1,64 @@
+schema_version: sourcey.vendor-authoring/v1alpha1
+entity_id: ent_01m0rf6y4ya673nzvqdtc97w9e
+slug: rhetorik
+slug_aliases: []
+name: Rhetorik
+domains:
+  - value: rhetorik.com
+    role: primary
+    valid_from: 2026-08-23T23:27:37.630Z
+category: crm-sales
+description: Rhetorik provides B2B company and people data, technographics, contact information, datasets, and APIs for data-driven applications.
+links:
+  site: https://rhetorik.com
+sources:
+  - source_id: src_65dac65247ca0b63f8d72f4cade2be5f56085f039740e183270d8282d966c6b8
+    url: https://rhetorik.com/lp-startups/
+programs:
+  - program_id: prg_01m0rf6y4yksyefkqjys9nbpqx
+    program_slug: data-for-startups
+    program_slug_aliases: []
+    title: Rhetorik Data for Startups
+    summary: Rhetorik supports early-stage companies building data-driven applications with API data credits and discounted access as they launch and scale.
+    source_ids:
+      - src_65dac65247ca0b63f8d72f4cade2be5f56085f039740e183270d8282d966c6b8
+offers:
+  - offer_id: off_01m0rf6y4yw204prxj2edfyv7d
+    program_id: prg_01m0rf6y4yksyefkqjys9nbpqx
+    offer_slug: data-for-startups
+    offer_slug_aliases: []
+    title: Rhetorik Data for Startups
+    summary: Early-stage companies can receive $10,000 in free API data credits for proof-of-concept or MVP development, followed by discounted access at later stages.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-23T23:27:37.630Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: $10,000 in free API data credits for proof-of-concept or MVP development
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 1000000
+            kind: exact
+        - benefit_id: ben_02
+          description: Heavily discounted access at launch and extended discounted access while scaling
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_01
+        statement: The program is intended for early-stage companies building data-driven applications.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m0rf6y4ya673nzvqdtc97w9e
+      access_operator_entity_id: ent_01m0rf6y4ya673nzvqdtc97w9e
+    access:
+      availability: public
+      method: form
+      url: https://rhetorik.com/lp-startups/
+    source_ids:
+      - src_65dac65247ca0b63f8d72f4cade2be5f56085f039740e183270d8282d966c6b8


### PR DESCRIPTION
Closes #775

## What changed

- Added a new Rhetorik vendor record.
- Recorded the current Data for Startups offer: $10,000 in free API data credits for proof-of-concept or MVP development, followed by discounted access at launch and growth stages.
- Captured the published startup eligibility and public application route.

## Source

- https://rhetorik.com/lp-startups/

## Validation

- Ran the repository's exact digest-pinned Sourcey Catalog Verifier against this change.
- Result: `{"status":"valid","vendors":1,"programs":1,"offers":1}`

## AI disclosure

AI assisted with source discovery and drafting. The submitted facts were reviewed against the cited first-party page before submission.

## Certification

- [x] I changed only allowed repository content and did not mix vendor YAML with other paths.
- [x] Public sources substantiate every submitted factual value; any Sourcey-written prose is a neutral summary, not a fabricated vendor quote.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commit includes a `Signed-off-by` line.