### PR TITLE
Add Air startup offer

### DIFF
--- a/entities/ai/air.yaml
+++ b/entities/ai/air.yaml
@@ -1,0 +1,68 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1a762a52r4ntg9n16eqvbhg
+  slug: air
+  slug_aliases:
+    - air-inc
+  name: Air
+  domains:
+    - value: air.inc
+      role: primary
+      valid_from: 2026-08-30T20:53:48.157Z
+  category: design
+profile:
+  summary: Creative operations platform for managing and scaling brand assets.
+  description: Air is a creative operations platform for organizing, finding, editing, reviewing, approving, storing, and sharing brand assets.
+  links:
+    site: https://air.inc
+sources:
+  - source_id: src_c57d5e5418b97c048c38b46b0f41dbcc77279d777c380fedd9cce884176b93ec
+    url: https://air.inc/startups
+  - source_id: src_0056a8e67ed9360f56ad3701e30359421ce50b27d372b8b567d20d41bf70d21e
+    url: https://air.inc/
+programs:
+  - program_id: prg_01m1a762ag97erhhvj4fekrjjy
+    program_slug: air-for-startups
+    program_slug_aliases: []
+    title: Air for Startups
+    summary: Air's partner-network startup program gives qualifying seed through Series B companies up to six months free on its Business plan.
+    source_ids:
+      - src_c57d5e5418b97c048c38b46b0f41dbcc77279d777c380fedd9cce884176b93ec
+offers:
+  - offer_id: off_01m1a762ag7g38n5tp54rr0z29
+    program_id: prg_01m1a762ag97erhhvj4fekrjjy
+    offer_slug: up-to-six-months-free-business-plan
+    offer_slug_aliases: []
+    title: Up to six months free on Air Business
+    summary: Eligible partner-network startups receive up to six months free on Air's Business plan, covering storage and AI action credits, with a published value of up to USD 5,800.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-30T20:53:48.157Z
+    economics:
+      consideration:
+        kind: none
+      benefits:
+        - benefit_id: ben_01
+          description: Get up to 6 months free on Air's Business plan.
+          kind: free-service
+          service: Business plan
+          duration:
+            kind: up-to
+            value: P6M
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_01
+        statement: You must be a non-paying Air customer with a valid work email (no Gmail, Outlook, etc), be a portfolio company of one of our ecosystem partners, and be a seed to Series B stage startup.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m1a762a52r4ntg9n16eqvbhg
+      access_operator_entity_id: ent_01m1a762a52r4ntg9n16eqvbhg
+    access:
+      availability: public
+      method: form
+      url: https://air.inc/startups
+    terms_url: https://air.inc/startups
+    source_ids:
+      - src_c57d5e5418b97c048c38b46b0f41dbcc77279d777c380fedd9cce884176b93ec
+      - src_0056a8e67ed9360f56ad3701e30359421ce50b27d372b8b567d20d41bf70d21e


### PR DESCRIPTION
## Summary
- adds exactly one new Sourcey Entity YAML and one startup offer
- keeps the change data-only and DCO-signed
- models the published economics, eligibility, access route, lifecycle, and vendor roles

## Review evidence
- Raw YAML: https://raw.githubusercontent.com/nwinkelman2/startup-credits/addfc4169c63af4afba1c376a1ace5387550991e/entities/ai/air.yaml
- First-party startup offer: https://air.inc/startups
- First-party product site: https://air.inc/
- Reservation: https://github.com/sourcey/startup-credits/issues/1012

## Verification
- Canonical Sourcey Candidate Verifier: passed (1 entity, 1 program, 1 offer)
- Signed identity-context digest: `sha256:3babf2d7e3efe8306862177272361efd347fb23c6c2719454851b452e7e279f8`
- Live parent release: `sha256:f54ae5559bef1aae2cdbacb1c26d5860eeb4459221b4469e67117cc1d09a01b8`
- `git diff --check`: passed
- Commit is DCO signed

Closes #1012

## Green checks
- Repository workflow: https://github.com/sourcey/startup-credits/actions/runs/33335492364/job/99321530827
- Sourcey validation: https://github.com/sourcey/startup-credits/runs/99321559953