### PR TITLE
data: add Fallax, auxx.Ai, and Lodgestory startup programs

### DIFF
--- a/entities/au/auxx.yaml
+++ b/entities/au/auxx.yaml
@@ -1,0 +1,86 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1bm0w59g34hrq47vk6axm9m
+  slug: auxx
+  slug_aliases: []
+  name: auxx.Ai
+  domains:
+    - value: auxx.ai
+      role: primary
+      valid_from: 2026-08-31T09:57:31.607Z
+  category: support
+profile:
+  description: auxx.Ai provides an AI customer-support platform that drafts replies, manages conversations, and automates support workflows.
+  links:
+    site: https://auxx.ai
+sources:
+  - source_id: src_37d4410520842e1d2bd3391e7c4ba9dd427a5cc7e9257fae26f6babadca2d7e3
+    url: https://auxx.ai/startups
+programs:
+  - program_id: prg_01m1bm0w59b8xjgakaz7qjc20x
+    program_slug: auxx-for-startups
+    program_slug_aliases: []
+    title: auxx.Ai for Startups
+    summary: Eligible startups receive phased discounts on the auxx.Ai Growth plan for three years, starting at 90% off in year one.
+    source_ids:
+      - src_37d4410520842e1d2bd3391e7c4ba9dd427a5cc7e9257fae26f6babadca2d7e3
+offers:
+  - offer_id: off_01m1bm0w59yqg8g25sfyqatyvv
+    program_id: prg_01m1bm0w59b8xjgakaz7qjc20x
+    offer_slug: three-year-growth-plan-discount
+    offer_slug_aliases: []
+    title: Up to 90% off auxx.Ai Growth for three years
+    summary: Qualified startups pay $5 per month in year one, $25 per month in year two, and $37.50 per month in year three for the normally $50-per-month Growth plan.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-31T09:57:31.607Z
+    economics:
+      consideration:
+        kind: variable
+        description: The discounted monthly price is $5 in year one, $25 in year two, and $37.50 in year three before returning to standard pricing.
+      benefits:
+        - benefit_id: ben_01
+          applies_to: auxx.Ai Growth plan
+          description: 90% off the Growth plan in year one
+          kind: discount
+          percentage:
+            kind: exact
+            basis_points: 9000
+          duration:
+            kind: exact
+            value: P1Y
+        - benefit_id: ben_02
+          applies_to: auxx.Ai Growth plan
+          description: 50% off the Growth plan in year two
+          kind: discount
+          percentage:
+            kind: exact
+            basis_points: 5000
+          duration:
+            kind: exact
+            value: P1Y
+        - benefit_id: ben_03
+          applies_to: auxx.Ai Growth plan
+          description: 25% off the Growth plan in year three
+          kind: discount
+          percentage:
+            kind: exact
+            basis_points: 2500
+          duration:
+            kind: exact
+            value: P1Y
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_01
+        statement: The startup must have raised no more than USD 10 million and have fewer than 15 team members.
+        reason: vendor-discretion
+    roles:
+      terms_authority_entity_id: ent_01m1bm0w59g34hrq47vk6axm9m
+      access_operator_entity_id: ent_01m1bm0w59g34hrq47vk6axm9m
+    access:
+      availability: public
+      method: automatic
+      url: https://auxx.ai/startups
+    source_ids:
+      - src_37d4410520842e1d2bd3391e7c4ba9dd427a5cc7e9257fae26f6babadca2d7e3

--- a/entities/fa/fallax.yaml
+++ b/entities/fa/fallax.yaml
@@ -1,0 +1,63 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1bm0w51ntzz3znbpbznjev0
+  slug: fallax
+  slug_aliases: []
+  name: Fallax
+  domains:
+    - value: fallax.io
+      role: primary
+      valid_from: 2026-08-31T09:57:31.607Z
+  category: legal-compliance
+profile:
+  description: Fallax is an employee phishing simulation and security-awareness platform with evidence exports for compliance and audits.
+  links:
+    site: https://fallax.io
+sources:
+  - source_id: src_b4626effcd583dfe0fef2e98ff6071521cfac3737fd830ec0bbd4206adab5c73
+    url: https://fallax.io/startups
+programs:
+  - program_id: prg_01m1bm0w52abpwmcfw1954nahp
+    program_slug: fallax-for-startups
+    program_slug_aliases: []
+    title: Fallax for Startups
+    summary: Eligible startups receive Fallax for up to 50 staff at no cost for 12 months, including unlimited campaigns, administrators, and evidence export.
+    source_ids:
+      - src_b4626effcd583dfe0fef2e98ff6071521cfac3737fd830ec0bbd4206adab5c73
+offers:
+  - offer_id: off_01m1bm0w525v1k453bd7yyyc1s
+    program_id: prg_01m1bm0w52abpwmcfw1954nahp
+    offer_slug: twelve-months-free-for-fifty-staff
+    offer_slug_aliases: []
+    title: 12 months free for up to 50 staff
+    summary: Qualified startups get Fallax free for 12 months for up to 50 staff, with unlimited campaigns, unlimited administrators, and compliance-ready evidence export.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-31T09:57:31.607Z
+    economics:
+      consideration:
+        kind: variable
+        description: The first 50 staff seats are free during the first year; seats above 50 use Fallax's published standard rate.
+      benefits:
+        - benefit_id: ben_01
+          description: Fallax for up to 50 staff at no cost for 12 months, including unlimited campaigns, administrators, and evidence export.
+          kind: free-service
+          service: Fallax for up to 50 staff
+          duration:
+            kind: exact
+            value: P1Y
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_01
+        statement: The company must have fewer than 100 people including contractors, no more than EUR 10 million raised, be founded within the past three years, be new to Fallax, use Fallax only for its own staff, and apply within 90 days of signup.
+        reason: vendor-discretion
+    roles:
+      terms_authority_entity_id: ent_01m1bm0w51ntzz3znbpbznjev0
+      access_operator_entity_id: ent_01m1bm0w51ntzz3znbpbznjev0
+    access:
+      availability: public
+      method: contact
+      url: https://fallax.io/startups
+    source_ids:
+      - src_b4626effcd583dfe0fef2e98ff6071521cfac3737fd830ec0bbd4206adab5c73

--- a/entities/lo/lodgestory.yaml
+++ b/entities/lo/lodgestory.yaml
@@ -1,0 +1,93 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1bm0w6jmxdge32e4qhrhbmh
+  slug: lodgestory
+  slug_aliases: []
+  name: Lodgestory
+  domains:
+    - value: lodgestory.com
+      role: primary
+      valid_from: 2026-08-31T09:57:31.607Z
+  category: support
+profile:
+  description: Lodgestory is an omnichannel customer communication platform with shared inboxes, automation, AI agents, and reporting.
+  links:
+    site: https://lodgestory.com
+sources:
+  - source_id: src_82d33385765de8048e06f188d514040041a042bb78683d0447b57c2b4286ab90
+    url: https://lodgestory.com/resources/blog/lodgestory-early-stage-program-startups
+  - source_id: src_82d33385765de8048e06f188d514040041a042bb78683d0447b57c2b4286ab91
+    url: https://lodgestory.com/signup
+programs:
+  - program_id: prg_01m1bm0w6kb6qtps5dt2axhwqj
+    program_slug: lodgestory-early-stage-program
+    program_slug_aliases: []
+    title: Lodgestory Early Stage Program
+    summary: Eligible early-stage startups receive three years of stepped discounts on Lodgestory Advanced, starting at 90% off in year one.
+    source_ids:
+      - src_82d33385765de8048e06f188d514040041a042bb78683d0447b57c2b4286ab90
+offers:
+  - offer_id: off_01m1bm0w6k8sxpdve2rqbbyhzx
+    program_id: prg_01m1bm0w6kb6qtps5dt2axhwqj
+    offer_slug: three-year-advanced-plan-discount
+    offer_slug_aliases: []
+    title: Up to 90% off Lodgestory Advanced for three years
+    summary: Accepted startups get 90% off Lodgestory Advanced in year one, 50% off in year two, and 25% off in year three, plus up to 300 AI agent resolutions monthly.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-31T09:57:31.607Z
+    economics:
+      consideration:
+        kind: variable
+        description: Discounted pricing starts at $65 per month in year one and steps down to smaller percentage discounts in years two and three.
+      benefits:
+        - benefit_id: ben_01
+          applies_to: Lodgestory Advanced plan
+          description: 90% off Lodgestory Advanced in year one
+          kind: discount
+          percentage:
+            kind: exact
+            basis_points: 9000
+          duration:
+            kind: exact
+            value: P1Y
+        - benefit_id: ben_02
+          applies_to: Lodgestory Advanced plan
+          description: 50% off Lodgestory Advanced in year two
+          kind: discount
+          percentage:
+            kind: exact
+            basis_points: 5000
+          duration:
+            kind: exact
+            value: P1Y
+        - benefit_id: ben_03
+          applies_to: Lodgestory Advanced plan
+          description: 25% off Lodgestory Advanced in year three
+          kind: discount
+          percentage:
+            kind: exact
+            basis_points: 2500
+          duration:
+            kind: exact
+            value: P1Y
+        - benefit_id: ben_04
+          description: Up to 300 AI agent resolutions per month during the program
+          kind: free-service
+          service: Up to 300 Lodgestory AI agent resolutions per month
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_01
+        statement: The startup must have raised no more than USD 10 million, have fewer than 15 full-time employees, and not currently be on a paid Lodgestory plan.
+        reason: vendor-discretion
+    roles:
+      terms_authority_entity_id: ent_01m1bm0w6jmxdge32e4qhrhbmh
+      access_operator_entity_id: ent_01m1bm0w6jmxdge32e4qhrhbmh
+    access:
+      availability: public
+      method: form
+      url: https://lodgestory.com/signup
+    source_ids:
+      - src_82d33385765de8048e06f188d514040041a042bb78683d0447b57c2b4286ab90
+      - src_82d33385765de8048e06f188d514040041a042bb78683d0447b57c2b4286ab91


### PR DESCRIPTION
## What changed

Added data-only Entity records for three current startup programs:
- Fallax for Startups (resolves #1051)
- auxx.Ai for Startups (resolves #1052)
- Lodgestory Early Stage Program (resolves #1053)

## Sources

- https://fallax.io/startups
- https://auxx.ai/startups
- https://lodgestory.com/resources/blog/lodgestory-early-stage-program-startups
- https://lodgestory.com/signup

## Certification

- [x] I changed only allowed repository content and did not mix Entity YAML with other paths.
- [x] Public sources substantiate every submitted factual value; Sourcey-written prose is a neutral summary.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commits include a Signed-off-by line.