### PR TITLE
data: add Sarvam AI startup offer

### DIFF
--- a/entities/sa/sarvam.yaml
+++ b/entities/sa/sarvam.yaml
@@ -1,0 +1,67 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_0194c1qf480040fykdbwazydrd
+  slug: sarvam
+  slug_aliases:
+    - sarvam-ai
+  name: Sarvam AI
+  domains:
+    - value: sarvam.ai
+      role: primary
+      valid_from: 2026-08-27T00:00:00.000Z
+  category: ai-ml
+profile:
+  description: Sarvam AI provides developer APIs for speech-to-text, text-to-speech, chat completion, text processing, document intelligence, and multilingual AI workflows.
+  links:
+    site: https://www.sarvam.ai
+sources:
+  - source_id: src_c3b0c07fb827b8ce780b19e9f2077b09cd214e0a9bad6cba18de95463d6d13ca
+    url: https://www.sarvam.ai/startup-program
+programs:
+  - program_id: prg_01f7en5z9rdbbtw2n1w9j88bs0
+    program_slug: sarvam-ai-startup-program
+    program_slug_aliases:
+      - sarvam-startup-program
+    title: Sarvam AI Startup Program
+    summary: Sarvam AI's startup program provides selected startups with API credits, priority support, production-ready infrastructure, and launch visibility for speech, vision, and LLM APIs.
+    source_ids:
+      - src_c3b0c07fb827b8ce780b19e9f2077b09cd214e0a9bad6cba18de95463d6d13ca
+offers:
+  - offer_id: off_01pq268zd2h7eqg4ytd9mxjh69
+    program_id: prg_01f7en5z9rdbbtw2n1w9j88bs0
+    offer_slug: sarvam-startup-program-api-credits
+    offer_slug_aliases: []
+    title: 6 to 12 months of Sarvam AI API credits
+    summary: Approved startups receive 6 to 12 months of Sarvam AI credits matched to their scale, plus production APIs, priority engineering support, and launch visibility.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-27T00:00:00.000Z
+    economics:
+      consideration:
+        kind: variable
+        description: Sarvam sizes credits and support based on the startup's application, expected usage, and approval review.
+      benefits:
+        - benefit_id: ben_01
+          description: 6 to 12 months of credits matched to the startup's scale across Sarvam speech, vision, and LLM APIs
+          kind: other
+        - benefit_id: ben_02
+          description: Direct access to Sarvam's engineering team for priority support
+          kind: other
+        - benefit_id: ben_03
+          description: Co-branded case studies and launch amplification
+          kind: other
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_01
+        reason: vendor-discretion
+        statement: Applicant must submit company, stage, funding, location, founder, API-interest, usage-scale, and product details for Sarvam AI review.
+    roles:
+      terms_authority_entity_id: ent_0194c1qf480040fykdbwazydrd
+      access_operator_entity_id: ent_0194c1qf480040fykdbwazydrd
+    access:
+      availability: public
+      method: form
+      url: https://www.sarvam.ai/startup-program
+    source_ids:
+      - src_c3b0c07fb827b8ce780b19e9f2077b09cd214e0a9bad6cba18de95463d6d13ca


### PR DESCRIPTION
Adds Sarvam AI as a new Sourcey entity with its startup program offer, sourced from the official Sarvam AI startup page.

Refs #860.

Checklist:
- [x] Data-only change under entities/
- [x] One new entity YAML
- [x] One current offer
- [x] Signed-off commit