### PR TITLE
data: add Zimev Startup Program

### DIFF
--- a/entities/zi/zimev.yaml
+++ b/entities/zi/zimev.yaml
@@ -1,0 +1,91 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1ajpaz6ytnzq93htbcfmfcv
+  slug: zimev
+  slug_aliases: []
+  name: Zimev
+  domains:
+    - value: zimev.com
+      role: primary
+      valid_from: 2026-08-31T00:14:47.000Z
+  category: hosting-infra
+profile:
+  description: Zimev provides cloud VPS, VDS, dedicated-server, and bare-metal hosting infrastructure with technical support.
+  links:
+    site: https://www.zimev.com/
+sources:
+  - source_id: src_bd68605d35a88249c24c4e892f9a45d83294a9989dbd631be3587fa6e932da1b
+    url: https://www.zimev.com/startup-program/
+programs:
+  - program_id: prg_01m1ajpazaj2r1d94wswthnqqv
+    program_slug: zimev-startup-program
+    program_slug_aliases: []
+    title: Zimev Startup Program
+    summary: Zimev assigns accepted startups to a 12-month Founders or Growth Stage cloud-credit tier and reviews applications monthly on a rolling basis.
+    source_ids:
+      - src_bd68605d35a88249c24c4e892f9a45d83294a9989dbd631be3587fa6e932da1b
+offers:
+  - offer_id: off_01m1ajpazavv388xkm52aeaf2j
+    program_id: prg_01m1ajpazaj2r1d94wswthnqqv
+    offer_slug: tiered-twelve-month-cloud-credits
+    offer_slug_aliases: []
+    title: Twelve-month tiered cloud credits
+    summary: >-
+      Accepted startups receive a stage-matched 12-month tier: Founders provides up to $1,000 for Cloud VPS, VDS, and Dedicated Servers; Growth Stage provides up to $10,000 across Zimev's public-cloud range.
+    description: Zimev reviews applications monthly on a rolling basis. Accepted startups can begin using the program after acceptance and receive technical assistance alongside the credits.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-31T00:14:47.000Z
+    economics:
+      consideration:
+        kind: fixed
+        amount:
+          currency: USD
+          minor_units: 100
+      benefits:
+        - benefit_id: ben_01
+          description: The Founders tier provides up to $1,000 in credits for 10Gbps Cloud VPS, VDS, and Dedicated Servers; the Growth Stage tier provides up to $10,000 in credits across Zimev's public-cloud infrastructure.
+          kind: credit
+          value:
+            kind: up-to
+            amount:
+              currency: USD
+              minor_units: 1000000
+          duration:
+            kind: exact
+            value: P1Y
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: vendor-discretion
+            statement: Any startup may apply regardless of vertical; Zimev prioritizes SaaS, media, and gaming startups and reviews applications monthly on a rolling basis.
+          - criterion_id: cri_02
+            kind: manual
+            reason: vendor-discretion
+            statement: Zimev assigns successful applicants by stage, with the Founders tier intended for the youngest projects and the Growth Stage tier intended for startups through Series A.
+          - criterion_id: cri_03
+            kind: manual
+            reason: external-verification
+            statement: Applicant must create a commercial Zimev account for the startup using a corporate email address on the same domain as its working company website and identify the corporate entity in the Company field.
+          - criterion_id: cri_04
+            kind: manual
+            reason: external-verification
+            statement: Applicant must connect a valid credit card to the Zimev account and pay the required $1 USD card-verification fee.
+          - criterion_id: cri_05
+            kind: manual
+            reason: external-verification
+            statement: Managed hosting providers, MSPs, system integrators, and other resellers are not eligible.
+    roles:
+      terms_authority_entity_id: ent_01m1ajpaz6ytnzq93htbcfmfcv
+      access_operator_entity_id: ent_01m1ajpaz6ytnzq93htbcfmfcv
+    access:
+      availability: public
+      method: form
+      url: https://www.zimev.com/startup-program/
+      instructions: Create a commercial Zimev business account with a company-domain email and matching working website, connect a valid credit card and complete the $1 USD verification charge, then submit the startup-program form. Applications are reviewed monthly on a rolling basis.
+    terms_url: https://www.zimev.com/startup-program/
+    source_ids:
+      - src_bd68605d35a88249c24c4e892f9a45d83294a9989dbd631be3587fa6e932da1b


### PR DESCRIPTION
## What changed

Adds Zimev and its 12-month Startup Program as one source-backed Program and one Offer. The Offer records the Founders tier (up to $1,000), Growth Stage tier (up to $10,000), supported infrastructure, rolling monthly review, account prerequisites, and the required $1 USD card-verification fee.

Closes #1028

## Sources

- https://www.zimev.com/startup-program/

## Certification

- [x] I changed only allowed repository content and did not mix Entity YAML with other paths.
- [x] Public sources substantiate every submitted factual value; any Sourcey-written prose is a neutral summary, not a fabricated vendor quote.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commits include a `Signed-off-by` line.