### PR TITLE
data: reauthor Vectorize Hindsight startup credits as an entity

### DIFF
--- a/entities/ve/vectorize.yaml
+++ b/entities/ve/vectorize.yaml
@@ -1,0 +1,69 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m0s6ee20skktfs8myvv5g3tz
+  slug: vectorize
+  slug_aliases: []
+  name: Vectorize
+  domains:
+    - value: vectorize.io
+      role: primary
+      valid_from: 2026-08-24T06:13:00.000Z
+  category: ai-ml
+profile:
+  description: Vectorize builds Hindsight, an open-source and managed memory platform that helps AI agents remember, learn from experience, and personalize across sessions.
+  links:
+    site: https://vectorize.io
+sources:
+  - source_id: src_ed0d677e02586d65ffb3c3d7489765aaac1dace5dcb18cbf22e3d70cf9d768d5
+    url: https://vectorize.io/startups
+programs:
+  - program_id: prg_01m0s6ee20qngparntqtx0saqm
+    program_slug: hindsight-cloud-for-startups
+    program_slug_aliases: []
+    title: Hindsight Cloud for Startups
+    summary: Hindsight Cloud for Startups gives qualifying product startups staged cloud credits and engineering support to build customer-facing agent memory.
+    source_ids:
+      - src_ed0d677e02586d65ffb3c3d7489765aaac1dace5dcb18cbf22e3d70cf9d768d5
+offers:
+  - offer_id: off_01m0s6ee20rydrdz997fj7qss8
+    program_id: prg_01m0s6ee20qngparntqtx0saqm
+    offer_slug: up-to-15000-in-hindsight-cloud-credits
+    offer_slug_aliases: []
+    title: Up to $15,000 in Hindsight Cloud credits
+    summary: Eligible product startups can receive up to $15,000 in Hindsight Cloud credits, starting with $1,000 and unlocking $4,000 and $10,000 additional credits as they grow.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-24T06:13:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $15,000 in Hindsight Cloud credits, starting with $1,000 and unlocking $4,000 and $10,000 additional credits as the startup grows.
+          duration:
+            kind: exact
+            value: P3M
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 1500000
+            kind: up-to
+        - benefit_id: ben_02
+          description: Dedicated Slack channel with the Vectorize engineering team, monthly office hours, and an architecture review for the startup's memory system.
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Applicant must be an incorporated company with under $10M in funding, build a customer-facing product on Hindsight whose usage scales with adoption, and not currently be a paying Hindsight Cloud customer; agencies, consultancies, custom solution shops, internal-only deployments, and research or exploration projects do not qualify.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m0s6ee20skktfs8myvv5g3tz
+      access_operator_entity_id: ent_01m0s6ee20skktfs8myvv5g3tz
+    access:
+      availability: public
+      method: form
+      url: https://vectorize.io/startups
+    source_ids:
+      - src_ed0d677e02586d65ffb3c3d7489765aaac1dace5dcb18cbf22e3d70cf9d768d5


### PR DESCRIPTION
## What changed

Reauthors Vectorize's Hindsight Cloud for Startups record against the current canonical Entity schema after #765 was closed following the repository's schema cutover.

Adds exactly one Entity file at `entities/ve/vectorize.yaml` with the current Hindsight Cloud for Startups program and startup-specific offer, including:

- Up to $15,000 in Hindsight Cloud credits
- Credits valid for 3 months
- Dedicated Slack support with the Vectorize engineering team
- Monthly office hours
- Architecture review
- Published startup eligibility and exclusions

This supersedes #765.

Closes #764.

## Sources

- https://vectorize.io/startups

## Certification

- [x] I changed only allowed repository content and did not mix Entity YAML with other paths.
- [x] Public sources substantiate every submitted factual value; any Sourcey-written prose is a neutral summary, not a fabricated vendor quote.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commits include a `Signed-off-by` line.