### PR TITLE
Add ManyLayers startup offer

### DIFF
--- a/entities/ma/manylayers.yaml
+++ b/entities/ma/manylayers.yaml
@@ -10,6 +10,7 @@ entity:
       valid_from: 2026-08-30T20:53:48.157Z
   category: ai-ml
 profile:
+  summary: AI infrastructure for model routing, governed team workflows, evaluations, and model deployment.
   description: ManyLayers is an AI infrastructure platform for model routing, governed team workflows, evaluations, and on-prem model deployment.
   links:
     site: https://manylayers.io

--- a/entities/ma/manylayers.yaml
+++ b/entities/ma/manylayers.yaml
@@ -43,14 +43,14 @@ offers:
         kind: none
       benefits:
         - benefit_id: ben_01
-          description: Free Team tier for 12 months with all features included.
+          description: Free Team tier for 12 months — all features included.
           kind: free-service
-          service: ManyLayers Team tier
+          service: Team tier
           duration:
             kind: exact
             value: P1Y
         - benefit_id: ben_02
-          description: Dedicated Slack channel with engineering support.
+          description: Direct access to the ManyLayers engineering team via a shared Slack channel.
           kind: other
     eligibility:
       rule:

--- a/entities/ma/manylayers.yaml
+++ b/entities/ma/manylayers.yaml
@@ -18,6 +18,8 @@ sources:
     url: https://manylayers.io/startup-program/
   - source_id: src_61887b7de1fc4e382694934502f9f2463c1d4f028f6af8d4dc1da2adad377957
     url: https://manylayers.io/
+  - source_id: src_a87c6d4fb95f4bcd9e7cbb49cae8837c9cbc2430093883a8d90a62bbbcf231ce
+    url: https://manylayers.io/talk-to-us/
 programs:
   - program_id: prg_01m1a761r67hp60vr5rsjm7zsq
     program_slug: manylayers-startup-program
@@ -41,14 +43,14 @@ offers:
         kind: none
       benefits:
         - benefit_id: ben_01
-          description: Full access to the ManyLayers Team tier, Gateway, Workspace, and Deploy is provided at no charge for 12 months; GPU compute is not included.
+          description: Free Team tier for 12 months with all features included.
           kind: free-service
           service: ManyLayers Team tier
           duration:
             kind: exact
             value: P1Y
         - benefit_id: ben_02
-          description: Dedicated Slack support, onboarding, usage guidance, and evaluation assistance are included.
+          description: Dedicated Slack channel with engineering support.
           kind: other
     eligibility:
       rule:
@@ -61,9 +63,9 @@ offers:
       access_operator_entity_id: ent_01m1a761qy6fhy92p3q0638wwj
     access:
       availability: public
-      method: contact
-      url: https://manylayers.io/startup-program/
-    terms_url: https://manylayers.io/startup-program/
+      method: form
+      url: https://manylayers.io/talk-to-us/
     source_ids:
       - src_e20af7418a9594b332a6108a21879ad59732c9699e0d07d68787196be994b7e3
       - src_61887b7de1fc4e382694934502f9f2463c1d4f028f6af8d4dc1da2adad377957
+      - src_a87c6d4fb95f4bcd9e7cbb49cae8837c9cbc2430093883a8d90a62bbbcf231ce

--- a/entities/ma/manylayers.yaml
+++ b/entities/ma/manylayers.yaml
@@ -43,14 +43,14 @@ offers:
         kind: none
       benefits:
         - benefit_id: ben_01
-          description: Free Team tier for 12 months — all features included.
+          description: Full access to ManyLayers Gateway, Workspace, and Deploy at no cost for your first year.
           kind: free-service
-          service: Team tier
+          service: ManyLayers Gateway, Workspace, and Deploy
           duration:
             kind: exact
             value: P1Y
         - benefit_id: ben_02
-          description: Direct access to the ManyLayers engineering team via a shared Slack channel.
+          description: Direct access to our engineering team via a shared Slack channel.
           kind: other
     eligibility:
       rule:

--- a/entities/ma/manylayers.yaml
+++ b/entities/ma/manylayers.yaml
@@ -1,0 +1,69 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1a761qy6fhy92p3q0638wwj
+  slug: manylayers
+  slug_aliases: []
+  name: ManyLayers
+  domains:
+    - value: manylayers.io
+      role: primary
+      valid_from: 2026-08-30T20:53:48.157Z
+  category: ai-ml
+profile:
+  description: ManyLayers provides AI model routing, guardrails, budgets, audit logs, team workspaces, RAG, agents, evaluations, and on-prem model deployment.
+  links:
+    site: https://manylayers.io
+sources:
+  - source_id: src_e20af7418a9594b332a6108a21879ad59732c9699e0d07d68787196be994b7e3
+    url: https://manylayers.io/startup-program/
+  - source_id: src_61887b7de1fc4e382694934502f9f2463c1d4f028f6af8d4dc1da2adad377957
+    url: https://manylayers.io/
+programs:
+  - program_id: prg_01m1a761r67hp60vr5rsjm7zsq
+    program_slug: manylayers-startup-program
+    program_slug_aliases: []
+    title: ManyLayers Startup Program
+    summary: ManyLayers gives qualifying AI-first startups free access to its Team tier and full platform for 12 months, with onboarding and dedicated support.
+    source_ids:
+      - src_e20af7418a9594b332a6108a21879ad59732c9699e0d07d68787196be994b7e3
+offers:
+  - offer_id: off_01m1a761r7kfc08z6xjgna4etp
+    program_id: prg_01m1a761r67hp60vr5rsjm7zsq
+    offer_slug: twelve-months-free-team-tier
+    offer_slug_aliases: []
+    title: 12 months free on ManyLayers Team
+    summary: Accepted AI-first startups receive the ManyLayers Team tier free for 12 months, including Gateway, Workspace, Deploy, onboarding, and dedicated Slack support.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-30T20:53:48.157Z
+    economics:
+      consideration:
+        kind: none
+      benefits:
+        - benefit_id: ben_01
+          description: Full access to the ManyLayers Team tier, Gateway, Workspace, and Deploy is provided at no charge for 12 months; GPU compute is not included.
+          kind: free-service
+          service: ManyLayers Team tier
+          duration:
+            kind: exact
+            value: P1Y
+        - benefit_id: ben_02
+          description: Dedicated Slack support, onboarding, usage guidance, and evaluation assistance are included.
+          kind: other
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_01
+        statement: Applicant must be an AI-first company founded within the last five years at Seed, Pre-Series A, or Series A stage, with no prior commercial contract and no current paid ManyLayers account.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m1a761qy6fhy92p3q0638wwj
+      access_operator_entity_id: ent_01m1a761qy6fhy92p3q0638wwj
+    access:
+      availability: public
+      method: contact
+      url: https://manylayers.io/startup-program/
+    terms_url: https://manylayers.io/startup-program/
+    source_ids:
+      - src_e20af7418a9594b332a6108a21879ad59732c9699e0d07d68787196be994b7e3
+      - src_61887b7de1fc4e382694934502f9f2463c1d4f028f6af8d4dc1da2adad377957

--- a/entities/ma/manylayers.yaml
+++ b/entities/ma/manylayers.yaml
@@ -10,7 +10,7 @@ entity:
       valid_from: 2026-08-30T20:53:48.157Z
   category: ai-ml
 profile:
-  description: ManyLayers provides AI model routing, guardrails, budgets, audit logs, team workspaces, RAG, agents, evaluations, and on-prem model deployment.
+  description: ManyLayers is an AI infrastructure platform for model routing, governed team workflows, evaluations, and on-prem model deployment.
   links:
     site: https://manylayers.io
 sources:


### PR DESCRIPTION
## Summary
- adds exactly one new Sourcey Entity YAML and one startup offer
- keeps the change data-only and DCO-signed
- models the published economics, eligibility, access route, lifecycle, and vendor roles

## Review evidence
- Raw YAML: https://raw.githubusercontent.com/nwinkelman2/startup-credits/d6bb0fbdc57630161021c3f7c8dd3f2d8cef58ad/entities/ma/manylayers.yaml
- First-party startup offer: https://manylayers.io/startup-program/
- First-party product site: https://manylayers.io/
- Reservation: https://github.com/sourcey/startup-credits/issues/1011

## Verification
- Canonical Sourcey Candidate Verifier: passed (1 entity, 1 program, 1 offer)
- Signed identity-context digest: `sha256:ea89b53a88c36849e447e05a546c47ad074390a123cf6fec46e52208bbd313e4`
- Live parent release: `sha256:f54ae5559bef1aae2cdbacb1c26d5860eeb4459221b4469e67117cc1d09a01b8`
- `git diff --check`: passed
- Commit is DCO signed

Closes #1011

## Green checks
- Repository workflow: https://github.com/sourcey/startup-credits/actions/runs/33335486062/job/99321514703
- Sourcey validation: https://github.com/sourcey/startup-credits/runs/99321546379