### PR TITLE
data: add Zunoy startup program

### DIFF
--- a/entities/zu/zunoy.yaml
+++ b/entities/zu/zunoy.yaml
@@ -1,0 +1,128 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m136y5j00q3zgs0ys3g1ktck
+  slug: zunoy
+  slug_aliases: []
+  name: Zunoy
+  domains:
+    - value: zunoy.com
+      role: primary
+      valid_from: 2026-08-28T03:34:40.531Z
+  category: productivity
+profile:
+  description: All-in-one SaaS workspace combining developer, operations, collaboration, HR, content, and knowledge tools under one account.
+  links:
+    site: https://zunoy.com
+sources:
+  - source_id: src_c0ffc9b159169525c938abacb18b77e05abd9e093237172e22ebaf1a09fef039
+    url: https://zunoy.com/start-up-program
+programs:
+  - program_id: prg_01m136y5j2r446w2tzwbq4nx9d
+    program_slug: zunoy-startup-program
+    program_slug_aliases: []
+    title: Zunoy Startup Program
+    summary: Eligible early-stage startups and nonprofits get free access to Zunoy's Growth/Business Plan for 12 months, plus priority support.
+    source_ids:
+      - src_c0ffc9b159169525c938abacb18b77e05abd9e093237172e22ebaf1a09fef039
+offers:
+  - offer_id: off_01m136y5j241j3skpwrggcx3ar
+    program_id: prg_01m136y5j2r446w2tzwbq4nx9d
+    offer_slug: zunoy-startup-program
+    offer_slug_aliases: []
+    title: Zunoy Startup Program
+    summary: Eligible startups and nonprofits receive Zunoy's Growth/Business Plan free for 12 months for teams of up to 25 users.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-28T03:34:40.531Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Free access to Zunoy's Growth/Business Plan for 12 months for organizations with up to 25 users.
+          duration:
+            kind: exact
+            value: P1Y
+          kind: free-service
+          service: Zunoy Growth/Business Plan
+        - benefit_id: ben_02
+          description: Priority support, resources, guides, and community access during the program.
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - kind: any
+            rules:
+              - kind: all
+                rules:
+                  - criterion_id: cri_01
+                    fact: company.age_months
+                    kind: predicate
+                    operator: lt
+                    statement: A startup must be less than 5 years old.
+                    value:
+                      type: number
+                      value: 60
+                  - criterion_id: cri_02
+                    fact: company.stage
+                    kind: predicate
+                    operator: in
+                    statement: A startup must be registered and at the pre-seed through Series A stage.
+                    value:
+                      type: string-set
+                      values:
+                        - pre-seed
+                        - seed
+                        - series-a
+              - kind: all
+                rules:
+                  - criterion_id: cri_03
+                    fact: company.is_nonprofit
+                    kind: predicate
+                    operator: eq
+                    statement: A nonprofit applicant must be a verified nonprofit or NGO.
+                    value:
+                      type: boolean
+                      value: true
+                  - criterion_id: cri_04
+                    fact: company.annual_operating_budget_usd
+                    kind: predicate
+                    operator: lt
+                    statement: A nonprofit applicant must have an annual operating budget under $500,000.
+                    value:
+                      type: number
+                      value: 500000
+          - criterion_id: cri_05
+            fact: company.employee_count
+            kind: predicate
+            operator: lt
+            statement: The applicant's entire team must be smaller than 25 people.
+            value:
+              type: number
+              value: 25
+          - criterion_id: cri_06
+            fact: company.has_social_impact_mission
+            kind: predicate
+            operator: eq
+            statement: The organization must use software to create social or community impact.
+            value:
+              type: boolean
+              value: true
+          - criterion_id: cri_07
+            fact: company.use_case
+            kind: predicate
+            operator: eq
+            statement: Zunoy must support the organization's core mission or product rather than an internal experiment.
+            value:
+              type: string
+              value: core mission or product
+    roles:
+      terms_authority_entity_id: ent_01m136y5j00q3zgs0ys3g1ktck
+      access_operator_entity_id: ent_01m136y5j00q3zgs0ys3g1ktck
+    access:
+      availability: public
+      method: form
+      url: https://zunoy.com/start-up-program
+    source_ids:
+      - src_c0ffc9b159169525c938abacb18b77e05abd9e093237172e22ebaf1a09fef039

--- a/entities/zu/zunoy.yaml
+++ b/entities/zu/zunoy.yaml
@@ -10,6 +10,7 @@ entity:
       valid_from: 2026-08-28T03:34:40.531Z
   category: productivity
 profile:
+  summary: Zunoy provides an all-in-one SaaS suite for teams to build, test, ship, and manage their work.
   description: All-in-one SaaS workspace combining developer, operations, collaboration, HR, content, and knowledge tools under one account.
   links:
     site: https://zunoy.com
@@ -37,86 +38,23 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: Free access to Zunoy's Growth/Business Plan for 12 months for organizations with up to 25 users.
+          description: Free access to Zunoy products for 12 months
           duration:
             kind: exact
             value: P1Y
           kind: free-service
-          service: Zunoy Growth/Business Plan
+          service: Growth/Business Plan
         - benefit_id: ben_02
-          description: Priority support, resources, guides, and community access during the program.
+          description: Priority support and access to resources, guides, and community
           kind: other
       consideration:
         kind: none
     eligibility:
       rule:
-        kind: all
-        rules:
-          - kind: any
-            rules:
-              - kind: all
-                rules:
-                  - criterion_id: cri_01
-                    fact: company.age_months
-                    kind: predicate
-                    operator: lt
-                    statement: A startup must be less than 5 years old.
-                    value:
-                      type: number
-                      value: 60
-                  - criterion_id: cri_02
-                    fact: company.stage
-                    kind: predicate
-                    operator: in
-                    statement: A startup must be registered and at the pre-seed through Series A stage.
-                    value:
-                      type: string-set
-                      values:
-                        - pre-seed
-                        - seed
-                        - series-a
-              - kind: all
-                rules:
-                  - criterion_id: cri_03
-                    fact: company.is_nonprofit
-                    kind: predicate
-                    operator: eq
-                    statement: A nonprofit applicant must be a verified nonprofit or NGO.
-                    value:
-                      type: boolean
-                      value: true
-                  - criterion_id: cri_04
-                    fact: company.annual_operating_budget_usd
-                    kind: predicate
-                    operator: lt
-                    statement: A nonprofit applicant must have an annual operating budget under $500,000.
-                    value:
-                      type: number
-                      value: 500000
-          - criterion_id: cri_05
-            fact: company.employee_count
-            kind: predicate
-            operator: lt
-            statement: The applicant's entire team must be smaller than 25 people.
-            value:
-              type: number
-              value: 25
-          - criterion_id: cri_06
-            fact: company.has_social_impact_mission
-            kind: predicate
-            operator: eq
-            statement: The organization must use software to create social or community impact.
-            value:
-              type: boolean
-              value: true
-          - criterion_id: cri_07
-            fact: company.use_case
-            kind: predicate
-            operator: eq
-            statement: Zunoy must support the organization's core mission or product rather than an internal experiment.
-            value:
-              type: string
-              value: core mission or product
+        criterion_id: cri_01
+        kind: manual
+        reason: external-verification
+        statement: A registered early-stage startup from pre-seed through Series A that is less than five years old, or a verified nonprofit or NGO with an annual operating budget under $500,000, may apply; the team must be smaller than 25 people, use software to create social or community impact, and use Zunoy to support its core mission or product.
     roles:
       terms_authority_entity_id: ent_01m136y5j00q3zgs0ys3g1ktck
       access_operator_entity_id: ent_01m136y5j00q3zgs0ys3g1ktck

--- a/entities/zu/zunoy.yaml
+++ b/entities/zu/zunoy.yaml
@@ -45,7 +45,7 @@ offers:
           kind: free-service
           service: Growth/Business Plan
         - benefit_id: ben_02
-          description: Priority support to help organizations get started
+          description: Priority support to help you get started fast
           kind: other
       consideration:
         kind: none
@@ -56,23 +56,23 @@ offers:
           - criterion_id: cri_01
             kind: manual
             reason: external-verification
-            statement: The startup must be less than five years old, or the NGO must have an annual operating budget under $500,000.
+            statement: The startup is less than five years old or the NGO has an annual operating budget under $500,000.
           - criterion_id: cri_02
             kind: manual
             reason: external-verification
-            statement: The applicant must be a registered early-stage startup from pre-seed to Series A or a verified nonprofit or NGO.
+            statement: The applicant is a registered early-stage startup from pre-seed to Series A or a verified nonprofit or NGO.
           - criterion_id: cri_03
             kind: manual
             reason: external-verification
-            statement: The applicant's entire team must be smaller than 25 people.
+            statement: The applicant's entire team is smaller than 25 people.
           - criterion_id: cri_04
             kind: manual
             reason: external-verification
-            statement: The organization must use software to create social or community impact.
+            statement: The organization uses software to create social or community impact.
           - criterion_id: cri_05
             kind: manual
             reason: external-verification
-            statement: Zunoy must support the organization's core mission or product rather than an internal experiment.
+            statement: Zunoy will be used to support the organization's core mission or product, not just internal experiments.
     roles:
       terms_authority_entity_id: ent_01m136y5j00q3zgs0ys3g1ktck
       access_operator_entity_id: ent_01m136y5j00q3zgs0ys3g1ktck

--- a/entities/zu/zunoy.yaml
+++ b/entities/zu/zunoy.yaml
@@ -38,23 +38,41 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: Free access to Zunoy products for 12 months
+          description: Free access to the Growth/Business Plan
           duration:
             kind: exact
             value: P1Y
           kind: free-service
           service: Growth/Business Plan
         - benefit_id: ben_02
-          description: Priority support and access to resources, guides, and community
+          description: Priority support to help organizations get started
           kind: other
       consideration:
         kind: none
     eligibility:
       rule:
-        criterion_id: cri_01
-        kind: manual
-        reason: external-verification
-        statement: A registered early-stage startup from pre-seed through Series A that is less than five years old, or a verified nonprofit or NGO with an annual operating budget under $500,000, may apply; the team must be smaller than 25 people, use software to create social or community impact, and use Zunoy to support its core mission or product.
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: The startup must be less than five years old, or the NGO must have an annual operating budget under $500,000.
+          - criterion_id: cri_02
+            kind: manual
+            reason: external-verification
+            statement: The applicant must be a registered early-stage startup from pre-seed to Series A or a verified nonprofit or NGO.
+          - criterion_id: cri_03
+            kind: manual
+            reason: external-verification
+            statement: The applicant's entire team must be smaller than 25 people.
+          - criterion_id: cri_04
+            kind: manual
+            reason: external-verification
+            statement: The organization must use software to create social or community impact.
+          - criterion_id: cri_05
+            kind: manual
+            reason: external-verification
+            statement: Zunoy must support the organization's core mission or product rather than an internal experiment.
     roles:
       terms_authority_entity_id: ent_01m136y5j00q3zgs0ys3g1ktck
       access_operator_entity_id: ent_01m136y5j00q3zgs0ys3g1ktck


### PR DESCRIPTION
## What changed

- Add the canonical Zunoy entity, startup program, and one active offer.
- Model 12 months of free Growth/Business Plan access, priority support, and the published startup/nonprofit eligibility rules.

Closes #873

## Sources

- https://zunoy.com/start-up-program

## Certification

- [x] I changed only allowed repository content and did not mix Entity YAML with other paths.
- [x] Public sources substantiate every submitted factual value; any Sourcey-written prose is a neutral summary, not a fabricated vendor quote.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commits include a `Signed-off-by` line.