### PR TITLE
data: add Evidently AI entity record

### DIFF
--- a/entities/ev/evidently-ai.yaml
+++ b/entities/ev/evidently-ai.yaml
@@ -1,0 +1,101 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m15djdfn8r2rtg7pbkew9j26
+  slug: evidently-ai
+  slug_aliases: []
+  name: Evidently AI
+  domains:
+    - value: evidentlyai.com
+      role: primary
+      valid_from: 2026-08-29T00:09:12.527Z
+  category: observability
+profile:
+  description: Evidently AI provides tools to evaluate, test, and monitor AI-powered products, including LLM and machine-learning systems.
+  links:
+    site: https://www.evidentlyai.com
+sources:
+  - source_id: src_f8c9fa05a204a32ec8cb101c0e4b3491482853660ee82f5de186b559865b3730
+    url: https://www.evidentlyai.com/sign-up-startups
+programs:
+  - program_id: prg_01m15djdg14azkhj6sggdc4xj9
+    program_slug: evidently-cloud-for-ai-startups
+    program_slug_aliases: []
+    title: Evidently Cloud for AI startups
+    summary: Evidently AI's startup program offers qualifying technology startups core AI evaluation features, Expert tier credits, testing tools, and priority support.
+    source_ids:
+      - src_f8c9fa05a204a32ec8cb101c0e4b3491482853660ee82f5de186b559865b3730
+offers:
+  - offer_id: off_01m15djdg2x8r3p76jkr868k7t
+    program_id: prg_01m15djdg14azkhj6sggdc4xj9
+    offer_slug: evidently-cloud-startup-offer
+    offer_slug_aliases: []
+    title: Evidently Cloud startup offer
+    summary: Qualifying AI startups get core evaluation features, up to 90% off the Expert tier for 6 months via free credits, synthetic-data and agent-testing access, and priority support.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-29T00:09:12.527Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Access to all core AI evaluation features.
+          kind: other
+        - benefit_id: ben_02
+          applies_to: Evidently Expert tier
+          description: Free credits worth up to a 90% discount on the Expert tier for 6 months.
+          kind: discount
+          percentage:
+            basis_points: 9000
+            kind: up-to
+          duration:
+            kind: exact
+            value: P6M
+        - benefit_id: ben_03
+          description: Full access to synthetic data and agent testing.
+          kind: other
+        - benefit_id: ben_04
+          description: Priority support with direct access to Evidently engineers.
+          kind: other
+      consideration:
+        kind: unknown
+        description: The startup page does not publish the Expert tier price or the free-credit amount.
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: Applicant is a technology startup.
+          - kind: any
+            rules:
+              - criterion_id: cri_02
+                fact: company.age_months
+                kind: predicate
+                operator: lt
+                statement: Company is less than 2 years old.
+                value:
+                  type: number
+                  value: 24
+              - criterion_id: cri_03
+                fact: company.funding_raised_usd
+                kind: predicate
+                operator: lt
+                statement: Company has raised less than $5 million in funding.
+                value:
+                  type: number
+                  value: 5000000
+          - criterion_id: cri_04
+            kind: manual
+            reason: external-verification
+            statement: Applicant has signed up for a free Evidently account before applying.
+    roles:
+      terms_authority_entity_id: ent_01m15djdfn8r2rtg7pbkew9j26
+      access_operator_entity_id: ent_01m15djdfn8r2rtg7pbkew9j26
+    access:
+      availability: public
+      method: form
+      url: https://www.evidentlyai.com/sign-up-startups
+    terms_url: https://www.evidentlyai.com/sign-up-startups
+    source_ids:
+      - src_f8c9fa05a204a32ec8cb101c0e4b3491482853660ee82f5de186b559865b3730
+

--- a/entities/ev/evidently-ai.yaml
+++ b/entities/ev/evidently-ai.yaml
@@ -38,11 +38,11 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: Evidently Cloud includes all core AI evaluation features.
+          description: All core AI evaluation features.
           kind: other
         - benefit_id: ben_02
           applies_to: Expert tier
-          description: Free credits toward the Expert tier provide up to a 90% discount for 6 months.
+          description: Free credits toward the Expert tier, up to a 90% discount for 6 months.
           kind: discount
           percentage:
             basis_points: 9000
@@ -54,41 +54,17 @@ offers:
           description: Full access to synthetic data and agent testing.
           kind: other
         - benefit_id: ben_04
-          description: Priority support provides direct access to Evidently engineers.
+          description: Priority support with direct access to engineers.
           kind: other
       consideration:
         kind: variable
-        description: The applicant pays the remaining Expert tier price after the free credits are applied.
+        description: The Expert tier offer is an up to 90% discount for 6 months.
     eligibility:
       rule:
-        kind: all
-        rules:
-          - criterion_id: cri_01
-            kind: manual
-            reason: external-verification
-            statement: Applicant is a technology startup.
-          - kind: any
-            rules:
-              - criterion_id: cri_02
-                fact: company.age_months
-                kind: predicate
-                operator: lt
-                statement: Company is less than 2 years old.
-                value:
-                  type: number
-                  value: 24
-              - criterion_id: cri_03
-                fact: company.funding_raised_usd
-                kind: predicate
-                operator: lt
-                statement: Company has raised less than $5 million in funding.
-                value:
-                  type: number
-                  value: 5000000
-          - criterion_id: cri_04
-            kind: manual
-            reason: external-verification
-            statement: Applicant has signed up for a free Evidently account before applying.
+        criterion_id: cri_01
+        kind: manual
+        reason: external-verification
+        statement: Applicant must sign up for a free account before applying, and the company must be a tech startup less than 2 years old or have raised less than $5 million in funding.
     roles:
       terms_authority_entity_id: ent_01m15djdfn8r2rtg7pbkew9j26
       access_operator_entity_id: ent_01m15djdfn8r2rtg7pbkew9j26

--- a/entities/ev/evidently-ai.yaml
+++ b/entities/ev/evidently-ai.yaml
@@ -42,7 +42,7 @@ offers:
           kind: other
         - benefit_id: ben_02
           applies_to: Expert tier
-          description: "Free credits towards Expert tier: Up to 90% discount for 6 months."
+          description: Up to 90% discount for 6 months.
           kind: discount
           percentage:
             basis_points: 9000
@@ -54,7 +54,7 @@ offers:
           description: Full access to synthetic data and agent testing.
           kind: other
         - benefit_id: ben_04
-          description: "Priority support: Direct access to engineers to help you build faster."
+          description: Priority support.
           kind: other
       consideration:
         kind: variable

--- a/entities/ev/evidently-ai.yaml
+++ b/entities/ev/evidently-ai.yaml
@@ -72,4 +72,3 @@ offers:
     terms_url: https://www.evidentlyai.com/sign-up-startups
     source_ids:
       - src_f8c9fa05a204a32ec8cb101c0e4b3491482853660ee82f5de186b559865b3730
-

--- a/entities/ev/evidently-ai.yaml
+++ b/entities/ev/evidently-ai.yaml
@@ -53,9 +53,6 @@ offers:
         - benefit_id: ben_03
           description: Full access to synthetic data and agent testing.
           kind: other
-        - benefit_id: ben_04
-          description: Priority support.
-          kind: other
       consideration:
         kind: variable
         description: Up to 90% discount for 6 months.

--- a/entities/ev/evidently-ai.yaml
+++ b/entities/ev/evidently-ai.yaml
@@ -42,7 +42,7 @@ offers:
           kind: other
         - benefit_id: ben_02
           applies_to: Expert tier
-          description: Free credits toward the Expert tier, up to a 90% discount for 6 months.
+          description: Free credits towards Expert tier, up to 90% discount for 6 months.
           kind: discount
           percentage:
             basis_points: 9000
@@ -54,11 +54,11 @@ offers:
           description: Full access to synthetic data and agent testing.
           kind: other
         - benefit_id: ben_04
-          description: Priority support with direct access to engineers.
+          description: Priority support with direct access to engineers to help you build faster.
           kind: other
       consideration:
         kind: variable
-        description: The Expert tier offer is an up to 90% discount for 6 months.
+        description: Up to 90% discount for 6 months.
     eligibility:
       rule:
         criterion_id: cri_01

--- a/entities/ev/evidently-ai.yaml
+++ b/entities/ev/evidently-ai.yaml
@@ -42,7 +42,7 @@ offers:
           kind: other
         - benefit_id: ben_02
           applies_to: Expert tier
-          description: Free credits towards Expert tier, up to 90% discount for 6 months.
+          description: "Free credits towards Expert tier: Up to 90% discount for 6 months."
           kind: discount
           percentage:
             basis_points: 9000
@@ -54,7 +54,7 @@ offers:
           description: Full access to synthetic data and agent testing.
           kind: other
         - benefit_id: ben_04
-          description: Priority support with direct access to engineers to help you build faster.
+          description: "Priority support: Direct access to engineers to help you build faster."
           kind: other
       consideration:
         kind: variable

--- a/entities/ev/evidently-ai.yaml
+++ b/entities/ev/evidently-ai.yaml
@@ -10,6 +10,7 @@ entity:
       valid_from: 2026-08-29T00:09:12.527Z
   category: observability
 profile:
+  summary: Evidently AI helps teams evaluate, test, and monitor AI-powered products.
   description: Evidently AI provides tools to evaluate, test, and monitor AI-powered products, including LLM and machine-learning systems.
   links:
     site: https://www.evidentlyai.com
@@ -37,11 +38,11 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: Access to all core AI evaluation features.
+          description: Evidently Cloud includes all core AI evaluation features.
           kind: other
         - benefit_id: ben_02
-          applies_to: Evidently Expert tier
-          description: Free credits worth up to a 90% discount on the Expert tier for 6 months.
+          applies_to: Expert tier
+          description: Free credits toward the Expert tier provide up to a 90% discount for 6 months.
           kind: discount
           percentage:
             basis_points: 9000
@@ -53,11 +54,11 @@ offers:
           description: Full access to synthetic data and agent testing.
           kind: other
         - benefit_id: ben_04
-          description: Priority support with direct access to Evidently engineers.
+          description: Priority support provides direct access to Evidently engineers.
           kind: other
       consideration:
-        kind: unknown
-        description: The startup page does not publish the Expert tier price or the free-credit amount.
+        kind: variable
+        description: The applicant pays the remaining Expert tier price after the free credits are applied.
     eligibility:
       rule:
         kind: all


### PR DESCRIPTION
## What changed

Adds Evidently AI and its current Evidently Cloud for AI startups program using the canonical Entity authoring schema.

This replaces the closed schema-obsolete attempt in #674. The record now lives at `entities/ev/evidently-ai.yaml`, uses fresh IDs, and follows the current `sourcey.entity-authoring/v1alpha1` shape.

Closes #672

## Sources

- https://www.evidentlyai.com/sign-up-startups

## Validation

- [x] Pinned Sourcey Catalog Verifier `validate-change`
- [x] `git diff --check`
- [x] Signed off under the DCO

## Certification

- [x] I changed only allowed repository content and did not mix Entity YAML with other paths.
- [x] Public sources substantiate every submitted factual value; any Sourcey-written prose is a neutral summary, not a fabricated vendor quote.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commits include a `Signed-off-by` line.