### PR TITLE
data: add Productlane Early Stage program

### DIFF
--- a/entities/pr/productlane.yaml
+++ b/entities/pr/productlane.yaml
@@ -1,0 +1,118 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1angtwz2pfnxqyfe0fnr269
+  slug: productlane
+  slug_aliases: []
+  name: Productlane
+  domains:
+    - value: productlane.com
+      role: primary
+      valid_from: 2026-08-31T01:04:13.905Z
+  category: support
+profile:
+  description: Productlane provides a Linear-native support platform with an inbox, AI agent, help center, feedback portal, roadmaps, and changelog.
+  links:
+    site: https://productlane.com
+sources:
+  - source_id: src_6fab27f32e19ab949dc077e2d787fb3c7fe7821fca061395a360ab566a105f2e
+    url: https://hello.productlane.com/docs/administration/startup-program
+  - source_id: src_36ed81ec9b1f80015b7e94a5abb388f0534feb7735318b71abe355d3ca373a5a
+    url: https://productlane.com/startup
+programs:
+  - program_id: prg_01m1angtx6neabhd1s6fgkt2cr
+    program_slug: early-stage-program
+    program_slug_aliases: []
+    title: Productlane Early Stage Program
+    summary: Productlane gives eligible early-stage companies its Scale plan for six full seats on a three-year price schedule, with unlimited viewer seats and a first-year AI Agent allowance.
+    source_ids:
+      - src_6fab27f32e19ab949dc077e2d787fb3c7fe7821fca061395a360ab566a105f2e
+      - src_36ed81ec9b1f80015b7e94a5abb388f0534feb7735318b71abe355d3ca373a5a
+offers:
+  - offer_id: off_01m1angtx7q2gcwcxg2hqr4g2c
+    program_id: prg_01m1angtx6neabhd1s6fgkt2cr
+    offer_slug: early-stage-scale-plan
+    offer_slug_aliases: []
+    title: Productlane Early Stage Scale Plan
+    summary: Approved startups get six Scale seats for $65 per month in year one and $451 per month in year two, plus unlimited viewers and 200 free AI Agent resolutions monthly in year one.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-31T01:04:13.905Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          applies_to: Productlane Scale plan with six full seats during year one
+          description: The first-year price is $65 per month, an 89% discount from the published $594 monthly list price.
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            kind: exact
+            basis_points: 8900
+        - benefit_id: ben_02
+          applies_to: Productlane Scale plan with six full seats during year two
+          description: The second-year price is $451 per month, a 24% discount from the published $594 monthly list price.
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            kind: exact
+            basis_points: 2400
+        - benefit_id: ben_03
+          description: Unlimited internal viewer seats are free and are not billed.
+          kind: free-service
+          service: Productlane internal viewer seats
+        - benefit_id: ben_04
+          description: The first year includes 200 free Productlane Agent resolutions per month.
+          duration:
+            kind: exact
+            value: P1Y
+          kind: free-service
+          service: 200 Productlane Agent resolutions per month
+      consideration:
+        kind: variable
+        description: The program is a 12-month contract billed monthly; the standard six-seat schedule costs $65 per month in year one, $451 per month in year two, and $594 per month in year three.
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: The company must have raised less than $10 million in funding.
+            value:
+              type: number
+              value: 10000000
+          - criterion_id: cri_02
+            fact: company.employee_count
+            kind: predicate
+            operator: lt
+            statement: The company must have fewer than 15 employees.
+            value:
+              type: number
+              value: 15
+          - criterion_id: cri_03
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: The company must not have previously used a paid Productlane plan.
+            value:
+              type: boolean
+              value: false
+          - criterion_id: cri_04
+            kind: manual
+            reason: external-verification
+            statement: The standard program supports no more than six full seats; viewer seats do not count toward this limit.
+    roles:
+      terms_authority_entity_id: ent_01m1angtwz2pfnxqyfe0fnr269
+      access_operator_entity_id: ent_01m1angtwz2pfnxqyfe0fnr269
+    access:
+      availability: public
+      method: form
+      url: https://productlane.com/startup
+    terms_url: https://hello.productlane.com/docs/administration/startup-program
+    source_ids:
+      - src_6fab27f32e19ab949dc077e2d787fb3c7fe7821fca061395a360ab566a105f2e
+      - src_36ed81ec9b1f80015b7e94a5abb388f0534feb7735318b71abe355d3ca373a5a


### PR DESCRIPTION
## What changed

Adds Productlane as a canonical Entity record with its current Early Stage program and one structured Scale-plan offer.

The record captures the published three-year pricing schedule, first- and second-year discounts, unlimited viewer seats, first-year Productlane Agent allowance, eligibility rules, contract terms, and public application path from Productlane's own pages.

Closes #571.

## Evidence

- Program details and terms: https://hello.productlane.com/docs/administration/startup-program
- Public application: https://productlane.com/startup
- No current Productlane implementation was open when the issue was reserved.

## Validation

- Ran the exact lockfile-pinned Sourcey Catalog Verifier against the live parent release.
- Result: entities: 1, programs: 1, offers: 1.
- Identity-context digest: sha256:9f9b1a1ed28298d2de1f626c08ea42050e984d200e59eaf1d2eabcb2c6d55b70.
- Commit includes DCO sign-off.