### PR TITLE
data: add SpAItial startup offer

### DIFF
--- a/entities/sp/spaitial.yaml
+++ b/entities/sp/spaitial.yaml
@@ -1,0 +1,66 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01w20rjdmrdgb2vvr1z69f27a9
+  slug: spaitial
+  slug_aliases:
+    - spaitial-ai
+  name: SpAItial
+  domains:
+    - value: spaitial.ai
+      role: primary
+      valid_from: 2026-08-27T00:00:00.000Z
+  category: ai-ml
+profile:
+  description: SpAItial develops Echo, a physically grounded world model and API for generating persistent 3D environments and spatial workflows.
+  links:
+    site: https://spaitial.ai
+sources:
+  - source_id: src_e2654bb219f754ba81b0a93d264db4547ab35cff505971d044052f6a482e887b
+    url: https://spaitial.ai/startups
+programs:
+  - program_id: prg_015r9vsh87djse68cqtnpk1dg6
+    program_slug: spaitial-startup-program
+    program_slug_aliases: []
+    title: SpAItial Startup Program
+    summary: SpAItial's startup program gives selected product teams Echo credits, priority API access, early model access, integration support, and launch amplification.
+    source_ids:
+      - src_e2654bb219f754ba81b0a93d264db4547ab35cff505971d044052f6a482e887b
+offers:
+  - offer_id: off_01n1ymx4yjzqqp743rnrgxzchv
+    program_id: prg_015r9vsh87djse68cqtnpk1dg6
+    offer_slug: spaitial-echo-startup-credits
+    offer_slug_aliases: []
+    title: SpAItial Echo credits and priority API access
+    summary: Selected startups receive Echo credits for real product usage, higher rate limits, early Echo model access, integration support, a feedback loop with the SpAItial team, and possible launch amplification.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-27T00:00:00.000Z
+    economics:
+      consideration:
+        kind: variable
+        description: Participants are expected to provide concrete product feedback and may share selected outputs, demos, or learnings that SpAItial can feature.
+      benefits:
+        - benefit_id: ben_01
+          description: Echo credits for prototyping, integration, and live product workflow testing
+          kind: other
+        - benefit_id: ben_02
+          description: Priority API access, higher rate limits, early Echo model access, and integration support
+          kind: other
+        - benefit_id: ben_03
+          description: Potential launch amplification across SpAItial channels when there is a fit
+          kind: other
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: external-verification
+        statement: Applicant must have a real product or prototype where Echo can be used now, be able to ship quickly, plan to integrate Echo into a product or workflow, give concrete feedback, and share selected outputs or demos when appropriate.
+    roles:
+      terms_authority_entity_id: ent_01w20rjdmrdgb2vvr1z69f27a9
+      access_operator_entity_id: ent_01w20rjdmrdgb2vvr1z69f27a9
+    access:
+      availability: public
+      method: form
+      url: https://spaitial.ai/startups
+    source_ids:
+      - src_e2654bb219f754ba81b0a93d264db4547ab35cff505971d044052f6a482e887b


### PR DESCRIPTION
Adds SpAItial as a new Sourcey entity with its Echo startup program offer, sourced from the official SpAItial startup page.

Refs #864.

Checklist:
- [x] Data-only change under entities/
- [x] One new entity YAML
- [x] One current offer
- [x] Signed-off commit