### PR TITLE
data: add Optibase startup program

### DIFF
--- a/entities/op/optibase.yaml
+++ b/entities/op/optibase.yaml
@@ -1,0 +1,74 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1b60d3kms3kmgzpyfs0n3vr
+  slug: optibase
+  slug_aliases: []
+  name: Optibase
+  domains:
+    - value: optibase.io
+      role: primary
+      valid_from: 2026-08-31T00:00:00Z
+  category: marketing
+profile:
+  description: Optibase provides no-code A/B testing, split testing, heatmaps, personalization, and conversion analytics for websites.
+  links:
+    site: https://www.optibase.io
+sources:
+  - source_id: src_2f1baa97e7c0a952971fac118483757ea8bed87058a8e46105e4be887533dfb7
+    url: https://www.optibase.io/startup-program
+programs:
+  - program_id: prg_01m1b60d408d3sshe3e2j6ztzd
+    program_slug: startup-program
+    program_slug_aliases: []
+    title: Optibase for Startups
+    summary: Optibase offers eligible early-stage startups a custom discount on monthly or yearly subscriptions for one year.
+    source_ids:
+      - src_2f1baa97e7c0a952971fac118483757ea8bed87058a8e46105e4be887533dfb7
+offers:
+  - offer_id: off_01m1b60d40maeztp489fgppbm1
+    program_id: prg_01m1b60d408d3sshe3e2j6ztzd
+    offer_slug: startup-subscription-discount
+    offer_slug_aliases: []
+    title: Optibase Startup Subscription Discount
+    summary: Approved startups receive a custom discount code for an Optibase monthly or yearly subscription, valid for one year.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-31T00:00:00Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: A custom discount on an Optibase monthly or yearly subscription for one year, with the amount provided after approval.
+          kind: other
+      consideration:
+        kind: unknown
+        description: The discounted price is provided after Optibase approves the startup application.
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: The startup must be less than one year old.
+          - criterion_id: cri_02
+            kind: manual
+            reason: external-verification
+            statement: The startup must have fewer than five employees.
+          - criterion_id: cri_03
+            kind: manual
+            reason: external-verification
+            statement: The startup must generate less than $50,000 in annual revenue.
+          - criterion_id: cri_04
+            kind: manual
+            reason: vendor-discretion
+            statement: Optibase approval is required.
+    roles:
+      terms_authority_entity_id: ent_01m1b60d3kms3kmgzpyfs0n3vr
+      access_operator_entity_id: ent_01m1b60d3kms3kmgzpyfs0n3vr
+    access:
+      availability: public
+      method: other
+      url: https://www.optibase.io/startup-program
+      instructions: Contact Optibase through the startup-program page; approved startups receive a custom discount code.
+    source_ids:
+      - src_2f1baa97e7c0a952971fac118483757ea8bed87058a8e46105e4be887533dfb7

--- a/entities/op/optibase.yaml
+++ b/entities/op/optibase.yaml
@@ -12,8 +12,6 @@ entity:
 profile:
   summary: No-code A/B testing, personalization, heatmaps, and conversion analytics for websites.
   description: Optibase provides no-code A/B testing, split testing, heatmaps, personalization, and conversion analytics for websites.
-  links:
-    site: https://www.optibase.io
 sources:
   - source_id: src_2f1baa97e7c0a952971fac118483757ea8bed87058a8e46105e4be887533dfb7
     url: https://www.optibase.io/startup-program
@@ -38,11 +36,9 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: A custom discount on an Optibase monthly or yearly subscription for one year, with the amount provided after approval.
           kind: other
       consideration:
         kind: unknown
-        description: The discounted price is provided after Optibase approves the startup application.
     eligibility:
       rule:
         kind: all

--- a/entities/op/optibase.yaml
+++ b/entities/op/optibase.yaml
@@ -36,9 +36,11 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
+          description: Approved startups receive a custom Optibase subscription discount code for one year.
           kind: other
       consideration:
         kind: unknown
+        description: The cited source does not establish separate consideration beyond the offer terms.
     eligibility:
       rule:
         kind: all

--- a/entities/op/optibase.yaml
+++ b/entities/op/optibase.yaml
@@ -13,7 +13,7 @@ profile:
   summary: No-code A/B testing, personalization, heatmaps, and conversion analytics for websites.
   description: Optibase provides no-code A/B testing, split testing, heatmaps, personalization, and conversion analytics for websites.
   links:
-    site: https://www.optibase.io
+    site: https://www.optibase.io/
 sources:
   - source_id: src_2f1baa97e7c0a952971fac118483757ea8bed87058a8e46105e4be887533dfb7
     url: https://www.optibase.io/startup-program

--- a/entities/op/optibase.yaml
+++ b/entities/op/optibase.yaml
@@ -13,7 +13,7 @@ profile:
   summary: No-code A/B testing, personalization, heatmaps, and conversion analytics for websites.
   description: Optibase provides no-code A/B testing, split testing, heatmaps, personalization, and conversion analytics for websites.
   links:
-    site: https://www.optibase.io
+    site: https://www.optibase.io/startup-program
 sources:
   - source_id: src_2f1baa97e7c0a952971fac118483757ea8bed87058a8e46105e4be887533dfb7
     url: https://www.optibase.io/startup-program
@@ -38,11 +38,11 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: Approved startups receive a custom Optibase subscription discount code for one year.
+          description: A custom discount for your monthly or yearly subscription.
           kind: other
       consideration:
-        kind: unknown
-        description: The cited source does not establish separate consideration beyond the offer terms.
+        kind: variable
+        description: Apply when upgrading your current plan or starting a new subscription.
     eligibility:
       rule:
         kind: all

--- a/entities/op/optibase.yaml
+++ b/entities/op/optibase.yaml
@@ -10,6 +10,7 @@ entity:
       valid_from: 2026-08-31T00:00:00Z
   category: marketing
 profile:
+  summary: No-code A/B testing, personalization, heatmaps, and conversion analytics for websites.
   description: Optibase provides no-code A/B testing, split testing, heatmaps, personalization, and conversion analytics for websites.
   links:
     site: https://www.optibase.io
@@ -68,7 +69,6 @@ offers:
     access:
       availability: public
       method: other
-      url: https://www.optibase.io/startup-program
       instructions: Contact Optibase through the startup-program page; approved startups receive a custom discount code.
     source_ids:
       - src_2f1baa97e7c0a952971fac118483757ea8bed87058a8e46105e4be887533dfb7

--- a/entities/op/optibase.yaml
+++ b/entities/op/optibase.yaml
@@ -12,6 +12,8 @@ entity:
 profile:
   summary: No-code A/B testing, personalization, heatmaps, and conversion analytics for websites.
   description: Optibase provides no-code A/B testing, split testing, heatmaps, personalization, and conversion analytics for websites.
+  links:
+    site: https://www.optibase.io
 sources:
   - source_id: src_2f1baa97e7c0a952971fac118483757ea8bed87058a8e46105e4be887533dfb7
     url: https://www.optibase.io/startup-program

--- a/entities/op/optibase.yaml
+++ b/entities/op/optibase.yaml
@@ -13,10 +13,12 @@ profile:
   summary: No-code A/B testing, personalization, heatmaps, and conversion analytics for websites.
   description: Optibase provides no-code A/B testing, split testing, heatmaps, personalization, and conversion analytics for websites.
   links:
-    site: https://www.optibase.io/startup-program
+    site: https://www.optibase.io
 sources:
   - source_id: src_2f1baa97e7c0a952971fac118483757ea8bed87058a8e46105e4be887533dfb7
     url: https://www.optibase.io/startup-program
+  - source_id: src_23c3c0b1f288bbd174001e81166fa6f819f8972bfde39c89a569cf00925915cc
+    url: https://www.optibase.io
 programs:
   - program_id: prg_01m1b60d408d3sshe3e2j6ztzd
     program_slug: startup-program


### PR DESCRIPTION
## What changed

Adds one new Optibase entity and one startup-program offer from the current first-party program page. The record captures the one-year custom subscription discount, published eligibility criteria, vendor approval, and public access route.

Closes #1046.

## Evidence

- Current first-party Optibase startup-program page and public application route.
- One Entity YAML only; no existing catalog file is modified.

## Validation

- Sourcey catalog validation passed.
- DCO sign-off is present on the commit.

Signed-off-by: Noah Winkelman <nwinkelman2@users.noreply.github.com>