### PR TITLE
data: add Atlasflow startup program

### DIFF
--- a/entities/at/atlasflow.yaml
+++ b/entities/at/atlasflow.yaml
@@ -1,0 +1,66 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m15rk2g53xbtn2wkgy8m8pb3
+  slug: atlasflow
+  slug_aliases: []
+  name: Atlasflow
+  domains:
+    - value: atlasflow.com
+      role: primary
+      valid_from: 2026-08-29T03:19:00.000Z
+  category: hosting-infra
+profile:
+  description: Atlasflow is a deployment platform that builds and runs each commit in an isolated microVM with published usage-based rates.
+  links:
+    site: https://atlasflow.com
+sources:
+  - source_id: src_d7e7d4daddcfd2875d5f03f73a6f3425cf58a39cbe1770e766f1ad03a53a01fb
+    url: https://atlasflow.com/startups
+programs:
+  - program_id: prg_01m15rk2g8p009a90bqb4anm4q
+    program_slug: atlasflow-for-startups
+    program_slug_aliases: []
+    title: Atlasflow for Startups
+    summary: Atlasflow for Startups offers eligible startups up to $10,000 in usage credits and a direct line to the founding team for deployment and debugging support.
+    source_ids:
+      - src_d7e7d4daddcfd2875d5f03f73a6f3425cf58a39cbe1770e766f1ad03a53a01fb
+offers:
+  - offer_id: off_01m15rk2g8w6kztn4t84w1t0c3
+    program_id: prg_01m15rk2g8p009a90bqb4anm4q
+    offer_slug: atlasflow-for-startups
+    offer_slug_aliases: []
+    title: Atlasflow for Startups usage credits
+    summary: Eligible startups receive up to $10,000 in Atlasflow usage credits plus a direct private channel with the founding team for deployment and debugging support.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-29T03:19:00.000Z
+    economics:
+      consideration:
+        kind: none
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $10,000 in Atlasflow usage credits; the approved amount and expiration date are confirmed by email.
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 1000000
+            kind: up-to
+        - benefit_id: ben_02
+          description: A private channel with the Atlasflow founding team for deployment and debugging support.
+          kind: other
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: vendor-discretion
+        statement: Applicant must be an eligible startup, submit the public application, and be approved by Atlasflow.
+    roles:
+      terms_authority_entity_id: ent_01m15rk2g53xbtn2wkgy8m8pb3
+      access_operator_entity_id: ent_01m15rk2g53xbtn2wkgy8m8pb3
+    access:
+      availability: public
+      method: form
+      url: https://atlasflow.com/startups
+    source_ids:
+      - src_d7e7d4daddcfd2875d5f03f73a6f3425cf58a39cbe1770e766f1ad03a53a01fb


### PR DESCRIPTION
## What changed

Adds Atlasflow as one new Entity with one named Atlasflow for Startups program and one current usage-credit offer.

- Data-only change at entities/at/atlasflow.yaml
- The offer records up to $10,000 in Atlasflow usage credits and the private founding-team deployment/debugging channel
- Eligibility and public application access are modeled from the first-party source
- Resolves #947

## Sources

- https://atlasflow.com/startups

## Certification

- [x] I changed only allowed repository content and did not mix Entity YAML with other paths.
- [x] Public sources substantiate every submitted factual value; Sourcey-written prose is a neutral summary.
- [x] I did not author verification, provenance, freshness, or signature claims in the Entity YAML.
- [x] The commit includes a Signed-off-by line.
- [x] The pinned Sourcey Catalog Verifier passed locally with one Entity, one Program, and one Offer.