### PR TITLE
data: add Fiddle startup program

### DIFF
--- a/entities/fi/fiddle.yaml
+++ b/entities/fi/fiddle.yaml
@@ -1,0 +1,99 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m19mv21asfgsyash7bjwm6yp
+  slug: fiddle
+  slug_aliases: []
+  name: Fiddle
+  domains:
+    - value: fiddle.io
+      role: primary
+      valid_from: 2026-08-30T15:40:00.000Z
+  category: commerce
+profile:
+  description: Fiddle provides inventory, order, manufacturing, fulfillment, and traceability software for growing product businesses.
+  links:
+    site: https://fiddle.io
+sources:
+  - source_id: src_e28303573a2d97aacaad1230cba64b138cd29ca76d1217b7d80bd444d6062f56
+    url: https://fiddle.io/startup-program
+programs:
+  - program_id: prg_01m19mv21cn6tdttsbh45vqkkd
+    program_slug: startup-program
+    program_slug_aliases: []
+    title: Fiddle Startup Program
+    summary: Fiddle offers early-stage startups discounted inventory management, platform credits, premium integrations, dedicated onboarding, and founder resources.
+    source_ids:
+      - src_e28303573a2d97aacaad1230cba64b138cd29ca76d1217b7d80bd444d6062f56
+offers:
+  - offer_id: off_01m19mv21cythhb3aspy6re33z
+    program_id: prg_01m19mv21cn6tdttsbh45vqkkd
+    offer_slug: startup-program-benefits
+    offer_slug_aliases: []
+    title: Fiddle Startup Program Benefits
+    summary: Eligible startups receive 90% off their first year, $2,500 in platform credits, free premium integrations, dedicated onboarding, and founder resources.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-30T15:40:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: 90% off the first year, with savings up to $10,000
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            kind: exact
+            basis_points: 9000
+        - benefit_id: ben_02
+          description: $2,500 in platform credits for premium features, additional users, and integrations
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 250000
+            kind: exact
+        - benefit_id: ben_03
+          description: Free premium integrations, dedicated onboarding, founder community access, and product roadmap input
+          kind: other
+      consideration:
+        kind: unknown
+        description: The vendor does not publish the discounted subscription price.
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: Company must have been founded less than 3 years ago.
+            value:
+              type: number
+              value: 36
+          - criterion_id: cri_02
+            fact: company.annual_revenue_usd
+            kind: predicate
+            operator: lt
+            statement: Company must have less than $5 million in annual revenue.
+            value:
+              type: number
+              value: 5000000
+          - criterion_id: cri_03
+            kind: manual
+            reason: not-machine-evaluable
+            statement: Company must have raised less than $10 million in total funding or be bootstrapped.
+          - criterion_id: cri_04
+            kind: manual
+            reason: not-machine-evaluable
+            statement: Company must currently use or plan to use inventory management.
+    roles:
+      terms_authority_entity_id: ent_01m19mv21asfgsyash7bjwm6yp
+      access_operator_entity_id: ent_01m19mv21asfgsyash7bjwm6yp
+    access:
+      availability: public
+      method: form
+      url: https://fiddle.io/startup-program
+    terms_url: https://fiddle.io/startup-program
+    source_ids:
+      - src_e28303573a2d97aacaad1230cba64b138cd29ca76d1217b7d80bd444d6062f56


### PR DESCRIPTION
## What changed

Adds Fiddle as a new Entity with its named Startup Program and one bundled offer. The record captures the published 90% first-year discount, $2,500 in platform credits, premium integrations, dedicated onboarding, founder resources, and explicit eligibility limits.

Closes #984.

## Sources

- https://fiddle.io/startup-program

## Validation

The repository-pinned Sourcey Catalog Verifier passed locally: 1 entity, 1 program, and 1 offer.

## Certification

- [x] I changed only allowed repository content and did not mix Entity YAML with other paths.
- [x] Public sources substantiate every submitted factual value; any Sourcey-written prose is a neutral summary, not a fabricated vendor quote.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commits include a `Signed-off-by` line.
