### PR TITLE
data: add NerveMind AI startup program

### DIFF
--- a/entities/ne/nervemind-ai.yaml
+++ b/entities/ne/nervemind-ai.yaml
@@ -1,0 +1,72 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m16c6h29v99bcpzp84pfr599
+  slug: nervemind-ai
+  slug_aliases: []
+  name: NerveMind AI
+  domains:
+    - value: nervemindos.com
+      role: primary
+      valid_from: 2026-08-29T00:00:00Z
+  category: legal-compliance
+profile:
+  description: NerveMind AI provides a governed runtime control plane for autonomous operations, multi-agent systems, and enterprise AI governance.
+  links:
+    site: https://nervemindos.com
+sources:
+  - source_id: src_72fc75bc200be043fe2c8aebbe6052666c25fc57ca62fbf2cc26be4b6b69f1aa
+    url: https://nervemindos.com/startup-program
+  - source_id: src_d28b4bfd13e6fcfc6fbd52db1740926b6800f60d29921475a0b40ebf7827ae49
+    url: https://nervemindos.com/startup-program/apply
+programs:
+  - program_id: prg_01m16c6h29xtxpatevgmwd0zgc
+    program_slug: nervemind-cgos-startup-program
+    program_slug_aliases: []
+    title: NerveMind CGOS Startup Program
+    summary: NerveMind offers approved AI startups and small businesses 50% off an eligible self-serve CGOS plan for 12 months.
+    source_ids:
+      - src_72fc75bc200be043fe2c8aebbe6052666c25fc57ca62fbf2cc26be4b6b69f1aa
+      - src_d28b4bfd13e6fcfc6fbd52db1740926b6800f60d29921475a0b40ebf7827ae49
+offers:
+  - offer_id: off_01m16c6h2ad1v2qfrgz6hsdjdy
+    program_id: prg_01m16c6h29xtxpatevgmwd0zgc
+    offer_slug: 50-percent-off-cgos-for-12-months
+    offer_slug_aliases: []
+    title: 50% off a CGOS plan for 12 months
+    summary: Approved applicants receive 50% off one eligible self-serve NerveMind CGOS plan and billing interval for 12 months.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-29T00:00:00Z
+    economics:
+      consideration:
+        kind: variable
+        description: The approved startup pays the remaining discounted price of its selected eligible self-serve CGOS plan and billing interval.
+      benefits:
+        - benefit_id: ben_01
+          applies_to: One eligible self-serve CGOS plan and billing interval selected at checkout
+          description: 50% off one eligible self-serve CGOS plan and billing interval for 12 months.
+          kind: discount
+          percentage:
+            kind: exact
+            basis_points: 5000
+          duration:
+            kind: exact
+            value: P1Y
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: vendor-discretion
+        statement: Applicants must be early-stage startups or small businesses building AI-enabled products; NerveMind generally considers annual revenue up to USD 1 million and reviews applications individually while capacity remains.
+    roles:
+      terms_authority_entity_id: ent_01m16c6h29v99bcpzp84pfr599
+      access_operator_entity_id: ent_01m16c6h29v99bcpzp84pfr599
+    access:
+      availability: public
+      instructions: Complete the NerveMind Startup Program application for individual review. The program is limited to the first 50 approved applicants.
+      method: form
+      url: https://nervemindos.com/startup-program/apply
+    terms_url: https://nervemindos.com/startup-program
+    source_ids:
+      - src_72fc75bc200be043fe2c8aebbe6052666c25fc57ca62fbf2cc26be4b6b69f1aa
+      - src_d28b4bfd13e6fcfc6fbd52db1740926b6800f60d29921475a0b40ebf7827ae49


### PR DESCRIPTION
## What changed
Adds NerveMind AI and one Startup Program offer providing approved AI startups and small businesses 50% off one eligible self-serve CGOS plan and billing interval for 12 months.

Resolves #937.

## Sources
- https://nervemindos.com/startup-program
- https://nervemindos.com/startup-program/apply

## Certification
- [x] I changed only allowed repository content and did not mix Entity YAML with other paths.
- [x] Public sources substantiate every submitted factual value; any Sourcey-written prose is a neutral summary, not a fabricated vendor quote.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commits include a `Signed-off-by` line.