### PR TITLE
data: add Zimt startup discount offer

### DIFF
--- a/entities/zi/zimt.yaml
+++ b/entities/zi/zimt.yaml
@@ -1,0 +1,121 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m14ky8dz0cx7zf1jq4tr5fw6
+  slug: zimt
+  slug_aliases: []
+  name: Zimt
+  domains:
+    - value: zimt.ai
+      role: primary
+      valid_from: 2026-08-28T16:41:09.000Z
+  category: data-analytics
+profile:
+  description: Zimt provides competitive and account intelligence software for monitoring market activity and analyzing wins, losses, and churn.
+  links:
+    site: https://www.zimt.ai
+sources:
+  - source_id: src_fc9d635aa88b952fd298a71898c348f9781fb63d191aacd05038aadd86f3f46b
+    url: https://www.zimt.ai/startup-program
+programs:
+  - program_id: prg_01m14ky8dzqy4wvsv9xbspqkeg
+    program_slug: zimt-startup-program
+    program_slug_aliases: []
+    title: Zimt Startup Program
+    summary: Zimt offers eligible early-stage B2B teams decreasing discounts on Signals+ annual plans for their first three years.
+    source_ids:
+      - src_fc9d635aa88b952fd298a71898c348f9781fb63d191aacd05038aadd86f3f46b
+offers:
+  - offer_id: off_01m14ky8dz11c3pqxy9je2hv14
+    program_id: prg_01m14ky8dzqy4wvsv9xbspqkeg
+    offer_slug: signals-plus-three-year-startup-discount
+    offer_slug_aliases: []
+    title: Zimt Signals+ Three-Year Startup Discount
+    summary: Eligible startups receive 60% off Signals+ in year one, 40% off in year two, and 30% off in year three when purchasing annual plans.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-28T16:41:09.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          applies_to: Zimt Signals+ annual plans
+          description: 60% off a Signals+ annual plan in the first year.
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            basis_points: 6000
+            kind: exact
+        - benefit_id: ben_02
+          applies_to: Zimt Signals+ annual plans
+          description: 40% off a Signals+ annual plan in the second year.
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            basis_points: 4000
+            kind: exact
+        - benefit_id: ben_03
+          applies_to: Zimt Signals+ annual plans
+          description: 30% off a Signals+ annual plan in the third year.
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            basis_points: 3000
+            kind: exact
+      consideration:
+        kind: variable
+        description: Purchase a Signals+ annual plan at the applicable discounted price.
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lte
+            statement: Company must have raised no more than USD 2 million
+            value:
+              type: number
+              value: 2000000
+          - criterion_id: cri_02
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: Company must be under five years old
+            value:
+              type: number
+              value: 60
+          - criterion_id: cri_03
+            fact: company.employee_count
+            kind: predicate
+            operator: lt
+            statement: Company must have fewer than 50 employees
+            value:
+              type: number
+              value: 50
+          - criterion_id: cri_04
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: Applicant must not currently be a Zimt customer
+            value:
+              type: boolean
+              value: false
+          - criterion_id: cri_05
+            kind: manual
+            reason: external-verification
+            statement: Applicant must apply within 90 days of signing up
+    roles:
+      terms_authority_entity_id: ent_01m14ky8dz0cx7zf1jq4tr5fw6
+      access_operator_entity_id: ent_01m14ky8dz0cx7zf1jq4tr5fw6
+    access:
+      availability: public
+      method: form
+      url: https://www.zimt.ai/startup-program
+    terms_url: https://www.zimt.ai/startup-program
+    source_ids:
+      - src_fc9d635aa88b952fd298a71898c348f9781fb63d191aacd05038aadd86f3f46b


### PR DESCRIPTION
## What changed\n\nAdds Zimt and records the three-year Signals+ startup discount with its published economics, eligibility, lifecycle, and application route.\n\nCloses #892\n\n## Sources\n\n- https://www.zimt.ai/startup-program\n\n## Certification\n\n- [x] I changed only allowed repository content and did not mix Entity YAML with other paths.\n- [x] Public sources substantiate every submitted factual value; any Sourcey-written prose is a neutral summary, not a fabricated vendor quote.\n- [x] I did not author verification, provenance, freshness, or signature claims.\n- [x] My commits include a Signed-off-by line.