### PR TITLE
Add Liner Startup Grant Program entity

### DIFF
--- a/entities/li/liner.yaml
+++ b/entities/li/liner.yaml
@@ -1,0 +1,63 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m13r34e17rbhka4hm8staydq
+  slug: liner
+  slug_aliases: []
+  name: Liner
+  domains:
+    - value: liner.com
+      role: primary
+      valid_from: 2026-08-28T08:31:00Z
+  category: ai-ml
+profile:
+  description: Liner provides web and academic search, cited research agents, and developer APIs for search and research applications.
+  links:
+    site: https://liner.com
+sources:
+  - source_id: src_968ad1daaad96e84ae921a2baf6cc1ed0cbd5d19ff53c2364fdb13b4c6e54d14
+    url: https://build.liner.com/blog/liner-startup-grant-program
+programs:
+  - program_id: prg_01m13r34e3n5xgdyf5m8wwhq4q
+    program_slug: startup-grant-program
+    program_slug_aliases: []
+    title: Liner Startup Grant Program
+    summary: Liner's non-dilutive grant program gives eligible early-stage startups API credits for its search and research developer platform.
+    source_ids:
+      - src_968ad1daaad96e84ae921a2baf6cc1ed0cbd5d19ff53c2364fdb13b4c6e54d14
+offers:
+  - offer_id: off_01m13r34e399hdj9p57c8zhf3j
+    program_id: prg_01m13r34e3n5xgdyf5m8wwhq4q
+    offer_slug: liner-startup-api-credits
+    offer_slug_aliases: []
+    title: Liner Startup API Credits
+    summary: Eligible early-stage startups can receive up to $1,000 in credits across Liner's Search and Research APIs, with no equity surrendered and nothing to repay.
+    lifecycle:
+      status: active
+      effective_from: 2026-07-28T00:00:00Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $1,000 in Liner API credits
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 100000
+            kind: up-to
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_requirement_01
+        kind: manual
+        reason: vendor-discretion
+        statement: Applicants must be an eligible early-stage startup and provide a company email, company name, company website, and intended Liner product through the application form.
+    roles:
+      terms_authority_entity_id: ent_01m13r34e17rbhka4hm8staydq
+      access_operator_entity_id: ent_01m13r34e17rbhka4hm8staydq
+    access:
+      availability: public
+      method: form
+      url: https://forms.gle/L6GEKR8z13RmmARF8
+    source_ids:
+      - src_968ad1daaad96e84ae921a2baf6cc1ed0cbd5d19ff53c2364fdb13b4c6e54d14

--- a/entities/li/liner.yaml
+++ b/entities/li/liner.yaml
@@ -10,6 +10,7 @@ entity:
       valid_from: 2026-08-28T08:31:00Z
   category: ai-ml
 profile:
+  summary: Liner provides AI-powered web and academic search, cited research tools, and developer APIs for search and research applications.
   description: Liner provides web and academic search, cited research agents, and developer APIs for search and research applications.
   links:
     site: https://liner.com


### PR DESCRIPTION
## What changed

Adds the Liner Entity record with its public Startup Grant Program and one offer for up to $1,000 in API credits. This replaces the obsolete vendor-schema submission in #692.

## Sources

- https://build.liner.com/blog/liner-startup-grant-program

## Certification

- [x] I changed only allowed repository content and did not mix Entity YAML with other paths.
- [x] Public sources substantiate every submitted factual value; any Sourcey-written prose is a neutral summary, not a fabricated vendor quote.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commits include a `Signed-off-by` line.

Closes #691.