### PR TITLE
data: add FabricBloc Founders Program

### DIFF
--- a/entities/fa/fabricbloc.yaml
+++ b/entities/fa/fabricbloc.yaml
@@ -1,0 +1,81 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1ahj1p55ts52njv7fpcyzs2
+  slug: fabricbloc
+  slug_aliases: []
+  name: FabricBloc
+  domains:
+    - value: fabricbloc.com
+      role: primary
+      valid_from: 2026-08-30T23:55:03.000Z
+  category: payments-fintech
+profile:
+  description: FabricBloc provides APIs and a macOS Studio for creating and operating onchain wallets, tokens, NFTs, vaults, analytics, and scoped agent workflows.
+  links:
+    site: https://fabricbloc.com/
+sources:
+  - source_id: src_4438dd7a46173f3427687773135e2bab85f4ff07cf8f7dac65f19265a8b500c7
+    url: https://fabricbloc.com/founders
+programs:
+  - program_id: prg_01m1ahj1pbm9dx724kdw8n3zx4
+    program_slug: fabricbloc-founders-program
+    program_slug_aliases: []
+    title: FabricBloc Founders Program
+    summary: Pre-seed and seed-stage technical teams can receive FabricBloc PRO free for 12 months plus engineering office hours, priority support, early API access, and launch co-marketing.
+    source_ids:
+      - src_4438dd7a46173f3427687773135e2bab85f4ff07cf8f7dac65f19265a8b500c7
+offers:
+  - offer_id: off_01m1ahj1pbd3shr5fx244fnemp
+    program_id: prg_01m1ahj1pbm9dx724kdw8n3zx4
+    offer_slug: fabricbloc-pro-free-for-one-year
+    offer_slug_aliases: []
+    title: FabricBloc PRO free for 12 months
+    summary: Eligible pre-seed and seed-stage teams receive FabricBloc PRO free for 12 months, monthly engineering office hours, priority support, early API access, and launch co-marketing.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-30T23:55:03.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: FabricBloc PRO free for 12 months
+          duration:
+            kind: exact
+            value: P1Y
+          kind: free-service
+          service: FabricBloc PRO
+        - benefit_id: ben_02
+          description: Monthly office hours with the FabricBloc engineering team
+          kind: other
+        - benefit_id: ben_03
+          description: Priority support channel
+          kind: other
+        - benefit_id: ben_04
+          description: Early access to new APIs and features
+          kind: other
+        - benefit_id: ben_05
+          description: Co-marketing support for the team's launch
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: not-machine-evaluable
+            statement: Must be a pre-seed or seed-stage team building a primary product on FabricBloc
+          - criterion_id: cri_02
+            kind: manual
+            reason: not-machine-evaluable
+            statement: At least one technical co-founder is required
+    roles:
+      terms_authority_entity_id: ent_01m1ahj1p55ts52njv7fpcyzs2
+      access_operator_entity_id: ent_01m1ahj1p55ts52njv7fpcyzs2
+    access:
+      availability: public
+      method: form
+      url: https://fabricbloc.com/contact
+    terms_url: https://fabricbloc.com/founders
+    source_ids:
+      - src_4438dd7a46173f3427687773135e2bab85f4ff07cf8f7dac65f19265a8b500c7


### PR DESCRIPTION
## What changed

Adds FabricBloc and one Founders Program offer in `entities/fa/fabricbloc.yaml`: eligible pre-seed and seed-stage technical teams receive 12 months of FabricBloc PRO, engineering office hours, priority support, early API access, and launch co-marketing. Closes #1020.

The September 14 revision adds the required 119-character `profile.summary`. Existing entity, program, offer, and source identifiers are preserved.

## Sources

The canonical [Founders Program page](https://fabricbloc.com/founders) supports the profile through its platform and Studio descriptions. Its program benefits list also explicitly includes monthly engineering office hours and launch co-marketing, the two benefits flagged in the September 6 review. Both remain in the YAML because the current official page supports them.

## Validation

Local verification parsed the YAML, checked the profile length limits, and confirmed the revision changes only the summary field. Both commits include the DCO Signed-off-by trailer. The new head is `60817ca030b715cd48bed6b576142dd83f0a92a0`; its [catalog validation run](https://github.com/sourcey/startup-credits/actions/runs/34799000720) passed, including the DCO check and `sourcey/validation`. The [new admission report](https://artifacts.sourcey.com/catalog/admission-results/sha256-bbd433bcb1fa7329b71b6ea24a236dcb671ab24f96d5b0b6ebb3759cc6d5ab59/report.json) clears the summary issue but rejects for `claim_unsupported` on the two benefits discussed above and `exact_conflict` with the FabricBloc record in later PR #1374. Those remaining issues require maintainer review.

## Certification

- [x] I changed only allowed repository content and did not mix Entity YAML with other paths.
- [x] Public sources substantiate every submitted factual value; any Sourcey-written prose is a neutral summary, not a fabricated vendor quote.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commits include a `Signed-off-by` line.
