### PR TITLE
data: add AnnounceKit startup discount offer

### DIFF
--- a/entities/an/announcekit.yaml
+++ b/entities/an/announcekit.yaml
@@ -1,0 +1,93 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m14ky8dz6ewr5n84zeq11atk
+  slug: announcekit
+  slug_aliases: []
+  name: AnnounceKit
+  domains:
+    - value: announcekit.app
+      role: primary
+      valid_from: 2026-08-28T16:41:09.000Z
+  category: communication
+profile:
+  description: AnnounceKit provides changelogs, release notes, product announcements, in-app widgets, notifications, feedback, and integrations for software teams.
+  links:
+    site: https://announcekit.app
+sources:
+  - source_id: src_e9f126c58daa831848dd3635a12dcfa4709b322a68734eb18f8759472bbeabf2
+    url: https://announcekit.app/startup
+programs:
+  - program_id: prg_01m14ky8dz07ghq5j1h4hhwcms
+    program_slug: announcekit-startup-program
+    program_slug_aliases: []
+    title: AnnounceKit Startup Program
+    summary: AnnounceKit offers qualifying early-stage product companies half-price access to any plan for their first year.
+    source_ids:
+      - src_e9f126c58daa831848dd3635a12dcfa4709b322a68734eb18f8759472bbeabf2
+offers:
+  - offer_id: off_01m14ky8dz5q4t0a155pbrk38d
+    program_id: prg_01m14ky8dz07ghq5j1h4hhwcms
+    offer_slug: fifty-percent-off-any-plan
+    offer_slug_aliases: []
+    title: 50% Off Any AnnounceKit Plan for 12 Months
+    summary: Eligible early-stage product companies receive 50% off AnnounceKit Essentials, Growth, or Scale for 12 months, with all plan features included.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-28T16:41:09.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          applies_to: AnnounceKit Essentials, Growth, or Scale
+          description: 50% off any AnnounceKit plan for the first 12 months.
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            basis_points: 5000
+            kind: exact
+      consideration:
+        kind: variable
+        description: Purchase an AnnounceKit plan at half of its listed price during the discount period.
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.employee_count
+            kind: predicate
+            operator: lt
+            statement: Company must have fewer than five employees, including founders and part-time team members
+            value:
+              type: number
+              value: 5
+          - criterion_id: cri_02
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: Company must have been incorporated within the last 24 months
+            value:
+              type: number
+              value: 24
+          - criterion_id: cri_03
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lte
+            statement: Company must have raised no more than USD 1 million; bootstrapped companies qualify
+            value:
+              type: number
+              value: 1000000
+          - criterion_id: cri_04
+            kind: manual
+            reason: external-verification
+            statement: Company must have a live product or a product in active development
+    roles:
+      terms_authority_entity_id: ent_01m14ky8dz6ewr5n84zeq11atk
+      access_operator_entity_id: ent_01m14ky8dz6ewr5n84zeq11atk
+    access:
+      availability: public
+      method: contact
+      url: https://announcekit.app/startup
+    terms_url: https://announcekit.app/startup
+    source_ids:
+      - src_e9f126c58daa831848dd3635a12dcfa4709b322a68734eb18f8759472bbeabf2


### PR DESCRIPTION
## What changed\n\nAdds AnnounceKit and records the 12-month startup discount with its published economics, eligibility, lifecycle, and email application route.\n\nCloses #893\n\n## Sources\n\n- https://announcekit.app/startup\n\n## Certification\n\n- [x] I changed only allowed repository content and did not mix Entity YAML with other paths.\n- [x] Public sources substantiate every submitted factual value; any Sourcey-written prose is a neutral summary, not a fabricated vendor quote.\n- [x] I did not author verification, provenance, freshness, or signature claims.\n- [x] My commits include a Signed-off-by line.