### PR TITLE
data: add Ultralytics for Startups

### DIFF
--- a/entities/ul/ultralytics.yaml
+++ b/entities/ul/ultralytics.yaml
@@ -1,0 +1,87 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1am5sz6fjf4tmpkc7244k6j
+  slug: ultralytics
+  slug_aliases: []
+  name: Ultralytics
+  domains:
+    - value: ultralytics.com
+      role: primary
+      valid_from: 2026-08-31T00:40:53.000Z
+  category: ai-ml
+profile:
+  description: Ultralytics builds computer vision software, including the YOLO model family and a platform for annotation, training, and deployment.
+  links:
+    site: https://www.ultralytics.com
+sources:
+  - source_id: src_4e1449d53c3ffef9c2a445ca5d99c6bb99af103105d2237d6716a78717d0e598
+    url: https://www.ultralytics.com/startups
+programs:
+  - program_id: prg_01m1am5szgke03tn18arqe4msf
+    program_slug: ultralytics-for-startups
+    program_slug_aliases: []
+    title: Ultralytics for Startups
+    summary: Ultralytics supports VC-backed Seed and later startups building computer vision products with Platform credits, Enterprise Licensing savings, and expert guidance.
+    source_ids:
+      - src_4e1449d53c3ffef9c2a445ca5d99c6bb99af103105d2237d6716a78717d0e598
+offers:
+  - offer_id: off_01m1am5szhv3hypy8bj2x1vmn8
+    program_id: prg_01m1am5szgke03tn18arqe4msf
+    offer_slug: ultralytics-for-startups
+    offer_slug_aliases: []
+    title: Ultralytics for Startups
+    summary: Eligible VC-backed startups from Seed through later rounds can receive up to $10,000 in Ultralytics Platform credits, first-year Enterprise Licensing savings, and computer vision guidance.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-31T00:40:53.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $10,000 in Ultralytics Platform credits for eligible Platform services such as dataset organization, YOLO26 training, and production deployment preparation. Credits are not general-purpose cloud credits.
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 1000000
+            kind: up-to
+        - benefit_id: ben_02
+          description: Qualified startups can save on the first year of an Ultralytics Enterprise License for private and commercial YOLO products.
+          kind: discount
+        - benefit_id: ben_03
+          description: Guidance from Ultralytics computer vision experts on a practical path from use case and data to training, deployment, and scale.
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.stage
+            kind: predicate
+            operator: in
+            statement: Privately held, for-profit startups that have raised institutional Seed, Series A, Series B, Series C, or later funding.
+            value:
+              type: string-set
+              values:
+                - Seed
+                - Series A
+                - Series B
+                - Series C
+          - criterion_id: cri_02
+            kind: manual
+            reason: vendor-discretion
+            statement: Computer vision is central to the product or planned for a concrete use case within the next 90 days.
+          - criterion_id: cri_03
+            kind: manual
+            reason: vendor-discretion
+            statement: The team has a company website, a business email, and enough product context to begin evaluating or building now.
+    roles:
+      terms_authority_entity_id: ent_01m1am5sz6fjf4tmpkc7244k6j
+      access_operator_entity_id: ent_01m1am5sz6fjf4tmpkc7244k6j
+    access:
+      availability: public
+      method: form
+      url: https://www.ultralytics.com/startups#startup-application
+    source_ids:
+      - src_4e1449d53c3ffef9c2a445ca5d99c6bb99af103105d2237d6716a78717d0e598

--- a/entities/ul/ultralytics.yaml
+++ b/entities/ul/ultralytics.yaml
@@ -45,8 +45,8 @@ offers:
               minor_units: 1000000
             kind: up-to
         - benefit_id: ben_02
-          description: Qualified startups can save on the first year of an Ultralytics Enterprise License for private and commercial YOLO products.
-          kind: discount
+          description: Qualified startups can save on the first year of an Ultralytics Enterprise License for private and commercial YOLO products. The vendor page does not publish a fixed percentage.
+          kind: other
         - benefit_id: ben_03
           description: Guidance from Ultralytics computer vision experts on a practical path from use case and data to training, deployment, and scale.
           kind: other
@@ -82,6 +82,6 @@ offers:
     access:
       availability: public
       method: form
-      url: https://www.ultralytics.com/startups#startup-application
+      url: https://www.ultralytics.com/startups
     source_ids:
       - src_4e1449d53c3ffef9c2a445ca5d99c6bb99af103105d2237d6716a78717d0e598

--- a/entities/ul/ultralytics.yaml
+++ b/entities/ul/ultralytics.yaml
@@ -10,6 +10,7 @@ entity:
       valid_from: 2026-08-31T00:40:53.000Z
   category: ai-ml
 profile:
+  summary: Ultralytics builds computer vision software, including the YOLO model family and a platform for annotation, training, and deployment.
   description: Ultralytics builds computer vision software, including the YOLO model family and a platform for annotation, training, and deployment.
   links:
     site: https://www.ultralytics.com
@@ -35,9 +36,11 @@ offers:
       status: active
       effective_from: 2026-08-31T00:40:53.000Z
     economics:
+      consideration:
+        kind: none
       benefits:
         - benefit_id: ben_01
-          description: Up to $10,000 in Ultralytics Platform credits for eligible Platform services such as dataset organization, YOLO26 training, and production deployment preparation. Credits are not general-purpose cloud credits.
+          description: Up to $10,000 in Platform credits across eligible Ultralytics Platform services to organize datasets, train YOLO26 models, and prepare production deployments. Credits are not general-purpose cloud credits.
           kind: credit
           value:
             amount:
@@ -45,37 +48,27 @@ offers:
               minor_units: 1000000
             kind: up-to
         - benefit_id: ben_02
-          description: Qualified startups can save on the first year of an Ultralytics Enterprise License for private and commercial YOLO products. The vendor page does not publish a fixed percentage.
+          description: Qualified startups can save on the first year of an Ultralytics Enterprise License for private and commercial YOLO products.
           kind: other
         - benefit_id: ben_03
-          description: Guidance from Ultralytics computer vision experts on a practical path from use case and data to training, deployment, and scale.
+          description: Guidance from Ultralytics computer vision experts to shape a practical path from use case and data to training, deployment, and scale.
           kind: other
-      consideration:
-        kind: none
     eligibility:
       rule:
         kind: all
         rules:
           - criterion_id: cri_01
-            fact: company.stage
-            kind: predicate
-            operator: in
+            kind: manual
+            reason: vendor-discretion
             statement: Privately held, for-profit startups that have raised institutional Seed, Series A, Series B, Series C, or later funding.
-            value:
-              type: string-set
-              values:
-                - Seed
-                - Series A
-                - Series B
-                - Series C
           - criterion_id: cri_02
             kind: manual
             reason: vendor-discretion
-            statement: Computer vision is central to the product or planned for a concrete use case within the next 90 days.
+            statement: Computer vision is central to your product or planned for a concrete use case within the next 90 days.
           - criterion_id: cri_03
             kind: manual
             reason: vendor-discretion
-            statement: The team has a company website, a business email, and enough product context to begin evaluating or building now.
+            statement: Your team has a company website, a business email, and enough product context to begin evaluating or building now.
     roles:
       terms_authority_entity_id: ent_01m1am5sz6fjf4tmpkc7244k6j
       access_operator_entity_id: ent_01m1am5sz6fjf4tmpkc7244k6j


### PR DESCRIPTION
## Summary
Adds one data-only Entity for Ultralytics with a single offer for the Ultralytics for Startups program.

- First-party source: https://www.ultralytics.com/startups
- Offer: up to $10,000 in Ultralytics Platform credits, first-year Enterprise Licensing savings, and computer vision guidance (one application bundle)
- Reservation: #1030

## Notes
Facts are limited to what the vendor page states. Access is the on-page startup application form.