### PR TITLE
data: add Shakebug startup plan

### DIFF
--- a/entities/sh/shakebug.yaml
+++ b/entities/sh/shakebug.yaml
@@ -1,0 +1,70 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m16c6h0z57w6b1chbvx7ftev
+  slug: shakebug
+  slug_aliases: []
+  name: Shakebug
+  domains:
+    - value: shakebug.com
+      role: primary
+      valid_from: 2026-08-29T00:00:00Z
+  category: observability
+profile:
+  description: Shakebug provides crash reporting, session journeys, product analytics, and bug reporting for mobile and web applications.
+  links:
+    site: https://www.shakebug.com
+sources:
+  - source_id: src_b900d049b32449064754656b7ca74e84636c730ea7c68ab1b2b451f71d1fd4fa
+    url: https://www.shakebug.com/startups
+programs:
+  - program_id: prg_01m16c6h28ce3pbk0kzne145t0
+    program_slug: shakebug-startup-plan
+    program_slug_aliases: []
+    title: Shakebug Startup Plan
+    summary: Shakebug offers qualifying early-stage teams its Premium plan for USD 20 per month during their first 12 months.
+    source_ids:
+      - src_b900d049b32449064754656b7ca74e84636c730ea7c68ab1b2b451f71d1fd4fa
+offers:
+  - offer_id: off_01m16c6h29jev5wykp358xwas6
+    program_id: prg_01m16c6h28ce3pbk0kzne145t0
+    offer_slug: premium-for-20-usd-per-month-first-year
+    offer_slug_aliases: []
+    title: Premium for USD 20 per month for 12 months
+    summary: Eligible startups receive the full Shakebug Premium plan for USD 20 per month for 12 months instead of the published USD 125 monthly price.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-29T00:00:00Z
+    economics:
+      consideration:
+        kind: fixed
+        amount:
+          currency: USD
+          minor_units: 2000
+      benefits:
+        - benefit_id: ben_01
+          applies_to: Shakebug Premium
+          description: Access to the full Premium plan for USD 20 per month instead of USD 125 per month during the first year.
+          kind: discount
+          percentage:
+            kind: exact
+            basis_points: 8400
+          duration:
+            kind: exact
+            value: P1Y
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: vendor-discretion
+        statement: The company must have been founded within five years, operate independently, have 15 or fewer team members, and be actively building a real product.
+    roles:
+      terms_authority_entity_id: ent_01m16c6h0z57w6b1chbvx7ftev
+      access_operator_entity_id: ent_01m16c6h0z57w6b1chbvx7ftev
+    access:
+      availability: public
+      instructions: Complete the Startup Plan application. Shakebug says applications are reviewed within two to three business days and no credit card is required to apply.
+      method: form
+      url: https://www.shakebug.com/startups
+    terms_url: https://www.shakebug.com/startups
+    source_ids:
+      - src_b900d049b32449064754656b7ca74e84636c730ea7c68ab1b2b451f71d1fd4fa


### PR DESCRIPTION
## What changed

Adds the Shakebug Entity and one Startup Plan offer for the full Premium plan at USD 20 per month for 12 months, with the published USD 125 monthly price and current eligibility and application details.

Resolves #936.

## Sources

- https://www.shakebug.com/startups

## Certification

- [x] I changed only allowed repository content and did not mix Entity YAML with other paths.
- [x] Public sources substantiate every submitted factual value; any Sourcey-written prose is a neutral summary, not a fabricated vendor quote.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commits include a `Signed-off-by` line.
