### PR TITLE
data: add XFA startup offer

### DIFF
--- a/entities/xf/xfa.yaml
+++ b/entities/xf/xfa.yaml
@@ -1,0 +1,54 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1awsktzw38vjb65d13x4xgd
+  slug: xfa
+  slug_aliases: []
+  name: XFA
+  domains:
+    - value: xfa.tech
+      role: primary
+      valid_from: 2026-08-31T03:11:39.000Z
+  category: auth-security
+profile:
+  description: XFA provides device-security software for securing access from work devices.
+  links:
+    site: https://xfa.tech
+sources:
+  - source_id: src_c855f35b038bc64af77e4dd954e54bb730166583b206c5042bf552d8ff9da31b
+    url: https://xfa.tech/usecases/startups
+programs: []
+offers:
+  - offer_id: off_01m1awskv2rqv3nm65zq4et2wq
+    offer_slug: free-xfa-for-two-years-up-to-five-users
+    offer_slug_aliases: []
+    title: Free XFA for two years for up to five users
+    summary: Startups can apply for free access to the XFA solution for two years for up to five users.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-31T03:11:39.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Free access to the XFA solution for two years for up to five users.
+          duration:
+            kind: exact
+            value: P2Y
+          kind: free-service
+          service: XFA solution for up to five users
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: not-machine-evaluable
+        statement: Applicant must be a startup.
+    roles:
+      terms_authority_entity_id: ent_01m1awsktzw38vjb65d13x4xgd
+      access_operator_entity_id: ent_01m1awsktzw38vjb65d13x4xgd
+    access:
+      availability: public
+      method: form
+      url: https://xfa.tech/usecases/startups
+    source_ids:
+      - src_c855f35b038bc64af77e4dd954e54bb730166583b206c5042bf552d8ff9da31b


### PR DESCRIPTION
## What changed

Adds XFA as a new auth-security Entity with one startup Offer. The Offer records free access to the XFA solution for two years for up to five users. No post-program pricing, plan name, regional restriction, or approval guarantee is inferred.

Local preflight against the current upstream main passed with 1 Entity, 0 Programs, and 1 Offer.

Closes #1038

## Sources

- https://xfa.tech/usecases/startups

## Certification

- [x] I changed only allowed repository content and did not mix Entity YAML with other paths.
- [x] Public sources substantiate every submitted factual value; any Sourcey-written prose is a neutral summary, not a fabricated vendor quote.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commits include a `Signed-off-by` line.