### PR TITLE
catalog: add Morph entity offer

### DIFF
--- a/entities/mo/morph.yaml
+++ b/entities/mo/morph.yaml
@@ -1,0 +1,60 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m13tkye5955vkzep7cpgybfj
+  slug: morph
+  slug_aliases:
+    - morphllm
+  name: Morph
+  domains:
+    - value: morphllm.com
+      role: primary
+      valid_from: 2026-08-08T05:32:49.000Z
+  category: ai-ml
+profile:
+  summary: Morph provides a fast OpenAI- and Anthropic-compatible API for coding agents, with specialized models for code editing, code search, and context compression.
+  description: Morph provides an OpenAI-compatible API and specialized models for code editing, code search, and context compression.
+  links:
+    site: https://www.morphllm.com
+sources:
+  - source_id: src_c3614f84c294bc01fcf6ed0aaa82ece54a2e4d60f6a0ee95e5c3c4c5d30213ef
+    url: https://www.morphllm.com/llms.txt
+  - source_id: src_783ac5453e4de613db7e2bbf5d298fb0aadc364af34c514225df42057ec2403e
+    url: https://www.morphllm.com/startups.md
+programs: []
+offers:
+  - offer_id: off_01m13tkye9ttnf50rna45a44f7
+    offer_slug: morph-startup-api-credits
+    offer_slug_aliases: []
+    title: Morph Startup Credits
+    summary: Startups that apply can receive up to $1,000 in Morph API credits.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-08T05:32:49.000Z
+    economics:
+      consideration:
+        kind: none
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $1,000 in Morph API credits for startups
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 100000
+            kind: up-to
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: vendor-discretion
+        statement: The applicant must be part of an accelerator or an early-stage startup building with Morph.
+    roles:
+      terms_authority_entity_id: ent_01m13tkye5955vkzep7cpgybfj
+      access_operator_entity_id: ent_01m13tkye5955vkzep7cpgybfj
+    access:
+      availability: public
+      method: form
+      instructions: For the fastest approval, create an account and an organization, then add a billing method with usage-based billing first.
+      url: https://www.morphllm.com/startups
+    source_ids:
+      - src_783ac5453e4de613db7e2bbf5d298fb0aadc364af34c514225df42057ec2403e

--- a/entities/mo/morph.yaml
+++ b/entities/mo/morph.yaml
@@ -32,10 +32,11 @@ offers:
       effective_from: 2026-08-08T05:32:49.000Z
     economics:
       consideration:
-        kind: none
+        kind: unknown
+        description: The cited source does not state whether separate consideration is required.
       benefits:
         - benefit_id: ben_01
-          description: Up to $1,000 in Morph API credits for startups
+          description: API credits up to $1,000
           kind: credit
           value:
             amount:
@@ -53,7 +54,7 @@ offers:
       access_operator_entity_id: ent_01m13tkye5955vkzep7cpgybfj
     access:
       availability: public
-      method: form
+      method: other
       instructions: For the fastest approval, create an account and an organization, then add a billing method with usage-based billing first.
       url: https://www.morphllm.com/startups
     source_ids:


### PR DESCRIPTION
## Summary

- Add Morph as a canonical Entity at `entities/mo/morph.yaml` using the post-cutover `sourcey.entity-authoring/v1alpha1` shape.
- Record Morph's public Free plan: $0/month and 250K credits applying to every product.
- Cite Morph's pricing pages and Auth documentation for the offer and API-key access flow.
- Supersedes the closed pre-cutover [PR #284](https://github.com/sourcey/startup-credits/pull/284).

## Verification

- Exact digest-pinned local verifier: `{"status":"valid","entities":1,"programs":0,"offers":1}`
- Commit includes DCO sign-off.

Related: #281