### PR TITLE
feat(catalog): add AnveVoice startup offer

### DIFF
--- a/entities/an/anvevoice.yaml
+++ b/entities/an/anvevoice.yaml
@@ -1,0 +1,73 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m16y0htnnsq1kmzac26dgkzh
+  slug: anvevoice
+  slug_aliases: []
+  name: AnveVoice
+  domains:
+    - value: anvevoice.app
+      role: primary
+      valid_from: 2026-08-29T14:15:39.096Z
+  category: ai-ml
+profile:
+  description: AnveVoice provides embeddable voice AI agents and speech APIs for websites, including multilingual conversations and on-page actions.
+  links:
+    site: https://anvevoice.app
+sources:
+  - source_id: src_324ec1242dab6d5ba4cf29562b87373262255f1c2f09fc7cc47de3c5407e8a15
+    url: https://anvevoice.app/startups
+programs:
+  - program_id: prg_01m16y0htr5e7atav28vycxxpe
+    program_slug: anvevoice-for-startups
+    program_slug_aliases: []
+    title: AnveVoice for Startups
+    summary: AnveVoice offers qualifying startups three months free on the Growth plan followed by 50% off all plans for six months.
+    source_ids:
+      - src_324ec1242dab6d5ba4cf29562b87373262255f1c2f09fc7cc47de3c5407e8a15
+offers:
+  - offer_id: off_01m16y0htrqb8c0dbq60pj2s5t
+    program_id: prg_01m16y0htr5e7atav28vycxxpe
+    offer_slug: three-months-free-and-six-months-half-price
+    offer_slug_aliases: []
+    title: Three months free plus six months at 50% off
+    summary: Qualifying startups receive three free months on AnveVoice Growth and then 50% off any AnveVoice plan for six months.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-29T14:15:39.096Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Three months of free access to the AnveVoice Growth plan
+          duration:
+            kind: exact
+            value: P3M
+          kind: free-service
+          service: AnveVoice Growth plan
+        - benefit_id: ben_02
+          description: 50% off any AnveVoice plan for the following six months
+          duration:
+            kind: exact
+            value: P6M
+          kind: discount
+          percentage:
+            kind: exact
+            basis_points: 5000
+      consideration:
+        kind: variable
+        description: During the six-month discount period, the startup pays half the regular price of its selected AnveVoice plan.
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        statement: The applicant must be a qualifying startup approved by AnveVoice; the public program page does not specify additional criteria.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m16y0htnnsq1kmzac26dgkzh
+      access_operator_entity_id: ent_01m16y0htnnsq1kmzac26dgkzh
+    access:
+      availability: public
+      instructions: Follow the sign-up link on the official startup program page and submit the requested company details for review.
+      method: form
+      url: https://anvevoice.app/startups
+    source_ids:
+      - src_324ec1242dab6d5ba4cf29562b87373262255f1c2f09fc7cc47de3c5407e8a15

--- a/entities/an/anvevoice.yaml
+++ b/entities/an/anvevoice.yaml
@@ -19,6 +19,8 @@ sources:
     url: https://anvevoice.app/startups
   - source_id: src_89cc441d328586b2fd9924ba1b6d5eccf7991cdc8fb454d21c673bb89272523c
     url: https://anvevoice.app/llms.txt
+  - source_id: src_141f878fc5a13aca332edf211df02ae786f740c2bd1ad961653bd4ff8ac4745f
+    url: https://anvevoice.app/pricing
 programs:
   - program_id: prg_01m16y0htr5e7atav28vycxxpe
     program_slug: anvevoice-for-startups
@@ -56,8 +58,8 @@ offers:
             kind: exact
             basis_points: 5000
       consideration:
-        kind: unknown
-        description: The source record did not establish separate consideration.
+        kind: variable
+        description: During the six-month discount period, participants pay half of the selected plan's published price.
     eligibility:
       rule:
         criterion_id: cri_01
@@ -75,3 +77,4 @@ offers:
     source_ids:
       - src_324ec1242dab6d5ba4cf29562b87373262255f1c2f09fc7cc47de3c5407e8a15
       - src_89cc441d328586b2fd9924ba1b6d5eccf7991cdc8fb454d21c673bb89272523c
+      - src_141f878fc5a13aca332edf211df02ae786f740c2bd1ad961653bd4ff8ac4745f

--- a/entities/an/anvevoice.yaml
+++ b/entities/an/anvevoice.yaml
@@ -11,6 +11,7 @@ entity:
   category: ai-ml
 profile:
   description: AnveVoice provides embeddable voice AI agents and speech APIs for websites, including multilingual conversations and on-page actions.
+  summary: AnveVoice provides embeddable voice AI agents and speech APIs that help websites handle multilingual conversations and on-page workflows.
   links:
     site: https://anvevoice.app
 sources:
@@ -37,14 +38,14 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: Three months of free access to the AnveVoice Growth plan
+          description: Three months free on AnveVoice Growth
           duration:
             kind: exact
             value: P3M
           kind: free-service
-          service: AnveVoice Growth plan
+          service: AnveVoice Growth
         - benefit_id: ben_02
-          description: 50% off any AnveVoice plan for the following six months
+          description: 50% off all AnveVoice plans for six months
           duration:
             kind: exact
             value: P6M
@@ -53,8 +54,8 @@ offers:
             kind: exact
             basis_points: 5000
       consideration:
-        kind: variable
-        description: During the six-month discount period, the startup pays half the regular price of its selected AnveVoice plan.
+        kind: unknown
+        description: The public startup page does not state separate consideration.
     eligibility:
       rule:
         criterion_id: cri_01
@@ -66,8 +67,7 @@ offers:
       access_operator_entity_id: ent_01m16y0htnnsq1kmzac26dgkzh
     access:
       availability: public
-      instructions: Follow the sign-up link on the official startup program page and submit the requested company details for review.
-      method: form
+      method: other
       url: https://anvevoice.app/startups
     source_ids:
       - src_324ec1242dab6d5ba4cf29562b87373262255f1c2f09fc7cc47de3c5407e8a15

--- a/entities/an/anvevoice.yaml
+++ b/entities/an/anvevoice.yaml
@@ -17,6 +17,8 @@ profile:
 sources:
   - source_id: src_324ec1242dab6d5ba4cf29562b87373262255f1c2f09fc7cc47de3c5407e8a15
     url: https://anvevoice.app/startups
+  - source_id: src_32c9f7fc29e51514637d352aa9afdec6a75b3edda331114683fb79c629aac517
+    url: https://app.anvevoice.app/auth?mode=sign-up
 programs:
   - program_id: prg_01m16y0htr5e7atav28vycxxpe
     program_slug: anvevoice-for-startups
@@ -55,7 +57,7 @@ offers:
             basis_points: 5000
       consideration:
         kind: variable
-        description: 50% off 6 months on all plans
+        description: Growth is listed at $39/month before the startup discount.
     eligibility:
       rule:
         criterion_id: cri_01
@@ -67,8 +69,9 @@ offers:
       access_operator_entity_id: ent_01m16y0htnnsq1kmzac26dgkzh
     access:
       availability: public
-      instructions: Use the Get Started Free sign-up link on the public startup page.
-      method: other
-      url: https://anvevoice.app/startups
+      instructions: Use the Get Started Free sign-up form.
+      method: form
+      url: https://app.anvevoice.app/auth?mode=sign-up
     source_ids:
       - src_324ec1242dab6d5ba4cf29562b87373262255f1c2f09fc7cc47de3c5407e8a15
+      - src_32c9f7fc29e51514637d352aa9afdec6a75b3edda331114683fb79c629aac517

--- a/entities/an/anvevoice.yaml
+++ b/entities/an/anvevoice.yaml
@@ -59,7 +59,7 @@ offers:
             basis_points: 5000
       consideration:
         kind: variable
-        description: During the six-month discount period, participants pay half of the selected plan's published price.
+        description: Growth is $39 per month, Scale is $129 per month, and Enterprise pricing is custom.
     eligibility:
       rule:
         criterion_id: cri_01

--- a/entities/an/anvevoice.yaml
+++ b/entities/an/anvevoice.yaml
@@ -38,14 +38,14 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: Three months free on AnveVoice Growth
+          description: 3 months free on Growth
           duration:
             kind: exact
             value: P3M
           kind: free-service
-          service: AnveVoice Growth
+          service: Growth
         - benefit_id: ben_02
-          description: 50% off all AnveVoice plans for six months
+          description: 50% off 6 months on all plans
           duration:
             kind: exact
             value: P6M
@@ -54,19 +54,20 @@ offers:
             kind: exact
             basis_points: 5000
       consideration:
-        kind: unknown
-        description: The public startup page does not state separate consideration.
+        kind: variable
+        description: 50% off 6 months on all plans
     eligibility:
       rule:
         criterion_id: cri_01
         kind: manual
-        statement: The applicant must be a qualifying startup approved by AnveVoice; the public program page does not specify additional criteria.
-        reason: not-machine-evaluable
+        statement: Qualifying startups can apply.
+        reason: vendor-discretion
     roles:
       terms_authority_entity_id: ent_01m16y0htnnsq1kmzac26dgkzh
       access_operator_entity_id: ent_01m16y0htnnsq1kmzac26dgkzh
     access:
       availability: public
+      instructions: Use the Get Started Free sign-up link on the public startup page.
       method: other
       url: https://anvevoice.app/startups
     source_ids:

--- a/entities/an/anvevoice.yaml
+++ b/entities/an/anvevoice.yaml
@@ -18,7 +18,7 @@ sources:
   - source_id: src_324ec1242dab6d5ba4cf29562b87373262255f1c2f09fc7cc47de3c5407e8a15
     url: https://anvevoice.app/startups
   - source_id: src_32c9f7fc29e51514637d352aa9afdec6a75b3edda331114683fb79c629aac517
-    url: https://app.anvevoice.app/auth?mode=sign-up
+    url: https://app.anvevoice.app/auth
 programs:
   - program_id: prg_01m16y0htr5e7atav28vycxxpe
     program_slug: anvevoice-for-startups
@@ -71,7 +71,7 @@ offers:
       availability: public
       instructions: Use the Get Started Free sign-up form.
       method: form
-      url: https://app.anvevoice.app/auth?mode=sign-up
+      url: https://app.anvevoice.app/auth
     source_ids:
       - src_324ec1242dab6d5ba4cf29562b87373262255f1c2f09fc7cc47de3c5407e8a15
       - src_32c9f7fc29e51514637d352aa9afdec6a75b3edda331114683fb79c629aac517

--- a/entities/an/anvevoice.yaml
+++ b/entities/an/anvevoice.yaml
@@ -17,8 +17,8 @@ profile:
 sources:
   - source_id: src_324ec1242dab6d5ba4cf29562b87373262255f1c2f09fc7cc47de3c5407e8a15
     url: https://anvevoice.app/startups
-  - source_id: src_32c9f7fc29e51514637d352aa9afdec6a75b3edda331114683fb79c629aac517
-    url: https://app.anvevoice.app/auth
+  - source_id: src_89cc441d328586b2fd9924ba1b6d5eccf7991cdc8fb454d21c673bb89272523c
+    url: https://anvevoice.app/llms.txt
 programs:
   - program_id: prg_01m16y0htr5e7atav28vycxxpe
     program_slug: anvevoice-for-startups
@@ -56,22 +56,22 @@ offers:
             kind: exact
             basis_points: 5000
       consideration:
-        kind: variable
-        description: Growth is listed at $39/month before the startup discount.
+        kind: unknown
+        description: The source record did not establish separate consideration.
     eligibility:
       rule:
         criterion_id: cri_01
         kind: manual
-        statement: Qualifying startups can apply.
-        reason: vendor-discretion
+        statement: Eligible startups were founded within the last three years, have under $5 million in annual revenue, have fewer than 50 employees, and have a live website.
+        reason: not-machine-evaluable
     roles:
       terms_authority_entity_id: ent_01m16y0htnnsq1kmzac26dgkzh
       access_operator_entity_id: ent_01m16y0htnnsq1kmzac26dgkzh
     access:
       availability: public
-      instructions: Use the Get Started Free sign-up form.
+      instructions: Apply at the official AnveVoice for Startups page.
       method: form
-      url: https://app.anvevoice.app/auth
+      url: https://anvevoice.app/startups
     source_ids:
       - src_324ec1242dab6d5ba4cf29562b87373262255f1c2f09fc7cc47de3c5407e8a15
-      - src_32c9f7fc29e51514637d352aa9afdec6a75b3edda331114683fb79c629aac517
+      - src_89cc441d328586b2fd9924ba1b6d5eccf7991cdc8fb454d21c673bb89272523c


### PR DESCRIPTION
Resolves #969

- Adds exactly one data-only Entity YAML at `entities/an/anvevoice.yaml`, with one program and one offer.
- Models AnveVoice for Startups: three months free on Growth followed by 50% off any plan for six months.
- Keeps eligibility vendor-reviewed because the public page does not publish narrower criteria, and records the public application route.
- Uses AnveVoice’s first-party startup page as the canonical source: https://anvevoice.app/startups
- Verification: the exact local Sourcey catalog preflight passes, and the current `sourcey/validation` and workflow checks are green with DCO sign-off.