### PR TITLE
data: add LINE SCALE UP entity

### DIFF
--- a/entities/li/line.yaml
+++ b/entities/li/line.yaml
@@ -1,0 +1,67 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01kzs0r8sw096nns8690g0m1qa
+  slug: line
+  slug_aliases: []
+  name: LINE
+  domains:
+    - value: line.me
+      role: primary
+      valid_from: 2026-08-11T19:05:00.000Z
+  category: communication
+profile:
+  description: LINE is a communication app that provides free voice calls and messages, alongside additional services.
+  links:
+    site: https://www.line.me/en/
+sources:
+  - source_id: src_3e9fb71f5dc2cf6b943434af6f7726a5d84f78f7279b30404f574aea5f2c444b
+    url: https://www.line.me/en/
+  - source_id: src_08a214e652980d1ac6ad8f41ad3932b9abadd2096ac03636441b8775a4ba736f
+    url: https://linescaleup.landpress.line.me/home/
+programs:
+  - program_id: prg_01kzs0r8swztr1qzvxv811s3ks
+    program_slug: line-scale-up
+    program_slug_aliases: []
+    title: LINE SCALE UP
+    summary: A one-year program connecting high-potential startups with LINE platform resources, expert support, and opportunities for strategic collaboration.
+    source_ids:
+      - src_08a214e652980d1ac6ad8f41ad3932b9abadd2096ac03636441b8775a4ba736f
+offers:
+  - offer_id: off_01kzs0r8swa9rg9sqqx0vmxkrz
+    program_id: prg_01kzs0r8swztr1qzvxv811s3ks
+    offer_slug: line-scale-up-one-year-startup-package
+    offer_slug_aliases: []
+    title: LINE SCALE UP one-year startup package
+    summary: Selected startups receive a one-year package valued at up to THB 4 million (USD 120,000), including Official Account and LINE ads credits, expert support, and partnership opportunities.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-11T19:05:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: One-year package valued at up to THB 4 million (USD 120,000), including Official Account and LINE ads credits
+          kind: other
+        - benefit_id: ben_02
+          description: API, technical, and business consultation from LINE experts
+          kind: other
+        - benefit_id: ben_03
+          description: Opportunities for strategic partnership and potential investment by LINE and its affiliates
+          kind: other
+      consideration:
+        kind: unknown
+        description: The public program page does not establish separate consideration.
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_01
+        statement: Seed to Series A startup with a validated product idea, proven business model, solid traction and revenue base, aligned with LINE's focus areas and ecosystem.
+        reason: external-verification
+    roles:
+      terms_authority_entity_id: ent_01kzs0r8sw096nns8690g0m1qa
+      access_operator_entity_id: ent_01kzs0r8sw096nns8690g0m1qa
+    access:
+      availability: public
+      method: form
+      url: https://linescaleup.landpress.line.me/home/
+    source_ids:
+      - src_08a214e652980d1ac6ad8f41ad3932b9abadd2096ac03636441b8775a4ba736f

--- a/entities/li/line.yaml
+++ b/entities/li/line.yaml
@@ -12,6 +12,7 @@ entity:
 profile:
   description: LINE is a communication app that provides free voice calls and messages, alongside additional services.
   summary: LINE operates a messaging platform and related services, including a startup program for selected companies.
+  links: {}
 sources:
   - source_id: src_3e9fb71f5dc2cf6b943434af6f7726a5d84f78f7279b30404f574aea5f2c444b
     url: https://www.line.me/en/
@@ -48,5 +49,6 @@ offers:
       availability: public
       method: form
       url: https://linescaleup.landpress.line.me/home/
+    economics: {}
     source_ids:
       - src_08a214e652980d1ac6ad8f41ad3932b9abadd2096ac03636441b8775a4ba736f

--- a/entities/li/line.yaml
+++ b/entities/li/line.yaml
@@ -12,7 +12,8 @@ entity:
 profile:
   description: LINE is a communication app that provides free voice calls and messages, alongside additional services.
   summary: LINE operates a messaging platform and related services, including a startup program for selected companies.
-  links: {}
+  links:
+    site: https://www.line.me/en/
 sources:
   - source_id: src_3e9fb71f5dc2cf6b943434af6f7726a5d84f78f7279b30404f574aea5f2c444b
     url: https://www.line.me/en/
@@ -49,6 +50,13 @@ offers:
       availability: public
       method: form
       url: https://linescaleup.landpress.line.me/home/
-    economics: {}
+    economics:
+      consideration:
+        kind: unknown
+        description: The public program page does not establish separate consideration for applicants.
+      benefits:
+        - benefit_id: ben_primary
+          description: Access to LINE platform resources for selected startups.
+          kind: other
     source_ids:
       - src_08a214e652980d1ac6ad8f41ad3932b9abadd2096ac03636441b8775a4ba736f

--- a/entities/li/line.yaml
+++ b/entities/li/line.yaml
@@ -53,10 +53,11 @@ offers:
     economics:
       consideration:
         kind: unknown
+        description: The public program page does not state separate consideration for applicants.
       benefits:
         - benefit_id: ben_primary
           description: LINE Platform Credits, including Official Account and LINE ads credits.
-          kind: credit
+          kind: other
         - benefit_id: ben_expert_support
           description: Support by LINE Experts, including API, technical, and business consultation.
           kind: other

--- a/entities/li/line.yaml
+++ b/entities/li/line.yaml
@@ -54,6 +54,9 @@ offers:
       consideration:
         kind: unknown
         description: No consideration is stated in the cited public program source.
-      benefits: []
+      benefits:
+        - benefit_id: ben_primary
+          description: LINE Platform Credits, including Official Account and LINE ads credits.
+          kind: other
     source_ids:
       - src_08a214e652980d1ac6ad8f41ad3932b9abadd2096ac03636441b8775a4ba736f

--- a/entities/li/line.yaml
+++ b/entities/li/line.yaml
@@ -12,8 +12,6 @@ entity:
 profile:
   description: LINE is a communication app that provides free voice calls and messages, alongside additional services.
   summary: LINE operates a messaging platform and related services, including a startup program for selected companies.
-  links:
-    site: https://linescaleup.landpress.line.me/home/
 sources:
   - source_id: src_3e9fb71f5dc2cf6b943434af6f7726a5d84f78f7279b30404f574aea5f2c444b
     url: https://www.line.me/en/
@@ -50,19 +48,5 @@ offers:
       availability: public
       method: form
       url: https://linescaleup.landpress.line.me/home/
-    economics:
-      consideration:
-        kind: unknown
-        description: The public program page does not state separate consideration for applicants.
-      benefits:
-        - benefit_id: ben_primary
-          description: LINE Platform Credits, including Official Account and LINE ads credits.
-          kind: other
-        - benefit_id: ben_expert_support
-          description: Support by LINE Experts, including API, technical, and business consultation.
-          kind: other
-        - benefit_id: ben_partnership
-          description: Strategic partnerships and investment opportunities with LINE and its affiliates.
-          kind: other
     source_ids:
       - src_08a214e652980d1ac6ad8f41ad3932b9abadd2096ac03636441b8775a4ba736f

--- a/entities/li/line.yaml
+++ b/entities/li/line.yaml
@@ -13,7 +13,7 @@ profile:
   description: LINE is a communication app that provides free voice calls and messages, alongside additional services.
   summary: LINE operates a messaging platform and related services, including a startup program for selected companies.
   links:
-    site: https://www.line.me/en/
+    site: https://linescaleup.landpress.line.me/home/
 sources:
   - source_id: src_3e9fb71f5dc2cf6b943434af6f7726a5d84f78f7279b30404f574aea5f2c444b
     url: https://www.line.me/en/
@@ -41,7 +41,7 @@ offers:
       rule:
         kind: manual
         criterion_id: cri_01
-        statement: Seed to Series A startup with a validated product idea, proven business model, solid traction and revenue base, aligned with LINE's focus areas and ecosystem.
+        statement: Seed to Series A startups with validated product ideas, a proven business model, and solid traction and revenue base.
         reason: external-verification
     roles:
       terms_authority_entity_id: ent_01kzs0r8sw096nns8690g0m1qa
@@ -53,10 +53,15 @@ offers:
     economics:
       consideration:
         kind: unknown
-        description: The public program page does not establish separate consideration for applicants.
       benefits:
         - benefit_id: ben_primary
-          description: Access to LINE platform resources for selected startups.
+          description: LINE Platform Credits, including Official Account and LINE ads credits.
+          kind: credit
+        - benefit_id: ben_expert_support
+          description: Support by LINE Experts, including API, technical, and business consultation.
+          kind: other
+        - benefit_id: ben_partnership
+          description: Strategic partnerships and investment opportunities with LINE and its affiliates.
           kind: other
     source_ids:
       - src_08a214e652980d1ac6ad8f41ad3932b9abadd2096ac03636441b8775a4ba736f

--- a/entities/li/line.yaml
+++ b/entities/li/line.yaml
@@ -12,7 +12,8 @@ entity:
 profile:
   description: LINE is a communication app that provides free voice calls and messages, alongside additional services.
   summary: LINE operates a messaging platform and related services, including a startup program for selected companies.
-  links: {}
+  links:
+    site: https://www.line.me/en/
 sources:
   - source_id: src_3e9fb71f5dc2cf6b943434af6f7726a5d84f78f7279b30404f574aea5f2c444b
     url: https://www.line.me/en/
@@ -49,6 +50,10 @@ offers:
       availability: public
       method: form
       url: https://linescaleup.landpress.line.me/home/
-    economics: {}
+    economics:
+      consideration:
+        kind: unknown
+        description: No consideration is stated in the cited public program source.
+      benefits: []
     source_ids:
       - src_08a214e652980d1ac6ad8f41ad3932b9abadd2096ac03636441b8775a4ba736f

--- a/entities/li/line.yaml
+++ b/entities/li/line.yaml
@@ -11,8 +11,7 @@ entity:
   category: communication
 profile:
   description: LINE is a communication app that provides free voice calls and messages, alongside additional services.
-  links:
-    site: https://www.line.me/en/
+  summary: LINE operates a messaging platform and related services, including a startup program for selected companies.
 sources:
   - source_id: src_3e9fb71f5dc2cf6b943434af6f7726a5d84f78f7279b30404f574aea5f2c444b
     url: https://www.line.me/en/
@@ -36,20 +35,6 @@ offers:
     lifecycle:
       status: active
       effective_from: 2026-08-11T19:05:00.000Z
-    economics:
-      benefits:
-        - benefit_id: ben_01
-          description: One-year package valued at up to THB 4 million (USD 120,000), including Official Account and LINE ads credits
-          kind: other
-        - benefit_id: ben_02
-          description: API, technical, and business consultation from LINE experts
-          kind: other
-        - benefit_id: ben_03
-          description: Opportunities for strategic partnership and potential investment by LINE and its affiliates
-          kind: other
-      consideration:
-        kind: unknown
-        description: The public program page does not establish separate consideration.
     eligibility:
       rule:
         kind: manual


### PR DESCRIPTION
Re-authors the LINE SCALE UP contribution from closed PR #435 using the current canonical Entity schema introduced by the vendors-to-entities cutover.\n\n- Adds one data-only record at entities/li/line.yaml\n- Preserves the original stable Entity, Program, Offer, and source IDs\n- Uses only LINE-owned public sources\n- Pinned local Catalog Verifier: valid (1 entity, 1 program, 1 offer)\n- DCO sign-off included\n\nCloses #434