### PR TITLE
data: add PentestPad founder discount

### DIFF
--- a/entities/pe/pentestpad.yaml
+++ b/entities/pe/pentestpad.yaml
@@ -1,0 +1,68 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m16c6h2cbqvdm39cr32fex9q
+  slug: pentestpad
+  slug_aliases: []
+  name: PentestPad
+  domains:
+    - value: pentestpad.com
+      role: primary
+      valid_from: 2026-08-29T00:00:00Z
+  category: auth-security
+profile:
+  description: PentestPad provides a collaborative workspace for penetration-testing teams to manage projects, evidence, findings, and reports.
+  links:
+    site: https://www.pentestpad.com
+sources:
+  - source_id: src_8274e727f25fb9abf863b243ed46a5bb449d14e46d629fc9ca7582d9d333ba2e
+    url: https://www.pentestpad.com/startup
+programs:
+  - program_id: prg_01m16c6h2dzm525r02gk3dzhfc
+    program_slug: pentestpad-founder-discount
+    program_slug_aliases: []
+    title: PentestPad Founder Discount
+    summary: PentestPad offers qualifying cybersecurity startups 50% off their first year, with the licenses they need included.
+    source_ids:
+      - src_8274e727f25fb9abf863b243ed46a5bb449d14e46d629fc9ca7582d9d333ba2e
+offers:
+  - offer_id: off_01m16c6h2dwh6fpfnfbpmep1cr
+    program_id: prg_01m16c6h2dzm525r02gk3dzhfc
+    offer_slug: 50-percent-founder-discount-first-year
+    offer_slug_aliases: []
+    title: 50% off PentestPad for the first year
+    summary: Eligible cybersecurity startups receive a 50% Founder Discount for their first year with the number of licenses they need.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-29T00:00:00Z
+    economics:
+      consideration:
+        kind: variable
+        description: The approved startup pays the remaining discounted price for its PentestPad subscription and required licenses.
+      benefits:
+        - benefit_id: ben_01
+          applies_to: PentestPad subscription and required licenses
+          description: 50% off the first year of PentestPad with the number of licenses the startup needs.
+          kind: discount
+          percentage:
+            kind: exact
+            basis_points: 5000
+          duration:
+            kind: exact
+            value: P1Y
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: vendor-discretion
+        statement: The applicant must be a cybersecurity startup founded within the last five years, be pre-seed, seed-funded, or bootstrapped, and build a security product or service.
+    roles:
+      terms_authority_entity_id: ent_01m16c6h2cbqvdm39cr32fex9q
+      access_operator_entity_id: ent_01m16c6h2cbqvdm39cr32fex9q
+    access:
+      availability: public
+      instructions: Submit the Founder Discount application. PentestPad states that it normally replies within three to five business days.
+      method: form
+      url: https://www.pentestpad.com/startup
+    terms_url: https://www.pentestpad.com/startup
+    source_ids:
+      - src_8274e727f25fb9abf863b243ed46a5bb449d14e46d629fc9ca7582d9d333ba2e


### PR DESCRIPTION
## What changed
Adds PentestPad and one Founder Discount offer providing eligible cybersecurity startups 50% off their first year with the licenses they need.

Resolves #939.

## Sources
- https://www.pentestpad.com/startup

## Certification
- [x] I changed only allowed repository content and did not mix Entity YAML with other paths.
- [x] Public sources substantiate every submitted factual value; any Sourcey-written prose is a neutral summary, not a fabricated vendor quote.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commits include a `Signed-off-by` line.