### PR TITLE
data: add OpStart startup discount offer

### DIFF
--- a/entities/op/opstart.yaml
+++ b/entities/op/opstart.yaml
@@ -1,0 +1,57 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1251hwbgv413evqe7vbyewn
+  slug: opstart
+  slug_aliases: []
+  name: OpStart
+  domains:
+    - value: opstart.co
+      role: primary
+      valid_from: 2026-08-27T17:42:19.000Z
+  category: finance-accounting
+profile:
+  description: OpStart provides bookkeeping, tax, billing, payroll, and fractional CFO services for startups.
+  links:
+    site: https://www.opstart.co
+sources:
+  - source_id: src_4c622b40cbe86a8bf9b12d01368a1b9c6448cb621f9344deca06b0d5e5730e41
+    url: https://www.opstart.co/startup-stack/
+programs: []
+offers:
+  - offer_id: off_01m1251hwdc7z9nzsjm8mcwa13
+    offer_slug: startup-stack-discount
+    offer_slug_aliases: []
+    title: OpStart Startup Stack discount
+    summary: Startup Stack members get 10% off OpStart bookkeeping, bill pay, payroll support, and related services for the first 12 months, capped at $1,000.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-27T17:42:19.000Z
+    economics:
+      consideration:
+        kind: unknown
+        description: The page does not publish a separate application fee or service price.
+      benefits:
+        - benefit_id: ben_01
+          description: 10% discount on bookkeeping, bill pay, payroll support, and related services for the first twelve months, capped at $1,000.
+          duration:
+            kind: exact
+            value: P12M
+          kind: discount
+          percentage:
+            kind: exact
+            basis_points: 1000
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_01
+        reason: external-verification
+        statement: Offer is for startups and is described on the page as a Startup Stack member discount.
+    roles:
+      terms_authority_entity_id: ent_01m1251hwbgv413evqe7vbyewn
+      access_operator_entity_id: ent_01m1251hwbgv413evqe7vbyewn
+    access:
+      availability: public
+      method: form
+      url: https://www.opstart.co/startup-stack/
+    source_ids:
+      - src_4c622b40cbe86a8bf9b12d01368a1b9c6448cb621f9344deca06b0d5e5730e41


### PR DESCRIPTION
## What changed

Adds exactly one new OpStart Entity at entities/op/opstart.yaml with exactly one standalone Startup Stack offer. The record captures the published 10% discount for the first 12 months, capped at $1,000, with startup-specific eligibility and public form access. No Program is added because the first-party source does not name a separate umbrella program.

## Sources

- https://www.opstart.co/startup-stack/

## Reservation and bounty

- Reservation issue: #869
- Frantic bounty: #120
- Frantic claim: d6f47bb7-90d9-4f63-9134-1a90c1e5c482

## Certification

- [x] I changed only allowed repository content and did not mix Entity YAML with other paths.
- [x] The public first-party source substantiates the submitted factual values; Sourcey-written prose is a neutral summary.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] The commit includes a Signed-off-by line.

The current main branch CONTRIBUTING.md requires the Entity authoring schema and entities/{shard}/ path. Exact pinned Sourcey Catalog Verifier result: {"status":"valid","entities":1,"programs":0,"offers":1}.

AI-assisted disclosure: drafted and locally verified with AI assistance; all published facts are linked to the vendor first-party source for maintainer review.