### PR TITLE
data: add AgentMail startup program

### DIFF
--- a/entities/ag/agentmail.yaml
+++ b/entities/ag/agentmail.yaml
@@ -1,0 +1,86 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1c2a0zpk1wx0kkvnvx50nmf
+  slug: agentmail
+  slug_aliases: []
+  name: AgentMail
+  domains:
+    - value: agentmail.to
+      role: primary
+      valid_from: 2026-08-31T14:06:56.000Z
+  category: communication
+profile:
+  description: AgentMail provides programmable email inboxes and infrastructure for AI agents.
+  links:
+    site: https://www.agentmail.to
+sources:
+  - source_id: src_84a1cbcf334e998aad8a8257972599369dc4d6772b8962bbcebf85e3c8fad175
+    url: https://www.agentmail.to/startups
+programs:
+  - program_id: prg_01m1c2a0zrsx5p2t74nsg2zyxq
+    program_slug: agentmail-for-startups
+    program_slug_aliases: []
+    title: AgentMail for Startups
+    summary: AgentMail's startup program gives eligible early-stage AI-agent companies three months of its Startup tier at no cost.
+    source_ids:
+      - src_84a1cbcf334e998aad8a8257972599369dc4d6772b8962bbcebf85e3c8fad175
+offers:
+  - offer_id: off_01m1c2a0zrdkbxrqczzwsmcfgy
+    program_id: prg_01m1c2a0zrsx5p2t74nsg2zyxq
+    offer_slug: three-months-free-startup-tier
+    offer_slug_aliases: []
+    title: Three months free on AgentMail Startup
+    summary: Approved startups receive three months of AgentMail's USD 200-per-month Startup tier free, including 150 inboxes, 150 custom domains, 10 organization seats, and a SOC 2 report.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-31T14:06:56.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Three months of the AgentMail Startup tier, normally priced at USD 200 per month
+          kind: free-service
+          service: AgentMail Startup tier
+          duration:
+            kind: exact
+            value: P3M
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: The applicant is an early-stage startup building with AI agents.
+          - criterion_id: cri_02
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: gte
+            statement: The startup has raised at least USD 500,000 in funding.
+            value:
+              type: number
+              value: 500000
+          - criterion_id: cri_03
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lte
+            statement: The startup has raised no more than USD 10 million in funding.
+            value:
+              type: number
+              value: 10000000
+          - criterion_id: cri_04
+            kind: manual
+            reason: external-verification
+            statement: The applicant is not currently and has never previously been an AgentMail customer.
+    roles:
+      terms_authority_entity_id: ent_01m1c2a0zpk1wx0kkvnvx50nmf
+      access_operator_entity_id: ent_01m1c2a0zpk1wx0kkvnvx50nmf
+    access:
+      availability: public
+      instructions: Submit the public startup-program form. AgentMail says no credit card is required and that applications are reviewed within a few business days.
+      method: form
+      url: https://www.agentmail.to/startups
+    terms_url: https://www.agentmail.to/startups
+    source_ids:
+      - src_84a1cbcf334e998aad8a8257972599369dc4d6772b8962bbcebf85e3c8fad175


### PR DESCRIPTION
## What changed

Adds AgentMail as one canonical Entity record with its named startup program and one current offer: three months of the USD 200/month Startup tier at no cost. The record captures the published feature limits, funding range, new-customer requirement, public application route, and no-card condition.

Closes #729

## Sources

- https://www.agentmail.to/startups

## Verification

- Pinned local Catalog Verifier passed: 1 entity, 1 program, 1 offer.

## Certification

- [x] I changed only allowed repository content and did not mix Entity YAML with other paths.
- [x] Public first-party sources substantiate every submitted factual value; Sourcey-written prose is a neutral summary.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commit includes a Signed-off-by line.

AI-assisted contribution, independently source-checked and reviewed by the operator.