### PR TITLE
Add NetMind Elevate startup credits

### DIFF
--- a/entities/ne/netmind.yaml
+++ b/entities/ne/netmind.yaml
@@ -29,21 +29,16 @@ offers:
     program_id: prg_01m1345cbemdxpjtzwtyyk5tj6
     offer_slug: netmind-elevate-inference-credits
     offer_slug_aliases: []
-    title: Up to $100,000 in NetMind inference credits
-    summary: Startups can apply to NetMind Elevate for up to $100,000 in credits to accelerate an eligible venture or project.
+    title: NetMind inference credits for startups
+    summary: Startups can apply to NetMind Elevate for inference credits to accelerate an eligible venture or project.
     lifecycle:
       status: active
       effective_from: 2026-08-28T00:00:00.000Z
     economics:
       benefits:
         - benefit_id: ben_01
-          description: Up to $100,000 in NetMind inference credits.
-          kind: credit
-          value:
-            amount:
-              currency: USD
-              minor_units: 10000000
-            kind: up-to
+          description: NetMind inference credits for an approved startup venture or project.
+          kind: other
       consideration:
         kind: unknown
         description: The public program information does not establish separate consideration.

--- a/entities/ne/netmind.yaml
+++ b/entities/ne/netmind.yaml
@@ -1,0 +1,65 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1345cb87fp2trxkgx8gm0pt
+  slug: netmind
+  slug_aliases: []
+  name: NetMind
+  domains:
+    - value: netmind.ai
+      role: primary
+      valid_from: 2026-08-28T00:00:00.000Z
+  category: ai-ml
+profile:
+  description: NetMind provides AI inference APIs, GPU infrastructure, and AI services for developers and businesses.
+  links:
+    site: https://www.netmind.ai/
+sources:
+  - source_id: src_3d69eec9387ccbb6190d899525f87c883cb98178e7d813cb3297bec09f38170b
+    url: https://blog.netmind.ai/article/Your_One_Stop_Access_to_AI_API_at_NetMind%21
+programs:
+  - program_id: prg_01m1345cbemdxpjtzwtyyk5tj6
+    program_slug: netmind-elevate
+    program_slug_aliases: []
+    title: NetMind Elevate
+    summary: NetMind Elevate supports startups with inference credits for eligible ventures or projects.
+    source_ids:
+      - src_3d69eec9387ccbb6190d899525f87c883cb98178e7d813cb3297bec09f38170b
+offers:
+  - offer_id: off_01m1345cbfntyxrpke0efr0r99
+    program_id: prg_01m1345cbemdxpjtzwtyyk5tj6
+    offer_slug: netmind-elevate-inference-credits
+    offer_slug_aliases: []
+    title: Up to $100,000 in NetMind inference credits
+    summary: Startups can apply to NetMind Elevate for up to $100,000 in credits to accelerate an eligible venture or project.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-28T00:00:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $100,000 in NetMind inference credits.
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 10000000
+            kind: up-to
+      consideration:
+        kind: unknown
+        description: The public program information does not establish separate consideration.
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: vendor-discretion
+        statement: Applicant is a startup and is approved by NetMind for the Elevate program.
+    roles:
+      terms_authority_entity_id: ent_01m1345cb87fp2trxkgx8gm0pt
+      access_operator_entity_id: ent_01m1345cb87fp2trxkgx8gm0pt
+    access:
+      availability: public
+      method: form
+      instructions: Apply to the NetMind Elevate program through NetMind.
+      url: https://www.netmind.ai/
+    source_ids:
+      - src_3d69eec9387ccbb6190d899525f87c883cb98178e7d813cb3297bec09f38170b


### PR DESCRIPTION
## What changed
Adds a new NetMind entity record with the NetMind Elevate startup inference-credit offer.

Closes #866. Supersedes #867, whose first web commit did not preserve its DCO trailer.

## Sources
- https://www.netmind.ai/
- https://blog.netmind.ai/article/Your_One_Stop_Access_to_AI_API_at_NetMind%21

## Certification
- [x] I changed only allowed repository content and did not mix Entity YAML with other paths.
- [x] Public sources substantiate every submitted factual value.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commit includes a `Signed-off-by` line.