### PR TITLE
feat(catalog): add FalkorDB startup program

### DIFF
--- a/entities/fa/falkordb.yaml
+++ b/entities/fa/falkordb.yaml
@@ -1,0 +1,95 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m16y9dymceqacvm663kw5z0z
+  slug: falkordb
+  slug_aliases: []
+  name: FalkorDB
+  domains:
+    - value: falkordb.com
+      role: primary
+      valid_from: 2026-08-29T14:20:30.040Z
+  category: databases
+profile:
+  description: FalkorDB develops an open-source graph database and GraphRAG tools for building knowledge graph and agentic AI applications.
+  links:
+    site: https://www.falkordb.com
+sources:
+  - source_id: src_90e1646168b9e8e88ef8256b64b2b0f6a58672d60285651b9fed1b88ec1fca83
+    url: https://www.falkordb.com/startup-program/
+programs:
+  - program_id: prg_01m16y9dyr3a3x6a3c7tka5pba
+    program_slug: falkordb-startup-program
+    program_slug_aliases: []
+    title: FalkorDB Startup Program
+    summary: FalkorDB supports qualifying early-stage startups with a six-month cloud discount, enterprise features, and help from a solutions architect.
+    source_ids:
+      - src_90e1646168b9e8e88ef8256b64b2b0f6a58672d60285651b9fed1b88ec1fca83
+offers:
+  - offer_id: off_01m16y9dyrrr6cd8t30m9zf33c
+    program_id: prg_01m16y9dyr3a3x6a3c7tka5pba
+    offer_slug: half-price-startup-tier-for-six-months
+    offer_slug_aliases: []
+    title: 50% off the Startup Tier for six months
+    summary: Qualifying startups receive 50% off FalkorDB's Startup Tier for six months, enterprise features on every tier, and a dedicated solutions architect.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-29T14:20:30.040Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          applies_to: FalkorDB Startup Tier
+          description: 50% off the FalkorDB Startup Tier for six months
+          duration:
+            kind: exact
+            value: P6M
+          kind: discount
+          percentage:
+            kind: exact
+            basis_points: 5000
+        - benefit_id: ben_02
+          description: Enterprise features are included on every tier
+          kind: other
+        - benefit_id: ben_03
+          description: Guidance from a dedicated FalkorDB solutions architect
+          kind: other
+      consideration:
+        kind: variable
+        description: The startup pays half the regular price of the FalkorDB Startup Tier during the six-month discount period.
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: The startup must be less than five years old.
+            value:
+              type: number
+              value: 60
+          - criterion_id: cri_02
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: The startup must have raised less than $5 million.
+            value:
+              type: number
+              value: 5000000
+          - criterion_id: cri_03
+            kind: manual
+            statement: The startup must be at the Seed or Series A stage.
+            reason: external-verification
+          - criterion_id: cri_04
+            kind: manual
+            statement: The startup must be developing in generative AI, cybersecurity, or agentic AI.
+            reason: external-verification
+    roles:
+      terms_authority_entity_id: ent_01m16y9dymceqacvm663kw5z0z
+      access_operator_entity_id: ent_01m16y9dymceqacvm663kw5z0z
+    access:
+      availability: public
+      instructions: Submit information about the startup and its graph use case through the application on the official program page.
+      method: form
+      url: https://www.falkordb.com/startup-program/
+    source_ids:
+      - src_90e1646168b9e8e88ef8256b64b2b0f6a58672d60285651b9fed1b88ec1fca83

--- a/entities/fa/falkordb.yaml
+++ b/entities/fa/falkordb.yaml
@@ -11,6 +11,7 @@ entity:
   category: databases
 profile:
   description: FalkorDB develops an open-source graph database and GraphRAG tools for building knowledge graph and agentic AI applications.
+  summary: FalkorDB develops a graph database and GraphRAG tools for teams building knowledge-graph and agentic-AI applications.
   links:
     site: https://www.falkordb.com
 sources:
@@ -53,8 +54,8 @@ offers:
           description: Guidance from a dedicated FalkorDB solutions architect
           kind: other
       consideration:
-        kind: variable
-        description: The startup pays half the regular price of the FalkorDB Startup Tier during the six-month discount period.
+        kind: unknown
+        description: The public Startup Program page does not state separate consideration.
     eligibility:
       rule:
         kind: all

--- a/entities/fa/falkordb.yaml
+++ b/entities/fa/falkordb.yaml
@@ -57,7 +57,7 @@ offers:
           kind: other
       consideration:
         kind: variable
-        description: Startup Tier pricing starts at $73 per 1 GB per month before the program discount.
+        description: The Startup plan is priced from $73 per 1 GB per month.
     eligibility:
       rule:
         kind: all

--- a/entities/fa/falkordb.yaml
+++ b/entities/fa/falkordb.yaml
@@ -39,7 +39,7 @@ offers:
       benefits:
         - benefit_id: ben_01
           applies_to: FalkorDB Startup Tier
-          description: 50% off the FalkorDB Startup Tier for six months
+          description: 50% Off Startup Tier (6 Months)
           duration:
             kind: exact
             value: P6M
@@ -48,14 +48,14 @@ offers:
             kind: exact
             basis_points: 5000
         - benefit_id: ben_02
-          description: Enterprise features are included on every tier
+          description: Enterprise Features on all Tiers
           kind: other
         - benefit_id: ben_03
-          description: Guidance from a dedicated FalkorDB solutions architect
+          description: Dedicated Solutions Architect
           kind: other
       consideration:
-        kind: unknown
-        description: The public Startup Program page does not state separate consideration.
+        kind: variable
+        description: 50% Off Startup Tier (6 Months)
     eligibility:
       rule:
         kind: all

--- a/entities/fa/falkordb.yaml
+++ b/entities/fa/falkordb.yaml
@@ -19,6 +19,8 @@ sources:
     url: https://www.falkordb.com/startup-program/
   - source_id: src_53527cc9d489b160eb693a2a4655e219a78d0c05683c2fe0b133ba070105d064
     url: https://www.falkordb.com/plans/
+  - source_id: src_ba0d94c036a19a448900f20dbe9fb9987f33408da69ddafe589e002789a6e5c5
+    url: https://www.falkordb.com/blog/ai-agent-memory-retrieval-architecture/
 programs:
   - program_id: prg_01m16y9dyr3a3x6a3c7tka5pba
     program_slug: falkordb-startup-program
@@ -57,7 +59,7 @@ offers:
           kind: other
       consideration:
         kind: variable
-        description: The Startup plan is priced from $73 per 1 GB per month.
+        description: The Startup tier starts at $73 per month for 1 GB.
     eligibility:
       rule:
         kind: all
@@ -97,3 +99,4 @@ offers:
     source_ids:
       - src_90e1646168b9e8e88ef8256b64b2b0f6a58672d60285651b9fed1b88ec1fca83
       - src_53527cc9d489b160eb693a2a4655e219a78d0c05683c2fe0b133ba070105d064
+      - src_ba0d94c036a19a448900f20dbe9fb9987f33408da69ddafe589e002789a6e5c5

--- a/entities/fa/falkordb.yaml
+++ b/entities/fa/falkordb.yaml
@@ -38,7 +38,7 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          applies_to: FalkorDB Startup Tier
+          applies_to: Startup Tier
           description: 50% Off Startup Tier (6 Months)
           duration:
             kind: exact
@@ -55,7 +55,7 @@ offers:
           kind: other
       consideration:
         kind: variable
-        description: 50% Off Startup Tier (6 Months)
+        description: The Startup Tier is offered at 50% off for six months.
     eligibility:
       rule:
         kind: all

--- a/entities/fa/falkordb.yaml
+++ b/entities/fa/falkordb.yaml
@@ -54,8 +54,8 @@ offers:
           description: Dedicated Solutions Architect
           kind: other
       consideration:
-        kind: variable
-        description: The Startup Tier is offered at 50% off for six months.
+        kind: unknown
+        description: The source record did not establish separate consideration.
     eligibility:
       rule:
         kind: all

--- a/entities/fa/falkordb.yaml
+++ b/entities/fa/falkordb.yaml
@@ -17,6 +17,8 @@ profile:
 sources:
   - source_id: src_90e1646168b9e8e88ef8256b64b2b0f6a58672d60285651b9fed1b88ec1fca83
     url: https://www.falkordb.com/startup-program/
+  - source_id: src_53527cc9d489b160eb693a2a4655e219a78d0c05683c2fe0b133ba070105d064
+    url: https://www.falkordb.com/plans/
 programs:
   - program_id: prg_01m16y9dyr3a3x6a3c7tka5pba
     program_slug: falkordb-startup-program
@@ -54,8 +56,8 @@ offers:
           description: Dedicated Solutions Architect
           kind: other
       consideration:
-        kind: unknown
-        description: The source record did not establish separate consideration.
+        kind: variable
+        description: Startup Tier pricing starts at $73 per 1 GB per month before the program discount.
     eligibility:
       rule:
         kind: all
@@ -94,3 +96,4 @@ offers:
       url: https://www.falkordb.com/startup-program/
     source_ids:
       - src_90e1646168b9e8e88ef8256b64b2b0f6a58672d60285651b9fed1b88ec1fca83
+      - src_53527cc9d489b160eb693a2a4655e219a78d0c05683c2fe0b133ba070105d064


### PR DESCRIPTION
Resolves #973

- Adds exactly one data-only Entity YAML at `entities/fa/falkordb.yaml`, with one program and one offer.
- Models FalkorDB Startup Program: 50% off the Startup Tier for six months, enterprise features, and solutions-architect guidance.
- Records the published stage, company-age, funding, and product-focus eligibility plus the public application route.
- Uses FalkorDB’s first-party program page as the canonical source: https://www.falkordb.com/startup-program/
- Verification: the exact local Sourcey catalog preflight passes, and the current `sourcey/validation` and workflow checks are green with DCO sign-off.