### PR TITLE
feat(catalog): add UniTrack Startup Launchpad

### DIFF
--- a/entities/un/unitrack.yaml
+++ b/entities/un/unitrack.yaml
@@ -21,26 +21,26 @@ programs:
     program_slug: unitrack-startup-launchpad
     program_slug_aliases: []
     title: UniTrack Startup Launchpad
-    summary: UniTrack gives qualifying early-stage teams a year of free access to its business operations platform without requiring a credit card.
+    summary: UniTrack gives qualifying early-stage teams three months of free access to its business operations platform without requiring a credit card.
     source_ids:
       - src_5959d0137cf87ba85ef4e7db18cf50c864f305ec7be13380712892bdb3428f14
 offers:
   - offer_id: off_01m16y9dyr3n1h00h3m8myz8jt
     program_id: prg_01m16y9dyrg5z275t1h1v27ek6
-    offer_slug: one-year-free-startup-launchpad
+    offer_slug: three-month-free-startup-launchpad
     offer_slug_aliases: []
-    title: One year of free UniTrack for early-stage startups
-    summary: Eligible startups with up to 10 employees receive one year of free access to UniTrack's Startup Launchpad under the published feature and usage limits.
+    title: Three months of free UniTrack for early-stage startups
+    summary: Eligible startups with up to 10 employees receive three months of free access to UniTrack's Startup Launchpad under the published feature and usage limits.
     lifecycle:
       status: active
       effective_from: 2026-08-29T14:20:30.040Z
     economics:
       benefits:
         - benefit_id: ben_01
-          description: One year of free access to the UniTrack Startup Launchpad for a team of up to 10 employees
+          description: Three months of free access to the UniTrack Startup Launchpad for a team of up to 10 employees
           duration:
             kind: exact
-            value: P1Y
+            value: P3M
           kind: free-service
           service: UniTrack Startup Launchpad
       consideration:

--- a/entities/un/unitrack.yaml
+++ b/entities/un/unitrack.yaml
@@ -1,0 +1,73 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m16y9dyrbmh65k0n6rk7qq8q
+  slug: unitrack
+  slug_aliases: []
+  name: UniTrack
+  domains:
+    - value: unitrack.ai
+      role: primary
+      valid_from: 2026-08-29T14:20:30.040Z
+  category: productivity
+profile:
+  description: UniTrack provides an integrated workspace for team chat, task management, HR, invoicing, CRM, documents, and business operations.
+  links:
+    site: https://unitrack.ai
+sources:
+  - source_id: src_5959d0137cf87ba85ef4e7db18cf50c864f305ec7be13380712892bdb3428f14
+    url: https://unitrack.ai/startup-launchpad/
+programs:
+  - program_id: prg_01m16y9dyrg5z275t1h1v27ek6
+    program_slug: unitrack-startup-launchpad
+    program_slug_aliases: []
+    title: UniTrack Startup Launchpad
+    summary: UniTrack gives qualifying early-stage teams a year of free access to its business operations platform without requiring a credit card.
+    source_ids:
+      - src_5959d0137cf87ba85ef4e7db18cf50c864f305ec7be13380712892bdb3428f14
+offers:
+  - offer_id: off_01m16y9dyr3n1h00h3m8myz8jt
+    program_id: prg_01m16y9dyrg5z275t1h1v27ek6
+    offer_slug: one-year-free-startup-launchpad
+    offer_slug_aliases: []
+    title: One year of free UniTrack for early-stage startups
+    summary: Eligible startups with up to 10 employees receive one year of free access to UniTrack's Startup Launchpad under the published feature and usage limits.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-29T14:20:30.040Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: One year of free access to the UniTrack Startup Launchpad for a team of up to 10 employees
+          duration:
+            kind: exact
+            value: P1Y
+          kind: free-service
+          service: UniTrack Startup Launchpad
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.employee_count
+            kind: predicate
+            operator: lte
+            statement: The startup must have no more than 10 employees.
+            value:
+              type: number
+              value: 10
+          - criterion_id: cri_02
+            kind: manual
+            statement: The applicant must be an early-stage startup, from idea or MVP through early revenue and up to Series A.
+            reason: external-verification
+    roles:
+      terms_authority_entity_id: ent_01m16y9dyrbmh65k0n6rk7qq8q
+      access_operator_entity_id: ent_01m16y9dyrbmh65k0n6rk7qq8q
+    access:
+      availability: public
+      instructions: Create a UniTrack account and apply for Startup Launchpad from the public program flow; no credit card is required.
+      method: form
+      url: https://unitrack.ai/startup-launchpad/
+    source_ids:
+      - src_5959d0137cf87ba85ef4e7db18cf50c864f305ec7be13380712892bdb3428f14

--- a/entities/un/unitrack.yaml
+++ b/entities/un/unitrack.yaml
@@ -38,20 +38,20 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: Three months of free access to the UniTrack Startup Launchpad
+          description: Free access to UniTrack for three months
           duration:
             kind: exact
             value: P3M
           kind: free-service
-          service: UniTrack Startup Launchpad
+          service: UniTrack
       consideration:
         kind: none
     eligibility:
       rule:
         kind: manual
         criterion_id: cri_01
-        statement: Early-stage startups with up to 10 employees can apply.
-        reason: vendor-discretion
+        statement: Any early-stage startup with up to 10 employees is eligible.
+        reason: not-machine-evaluable
     roles:
       terms_authority_entity_id: ent_01m16y9dyrbmh65k0n6rk7qq8q
       access_operator_entity_id: ent_01m16y9dyrbmh65k0n6rk7qq8q

--- a/entities/un/unitrack.yaml
+++ b/entities/un/unitrack.yaml
@@ -45,8 +45,7 @@ offers:
           kind: free-service
           service: UniTrack Startup Launchpad
       consideration:
-        kind: unknown
-        description: The public Startup Launchpad page does not state separate consideration.
+        kind: none
     eligibility:
       rule:
         kind: manual

--- a/entities/un/unitrack.yaml
+++ b/entities/un/unitrack.yaml
@@ -49,20 +49,10 @@ offers:
         description: The public Startup Launchpad page does not state separate consideration.
     eligibility:
       rule:
-        kind: all
-        rules:
-          - criterion_id: cri_01
-            fact: company.employee_count
-            kind: predicate
-            operator: lte
-            statement: The startup must have no more than 10 employees.
-            value:
-              type: number
-              value: 10
-          - criterion_id: cri_02
-            kind: manual
-            statement: The applicant must be an early-stage startup, from idea or MVP through early revenue and up to Series A.
-            reason: external-verification
+        kind: manual
+        criterion_id: cri_01
+        statement: Early-stage startups with up to 10 employees can apply.
+        reason: vendor-discretion
     roles:
       terms_authority_entity_id: ent_01m16y9dyrbmh65k0n6rk7qq8q
       access_operator_entity_id: ent_01m16y9dyrbmh65k0n6rk7qq8q

--- a/entities/un/unitrack.yaml
+++ b/entities/un/unitrack.yaml
@@ -11,6 +11,7 @@ entity:
   category: productivity
 profile:
   description: UniTrack provides an integrated workspace for team chat, task management, HR, invoicing, CRM, documents, and business operations.
+  summary: UniTrack is a business operations platform that helps startups manage teams, work, finance, and customer workflows in one workspace.
   links:
     site: https://unitrack.ai
 sources:
@@ -37,14 +38,15 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: Three months of free access to the UniTrack Startup Launchpad for a team of up to 10 employees
+          description: Three months of free access to the UniTrack Startup Launchpad
           duration:
             kind: exact
             value: P3M
           kind: free-service
           service: UniTrack Startup Launchpad
       consideration:
-        kind: none
+        kind: unknown
+        description: The public Startup Launchpad page does not state separate consideration.
     eligibility:
       rule:
         kind: all


### PR DESCRIPTION
Resolves #972

- Adds exactly one data-only Entity YAML at `entities/un/unitrack.yaml`, with one program and one offer.
- Models UniTrack Startup Launchpad: three months of free access for qualifying early-stage startups with teams of up to 10 employees.
- Records the public application route, no-card requirement, published eligibility, duration, and usage constraints without inventing unavailable terms.
- Uses UniTrack’s first-party program page as the canonical source: https://unitrack.ai/startup-launchpad/
- Verification: the exact local Sourcey catalog preflight passes, and the current `sourcey/validation` and workflow checks are green with DCO sign-off.