### PR TITLE
data: add Lightdash startup program

### DIFF
--- a/entities/li/lightdash.yaml
+++ b/entities/li/lightdash.yaml
@@ -1,0 +1,88 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1agcp3n0a5ct9v7yfcw6n0p
+  slug: lightdash
+  slug_aliases: []
+  name: Lightdash
+  domains:
+    - value: lightdash.com
+      role: primary
+      valid_from: 2026-08-30T23:36:00Z
+  category: data-analytics
+profile:
+  description: Lightdash is a business-intelligence platform that turns dbt projects into governed metrics, dashboards, and self-service analytics for teams.
+  links:
+    site: https://www.lightdash.com/
+sources:
+  - source_id: src_12c5f5575a3dea6dd0d479f83e3a0f4bc3f3eb56f4f2e889301171fa04c8dcf1
+    url: https://www.lightdash.com/startups
+  - source_id: src_6f53f4765cfa172d8baccd9a608f90b2208bf7cf1c25272eb41339c3fa6daaad
+    url: https://www.lightdash.com/start
+programs:
+  - program_id: prg_01m1agcp3xyqm8644vee5kd38x
+    program_slug: lightdash-for-startups
+    program_slug_aliases: []
+    title: Lightdash for Startups
+    summary: Lightdash gives qualifying young startups half-price Cloud or Pro access for a year, expert onboarding, and direct product-team support.
+    source_ids:
+      - src_12c5f5575a3dea6dd0d479f83e3a0f4bc3f3eb56f4f2e889301171fa04c8dcf1
+offers:
+  - offer_id: off_01m1agcp3x5kr1ye4nf6x24vbm
+    program_id: prg_01m1agcp3xyqm8644vee5kd38x
+    offer_slug: half-price-cloud-or-pro-for-one-year
+    offer_slug_aliases: []
+    title: 50% Off Lightdash Cloud or Pro for 12 Months
+    summary: Eligible startups receive 50% off Lightdash Cloud or Pro for 12 months, a benefit valued at up to USD 18,000, plus onboarding and dedicated support.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-30T23:36:00Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: 50% off Lightdash Cloud or Pro for 12 months, worth up to USD 18,000
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            basis_points: 5000
+            kind: exact
+        - benefit_id: ben_02
+          description: Personalized kickoff and training calls with the Lightdash data team
+          kind: other
+        - benefit_id: ben_03
+          description: Dedicated support channel with direct access to the product team
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: The company is less than five years old.
+            value:
+              type: number
+              value: 60
+          - criterion_id: cri_02
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: The company has raised less than USD 7.5 million.
+            value:
+              type: number
+              value: 7500000
+    roles:
+      terms_authority_entity_id: ent_01m1agcp3n0a5ct9v7yfcw6n0p
+      access_operator_entity_id: ent_01m1agcp3n0a5ct9v7yfcw6n0p
+    access:
+      availability: public
+      instructions: Use the application link published on the Lightdash for Startups page to contact the team and apply for the program.
+      method: form
+      url: https://www.lightdash.com/start
+    source_ids:
+      - src_12c5f5575a3dea6dd0d479f83e3a0f4bc3f3eb56f4f2e889301171fa04c8dcf1
+      - src_6f53f4765cfa172d8baccd9a608f90b2208bf7cf1c25272eb41339c3fa6daaad

--- a/entities/li/lightdash.yaml
+++ b/entities/li/lightdash.yaml
@@ -56,6 +56,7 @@ offers:
           kind: other
       consideration:
         kind: unknown
+        description: The cited source does not establish separate consideration beyond the offer terms.
     eligibility:
       rule:
         kind: all

--- a/entities/li/lightdash.yaml
+++ b/entities/li/lightdash.yaml
@@ -39,7 +39,7 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: 50% off Lightdash Cloud or Pro for 12 months, worth up to USD 18,000
+          description: 50% off Lightdash Cloud or Pro for 12 months.
           duration:
             kind: exact
             value: P1Y
@@ -48,13 +48,14 @@ offers:
             basis_points: 5000
             kind: exact
         - benefit_id: ben_02
-          description: Personalized kickoff and training calls with the Lightdash data team
+          description: Kickoff and training calls with the Lightdash data team.
           kind: other
         - benefit_id: ben_03
-          description: Dedicated support channel with direct access to the product team
+          description: Expert support and direct access to the product team for feedback and beta features.
           kind: other
       consideration:
-        kind: none
+        kind: unknown
+        description: The public program page states that the plans are half-price but does not publish the resulting payable price.
     eligibility:
       rule:
         kind: all
@@ -81,7 +82,7 @@ offers:
     access:
       availability: public
       instructions: Use the application link published on the Lightdash for Startups page to contact the team and apply for the program.
-      method: form
+      method: contact
       url: https://www.lightdash.com/start
     source_ids:
       - src_12c5f5575a3dea6dd0d479f83e3a0f4bc3f3eb56f4f2e889301171fa04c8dcf1

--- a/entities/li/lightdash.yaml
+++ b/entities/li/lightdash.yaml
@@ -10,6 +10,7 @@ entity:
       valid_from: 2026-08-30T23:36:00Z
   category: data-analytics
 profile:
+  summary: Business-intelligence platform for governed metrics, dashboards, and self-service analytics.
   description: Lightdash is a business-intelligence platform that turns dbt projects into governed metrics, dashboards, and self-service analytics for teams.
   links:
     site: https://www.lightdash.com/
@@ -55,7 +56,6 @@ offers:
           kind: other
       consideration:
         kind: unknown
-        description: The public program page states that the plans are half-price but does not publish the resulting payable price.
     eligibility:
       rule:
         kind: all

--- a/entities/li/lightdash.yaml
+++ b/entities/li/lightdash.yaml
@@ -40,7 +40,7 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: 50% off Lightdash Cloud or Pro for 12 months.
+          description: 50% off Lightdash Cloud or Pro for 12 months
           duration:
             kind: exact
             value: P1Y
@@ -49,14 +49,14 @@ offers:
             basis_points: 5000
             kind: exact
         - benefit_id: ben_02
-          description: Kickoff and training calls with the Lightdash data team.
+          description: Kickoff and training calls with the Lightdash data team
           kind: other
         - benefit_id: ben_03
-          description: Expert support and direct access to the product team for feedback and beta features.
+          description: Expert support and direct access to our product team for feedback and beta features
           kind: other
       consideration:
-        kind: unknown
-        description: The cited source does not establish separate consideration beyond the offer terms.
+        kind: variable
+        description: 50% off Lightdash Cloud or Pro for 12 months
     eligibility:
       rule:
         kind: all


### PR DESCRIPTION
Closes #250.

The prior implementations were closed without merge, and the maintainer explicitly invited a fresh contribution after Sourcey's canonical Entity authoring cutover. This pull request adds the missing Lightdash startup offer in the current `entities/` schema using current first-party sources.

The record models:
- 50% off Lightdash Cloud or Pro for 12 months (stated value up to USD 18,000)
- personalized onboarding and training
- a dedicated support channel with direct product-team access
- published eligibility: under five years old and under USD 7.5 million raised
- the public application route linked from the startup-program page

Canonical sources:
- https://www.lightdash.com/startups
- https://www.lightdash.com/start

Validation:
- Sourcey signed identity-context preflight passed: 1 Entity, 1 Program, 1 Offer
- `git diff --check upstream/main...HEAD` passed
- commit includes DCO sign-off

This contribution is also being delivered against Frantic bounty #120; acceptance and payment remain provider/maintainer decisions.
Provider verification links:
- Raw entity YAML: https://raw.githubusercontent.com/nwinkelman2/startup-credits/3fcbabb3b47cfc203ba91ff370ff34c6946d11bc/entities/li/lightdash.yaml
- Exact pull-request diff: https://github.com/sourcey/startup-credits/pull/1019.diff
- Exact signed-off commit: https://github.com/nwinkelman2/startup-credits/commit/3fcbabb3b47cfc203ba91ff370ff34c6946d11bc
- Catalog validation job: https://github.com/sourcey/startup-credits/actions/runs/33342308843/job/99340036642
- Sourcey validation run: https://github.com/sourcey/startup-credits/actions/runs/33342308843