### PR TITLE
data: add Greptile startup discount

### DIFF
--- a/entities/gr/greptile.yaml
+++ b/entities/gr/greptile.yaml
@@ -1,0 +1,66 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1c3xn4zv8y9ccn41rk3hnv5
+  slug: greptile
+  slug_aliases: []
+  name: Greptile
+  domains:
+    - value: greptile.com
+      role: primary
+      valid_from: 2026-08-31T14:35:07.000Z
+  category: devtools-other
+profile:
+  description: Greptile provides AI-powered code review that analyzes codebases and reviews pull requests.
+  links:
+    site: https://www.greptile.com
+sources:
+  - source_id: src_d124523d6200c012a15f89245e5b5b6b6506fbb349c89673fdaad44f1d37dedb
+    url: https://www.greptile.com/startup-discount
+programs: []
+offers:
+  - offer_id: off_01m1c3xn50q8p5s9pptpr4hrwe
+    offer_slug: early-stage-startup-discount
+    offer_slug_aliases: []
+    title: 50% off Greptile for early-stage startups
+    summary: Eligible pre-Series A startups with less than USD 2 million in revenue over the past 12 months receive 50% off Greptile.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-31T14:35:07.000Z
+    economics:
+      benefits:
+        - applies_to: Greptile subscription
+          benefit_id: ben_01
+          description: 50% off Greptile
+          kind: discount
+          percentage:
+            basis_points: 5000
+            kind: exact
+      consideration:
+        description: Subscription to Greptile at the discounted price.
+        kind: unknown
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: The applicant is a pre-Series A startup.
+          - criterion_id: cri_02
+            fact: company.annual_revenue_usd
+            kind: predicate
+            operator: lt
+            statement: The startup generated less than USD 2 million in revenue over the past 12 months.
+            value:
+              type: number
+              value: 2000000
+    roles:
+      terms_authority_entity_id: ent_01m1c3xn4zv8y9ccn41rk3hnv5
+      access_operator_entity_id: ent_01m1c3xn4zv8y9ccn41rk3hnv5
+    access:
+      availability: public
+      method: form
+      url: https://www.greptile.com/startup-discount
+    terms_url: https://www.greptile.com/startup-discount
+    source_ids:
+      - src_d124523d6200c012a15f89245e5b5b6b6506fbb349c89673fdaad44f1d37dedb


### PR DESCRIPTION
## What changed

Adds Greptile as one canonical Entity record with one current startup-specific offer: 50% off for pre-Series A companies with less than USD 2 million in revenue over the past 12 months.

Closes #695

## Sources

- https://www.greptile.com/startup-discount

## Verification

- Pinned local Catalog Verifier passed: 1 entity, 0 programs, 1 offer.

## Certification

- [x] I changed only allowed repository content and did not mix Entity YAML with other paths.
- [x] The public first-party source substantiates every submitted factual value; Sourcey-written prose is a neutral summary.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commit includes a Signed-off-by line.

AI-assisted contribution, independently source-checked and reviewed by the operator.