### PR TITLE
data: reauthor Influship Startup Program as an entity

### DIFF
--- a/entities/in/influship.yaml
+++ b/entities/in/influship.yaml
@@ -1,0 +1,69 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m0kb3kncz7ev60zcqy3jr83b
+  slug: influship
+  slug_aliases: []
+  name: Influship
+  domains:
+    - value: influship.com
+      role: primary
+      valid_from: 2026-08-21T23:39:45Z
+  category: marketing
+profile:
+  description: Influship provides creator intelligence, influencer discovery, creator data, datasets, and API access for marketing products and AI agents.
+  links:
+    site: https://www.influship.com
+sources:
+  - source_id: src_6ea0f1cb945d33358692d415e9ecc80e11608c0385ecde9f16038cbd74fdc287
+    url: https://www.influship.com/startups
+programs:
+  - program_id: prg_01m0kb3kne8qgp0wtmq1wrrsec
+    program_slug: startup-program
+    program_slug_aliases: []
+    title: Influship Startup Program
+    summary: Influship offers approved startups custom API credits, technical onboarding, dedicated support, and early API access.
+    source_ids:
+      - src_6ea0f1cb945d33358692d415e9ecc80e11608c0385ecde9f16038cbd74fdc287
+offers:
+  - offer_id: off_01m0kb3knek4pamz80vf47663n
+    program_id: prg_01m0kb3kne8qgp0wtmq1wrrsec
+    offer_slug: api-credits-and-integration-support
+    offer_slug_aliases: []
+    title: API credits and integration support
+    summary: Approved startups receive a project-sized Influship API credit grant, one-to-one technical onboarding, dedicated support, and early API access.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-21T23:39:45Z
+    economics:
+      consideration:
+        kind: none
+      benefits:
+        - benefit_id: ben_01
+          description: A custom grant of Influship API credits sized to the project and expected usage during an introductory call
+          kind: other
+        - benefit_id: ben_02
+          description: One-to-one technical onboarding for API integration planning
+          kind: other
+        - benefit_id: ben_03
+          description: Direct access to the Influship team through a dedicated support channel
+          kind: other
+        - benefit_id: ben_04
+          description: Early access to new API features and endpoints
+          kind: other
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_01
+        statement: Applicant must be a startup building a product that uses influencer or creator data, plan to integrate the Influship API, and receive Influship approval.
+        reason: vendor-discretion
+    roles:
+      terms_authority_entity_id: ent_01m0kb3kncz7ev60zcqy3jr83b
+      access_operator_entity_id: ent_01m0kb3kncz7ev60zcqy3jr83b
+    access:
+      availability: public
+      instructions: Submit the startup-program form; Influship reviews the application and schedules a call to size the credit grant and onboarding plan.
+      method: form
+      url: https://www.influship.com/startups
+    terms_url: https://www.influship.com/startups
+    source_ids:
+      - src_6ea0f1cb945d33358692d415e9ecc80e11608c0385ecde9f16038cbd74fdc287


### PR DESCRIPTION
## What changed

Reauthors the Influship Startup Program against the current canonical Entity schema after #682 was closed following the repository's schema cutover.

The change adds exactly one new Entity file under `entities/in/` and records the publicly documented custom API credit grant, technical onboarding, dedicated support, and early API access.

## Sources

https://www.influship.com/startups

## Certification

- [x] I changed only allowed repository content and did not mix Entity YAML with other paths.
- [x] Public sources substantiate every submitted factual value; any Sourcey-written prose is a neutral summary, not a fabricated vendor quote.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commit includes a `Signed-off-by` line.

Closes #681