### PR TITLE
data: add CallMissed startup credits

### DIFF
--- a/entities/ca/callmissed.yaml
+++ b/entities/ca/callmissed.yaml
@@ -58,7 +58,7 @@ offers:
     access:
       availability: public
       method: contact
-      instructions: Create a free CallMissed account, then email karan@callmissed.com with subject "Startup Credits Application" and the company, founder, product, stage, intended use, expected usage, and any available demo or affiliation details.
+      instructions: Create a free CallMissed account, then use the contact channel and subject published on the program page and provide the requested company, founder, product, stage, use, expected usage, and any available demo or affiliation details.
       url: https://www.callmissed.com/solutions/startups
     source_ids:
       - src_a4630791e3ace0347b104db469b076c132d701a10584c4dc3afcc007cb2a3911

--- a/entities/ca/callmissed.yaml
+++ b/entities/ca/callmissed.yaml
@@ -1,0 +1,64 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m0x9dbv7sh27d9c7kw5228q9
+  slug: callmissed
+  slug_aliases: []
+  name: CallMissed
+  domains:
+    - value: callmissed.com
+      role: primary
+      valid_from: 2026-08-25T00:00:00.000Z
+  category: communication
+profile:
+  description: CallMissed provides AI communication infrastructure for WhatsApp, voice, transcription, speech synthesis, language models, images, email, and embeddings.
+  links:
+    site: https://www.callmissed.com
+sources:
+  - source_id: src_a4630791e3ace0347b104db469b076c132d701a10584c4dc3afcc007cb2a3911
+    url: https://www.callmissed.com/solutions/startups
+programs:
+  - program_id: prg_01m0x9dbv791m7qx9b6c9h4pys
+    program_slug: startup-credits-program
+    program_slug_aliases: []
+    title: CallMissed Startup Credits Program
+    summary: CallMissed gives qualifying early-stage startups additional API credits for building WhatsApp agents, voice pilots, speech workflows, and language-model applications.
+    source_ids:
+      - src_a4630791e3ace0347b104db469b076c132d701a10584c4dc3afcc007cb2a3911
+offers:
+  - offer_id: off_01m0x9dbv70n7dcgdn41jm5tfq
+    program_id: prg_01m0x9dbv791m7qx9b6c9h4pys
+    offer_slug: 1000-usd-api-credits
+    offer_slug_aliases: []
+    title: $1,000 in CallMissed API credits
+    summary: Approved startups receive $1,000 in additional API credits, equal to 100,000 CallMissed credits, loaded to their account on top of the free signup bundle.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-25T00:00:00.000Z
+    economics:
+      consideration:
+        kind: none
+      benefits:
+        - benefit_id: ben_01
+          description: $1,000 in additional API credits, equal to 100,000 CallMissed credits at $0.01 each
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 100000
+            kind: exact
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: vendor-discretion
+        statement: Applicant is a qualifying early-stage startup building on CallMissed and is approved after CallMissed reviews its company, founders, product stage, intended platform use, expected usage, and available demo or affiliation details.
+    roles:
+      terms_authority_entity_id: ent_01m0x9dbv7sh27d9c7kw5228q9
+      access_operator_entity_id: ent_01m0x9dbv7sh27d9c7kw5228q9
+    access:
+      availability: public
+      method: contact
+      instructions: Create a free CallMissed account, then email karan@callmissed.com with subject "Startup Credits Application" and the company, founder, product, stage, intended use, expected usage, and any available demo or affiliation details.
+      url: https://www.callmissed.com/solutions/startups
+    source_ids:
+      - src_a4630791e3ace0347b104db469b076c132d701a10584c4dc3afcc007cb2a3911


### PR DESCRIPTION
Adds CallMissed and its public startup-only API credit program. The first-party source publishes an exact USD 1,000 grant (100,000 platform credits), application instructions, the requested review information, five-business-day review timing, account loading after approval, and no equity consideration.

Official source: https://www.callmissed.com/solutions/startups

Closes #785.

Automation disclosure: this contribution was prepared with Codex automation; the source and encoded claims were checked against the current Entity schema before submission.