### PR TITLE
data: add Supabase startup program and credits

### DIFF
--- a/entities/su/supabase.yaml
+++ b/entities/su/supabase.yaml
@@ -1,0 +1,68 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01mn9cy1has4rrqz917d75fp8c
+  slug: supabase
+  slug_aliases: []
+  name: Supabase
+  domains:
+    - value: supabase.com
+      role: primary
+      valid_from: 2026-08-28T00:00:00.000Z
+  category: hosting-infra
+profile:
+  description: Supabase is an open source Firebase alternative providing a Postgres database, Authentication, instant APIs, Edge Functions, Realtime subscriptions, and Storage.
+  links:
+    site: https://supabase.com
+sources:
+  - source_id: src_01e6phh9by89rjx496xvb595b4
+    url: https://supabase.com/solutions/startups
+programs:
+  - program_id: prg_01gpwtdysnjpz6pjc7q9ccsjk8
+    program_slug: supabase-startup-program
+    program_slug_aliases: []
+    title: Supabase Startup Program
+    summary: Supabase provides early-stage startups with credits to help them build and scale using their open source Postgres platform.
+    source_ids:
+      - src_01e6phh9by89rjx496xvb595b4
+offers:
+  - offer_id: off_010q8rphrrdhb796x5yahk6jsb
+    program_id: prg_01gpwtdysnjpz6pjc7q9ccsjk8
+    offer_slug: supabase-startup-credits
+    offer_slug_aliases: []
+    title: Supabase Startup Credits
+    summary: Eligible early-stage startups can receive significant credits (up to $3,000 for standard startups, or more for specific accelerator partners) to use across the Supabase platform.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-28T00:00:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: $3,000 in Supabase credits for 12 months for eligible early-stage startups.
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 300000
+            kind: up-to
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: any
+        rules:
+          - kind: all
+            rules:
+              - criterion_id: cri_01
+                kind: manual
+                reason: external-verification
+                statement: Startup must be associated with an approved startup partner or accelerator, or meet bootstrapping pre-seed/seed stage criteria.
+    roles:
+      terms_authority_entity_id: ent_01mn9cy1has4rrqz917d75fp8c
+      access_operator_entity_id: ent_01mn9cy1has4rrqz917d75fp8c
+    access:
+      availability: public
+      method: form
+      url: https://supabase.com/solutions/startups
+    terms_url: https://supabase.com/solutions/startups
+    source_ids:
+      - src_01e6phh9by89rjx496xvb595b4


### PR DESCRIPTION
Add the Supabase startup program to the entities registry. This includes up to  in credits for eligible early-stage startups.