### PR TITLE
fix(validation): check the echoed identity release field

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -106,7 +106,7 @@ jobs:
           jq -e \
             --arg release_id "$live_parent_release_id" \
             '.release_id == $release_id
-             and .data.query.live_parent_release_id == $release_id' \
+             and .data.query.liveParentReleaseId == $release_id' \
             "$RUNNER_TEMP/sourcey-identity-response.json" >/dev/null
           jq -e '.data' "$RUNNER_TEMP/sourcey-identity-response.json" \
             > "$RUNNER_TEMP/sourcey-identity-context.json"


### PR DESCRIPTION
## Summary

Fix the trusted workflow's identity-response assertion to read the echoed query field defined by the public Catalog Verifier contract.

`.data.query` uses `liveParentReleaseId`; the snake_case `live_parent_release_id` belongs to `.data.context`. The current missing-field lookup makes `jq -e` return 1 after the identity context is issued.

## Regression evidence

PRs #961, #964, #966, and #968 all target base commit `cd0f8f3` and fail at the same `Issue the exact bounded Catalog identity context` step. The public OpenAPI schema for `POST /v1/catalog-verifier/identity-contexts` requires `liveParentReleaseId` in the request and echoed `.data.query`.

## Validation

- `git diff --check`
- one file changed, one insertion, one deletion
- Signed-off-by included