### PR TITLE
Add Olqan startup offer

### DIFF
--- a/entities/ol/olqan.yaml
+++ b/entities/ol/olqan.yaml
@@ -1,0 +1,66 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1a761d5nqzwxfmefajdch5n
+  slug: olqan
+  slug_aliases: []
+  name: Olqan
+  domains:
+    - value: olqan.com
+      role: primary
+      valid_from: 2026-08-30T20:53:48.157Z
+  category: productivity
+profile:
+  description: Olqan unifies CRM, project management, finance, HR, support, procurement, and analytics in one business operations platform.
+  links:
+    site: https://olqan.com
+sources:
+  - source_id: src_f1ef04fed4f65461df48257364bc96be5fcc455c6ddb5339e78dadbfb9816018
+    url: https://olqan.com/startup-program/
+  - source_id: src_25801a2859f9c7929e8b82ee03d6d844179bc9f5ea195d036d862f0b8ae0e010
+    url: https://olqan.com/
+programs:
+  - program_id: prg_01m1a761ddr867k4j4570jvswg
+    program_slug: olqan-startup-program
+    program_slug_aliases: []
+    title: Olqan Startup Program
+    summary: Olqan's startup program gives qualifying new users its Growth plan free for 12 months, with onboarding, migration, and priority support.
+    source_ids:
+      - src_f1ef04fed4f65461df48257364bc96be5fcc455c6ddb5339e78dadbfb9816018
+offers:
+  - offer_id: off_01m1a761detcy2x7syaj1b7x19
+    program_id: prg_01m1a761ddr867k4j4570jvswg
+    offer_slug: twelve-months-free-growth-plan
+    offer_slug_aliases: []
+    title: 12 months free on Olqan Growth
+    summary: Accepted startups receive the Olqan Growth plan free for 12 months with all platform features, onboarding and migration, and 24/7 priority support.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-30T20:53:48.157Z
+    economics:
+      consideration:
+        kind: none
+      benefits:
+        - benefit_id: ben_01
+          description: The Olqan Growth plan is provided at no charge for 12 months, including onboarding, migration, and priority support.
+          kind: free-service
+          service: Olqan Growth plan
+          duration:
+            kind: exact
+            value: P1Y
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_01
+        statement: Applicant must be a new Olqan user with fewer than 20 employees and no more than USD 2 million in funding.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m1a761d5nqzwxfmefajdch5n
+      access_operator_entity_id: ent_01m1a761d5nqzwxfmefajdch5n
+    access:
+      availability: public
+      method: form
+      url: https://olqan.com/startup-program/
+    terms_url: https://olqan.com/startup-program/
+    source_ids:
+      - src_f1ef04fed4f65461df48257364bc96be5fcc455c6ddb5339e78dadbfb9816018
+      - src_25801a2859f9c7929e8b82ee03d6d844179bc9f5ea195d036d862f0b8ae0e010

--- a/entities/ol/olqan.yaml
+++ b/entities/ol/olqan.yaml
@@ -10,6 +10,7 @@ entity:
       valid_from: 2026-08-30T20:53:48.157Z
   category: productivity
 profile:
+  summary: One business platform for sales, projects, finance, HR, tickets, procurement, and analytics.
   description: Olqan unifies CRM, project management, finance, HR, support, procurement, and analytics in one business operations platform.
   links:
     site: https://olqan.com
@@ -39,7 +40,7 @@ offers:
     economics:
       consideration:
         kind: variable
-        description: Startups pay for six months in year one, eight months in year two, and ten months in year three.
+        description: "Year 1: pay 6 months; year 2: pay 8 months; year 3: pay 10 months."
       benefits:
         - benefit_id: ben_01
           description: Pay for six months and get six months free in year one

--- a/entities/ol/olqan.yaml
+++ b/entities/ol/olqan.yaml
@@ -23,30 +23,45 @@ programs:
     program_slug: olqan-startup-program
     program_slug_aliases: []
     title: Olqan Startup Program
-    summary: Olqan's startup program gives qualifying new users its Growth plan free for 12 months, with onboarding, migration, and priority support.
+    summary: Olqan's startup program gives qualifying new users a three-year structure with six free months in year one, four in year two, and two in year three.
     source_ids:
       - src_f1ef04fed4f65461df48257364bc96be5fcc455c6ddb5339e78dadbfb9816018
 offers:
   - offer_id: off_01m1a761detcy2x7syaj1b7x19
     program_id: prg_01m1a761ddr867k4j4570jvswg
-    offer_slug: twelve-months-free-growth-plan
+    offer_slug: three-year-free-months-structure
     offer_slug_aliases: []
-    title: 12 months free on Olqan Growth
-    summary: Accepted startups receive the Olqan Growth plan free for 12 months with all platform features, onboarding and migration, and 24/7 priority support.
+    title: Six, four, and two free months across three years
+    summary: Accepted startups pay for six months and get six free in year one, pay for eight and get four free in year two, then pay for ten and get two free in year three.
     lifecycle:
       status: active
       effective_from: 2026-08-30T20:53:48.157Z
     economics:
       consideration:
-        kind: none
+        kind: variable
+        description: Startups pay for six months in year one, eight months in year two, and ten months in year three.
       benefits:
         - benefit_id: ben_01
-          description: The Olqan Growth plan is provided at no charge for 12 months, including onboarding, migration, and priority support.
+          description: Pay for six months and get six months free in year one
           kind: free-service
-          service: Olqan Growth plan
+          service: Six months of Olqan access in year one
           duration:
             kind: exact
-            value: P1Y
+            value: P6M
+        - benefit_id: ben_02
+          description: Pay for eight months and get four months free in year two
+          kind: free-service
+          service: Four months of Olqan access in year two
+          duration:
+            kind: exact
+            value: P4M
+        - benefit_id: ben_03
+          description: Pay for ten months and get two months free in year three
+          kind: free-service
+          service: Two months of Olqan access in year three
+          duration:
+            kind: exact
+            value: P2M
     eligibility:
       rule:
         kind: manual

--- a/entities/ol/olqan.yaml
+++ b/entities/ol/olqan.yaml
@@ -39,7 +39,7 @@ offers:
       effective_from: 2026-08-30T20:53:48.157Z
     economics:
       consideration:
-        kind: variable
+        kind: unknown
         description: "Year 1: pay 6 months; year 2: pay 8 months; year 3: pay 10 months."
       benefits:
         - benefit_id: ben_01


### PR DESCRIPTION
## Summary
- adds exactly one new Sourcey Entity YAML and one startup offer
- keeps the change data-only and DCO-signed
- models the published economics, eligibility, access route, lifecycle, and vendor roles

## Review evidence
- Raw YAML: https://raw.githubusercontent.com/nwinkelman2/startup-credits/9ef01407418d032f2179e264f3ef20b5731a2582/entities/ol/olqan.yaml
- First-party startup offer: https://olqan.com/startup-program/
- First-party product site: https://olqan.com/
- Reservation: https://github.com/sourcey/startup-credits/issues/1010

## Verification
- Canonical Sourcey Candidate Verifier: passed (1 entity, 1 program, 1 offer)
- Signed identity-context digest: `sha256:0b8d4f134e8a1c21a4f1f5e740cf819326627dee9a514dfedc1d6a1f71a280f7`
- Live parent release: `sha256:f54ae5559bef1aae2cdbacb1c26d5860eeb4459221b4469e67117cc1d09a01b8`
- `git diff --check`: passed
- Commit is DCO signed

Closes #1010

## Green checks
- Repository workflow: https://github.com/sourcey/startup-credits/actions/runs/33335481115/job/99321502021
- Sourcey validation: https://github.com/sourcey/startup-credits/runs/99321531990