### PR TITLE
data: add Mixedbread startup credits

### DIFF
--- a/entities/mi/mixedbread.yaml
+++ b/entities/mi/mixedbread.yaml
@@ -1,0 +1,84 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1c4vntb4k9bqgxctg9snt19
+  slug: mixedbread
+  slug_aliases: []
+  name: Mixedbread
+  domains:
+    - value: mixedbread.com
+      role: primary
+      valid_from: 2026-08-31T14:51:40.000Z
+  category: ai-ml
+profile:
+  description: Mixedbread provides multimodal search infrastructure for indexing and retrieving text, images, audio, and video.
+  links:
+    site: https://www.mixedbread.com
+    pricing: https://www.mixedbread.com/pricing
+sources:
+  - source_id: src_eb03f4bb398b3d172930bc6f92d638243398c5f5d31323cc48bdddb4657cb33f
+    url: https://www.mixedbread.com/pricing
+programs:
+  - program_id: prg_01m1c4vntd9nge959h1hfp4hdy
+    program_slug: mixedbread-for-startups
+    program_slug_aliases: []
+    title: Mixedbread for Startups
+    summary: Qualified startups can receive an initial grant of one-time Mixedbread credits, with additional credits considered case by case.
+    source_ids:
+      - src_eb03f4bb398b3d172930bc6f92d638243398c5f5d31323cc48bdddb4657cb33f
+offers:
+  - offer_id: off_01m1c4vntddgrb0dqknz2a7d3d
+    program_id: prg_01m1c4vntd9nge959h1hfp4hdy
+    offer_slug: 250-in-one-time-startup-credits
+    offer_slug_aliases: []
+    title: $250 in one-time Mixedbread startup credits
+    summary: Qualified startups receive an initial $250 in one-time Mixedbread credits, with additional credits potentially available case by case.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-31T14:51:40.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: $250 in one-time Mixedbread credits
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 25000
+            kind: exact
+      consideration:
+        kind: variable
+        description: Applicants must already be paying Mixedbread users; the qualifying plan and spend are not specified on the public page.
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: The startup is an existing paying Mixedbread user.
+            value:
+              type: boolean
+              value: true
+          - criterion_id: cri_02
+            kind: manual
+            reason: external-verification
+            statement: The startup has raised funding from institutional venture capital firms.
+          - criterion_id: cri_03
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lte
+            statement: The startup has raised no more than $20 million in venture funding.
+            value:
+              type: number
+              value: 20000000
+    roles:
+      terms_authority_entity_id: ent_01m1c4vntb4k9bqgxctg9snt19
+      access_operator_entity_id: ent_01m1c4vntb4k9bqgxctg9snt19
+    access:
+      availability: public
+      method: form
+      url: https://www.mixedbread.com/pricing
+    terms_url: https://www.mixedbread.com/pricing
+    source_ids:
+      - src_eb03f4bb398b3d172930bc6f92d638243398c5f5d31323cc48bdddb4657cb33f


### PR DESCRIPTION
## What changed

Added one current-schema Entity record for Mixedbread with one source-backed program and one offer. Reauthors the retired-schema contribution after the maintainer invitation in #730.

Closes #730.

## Sources

- https://www.mixedbread.com/pricing

## Validation

The exact lockfile-pinned Catalog Verifier passes locally for one Entity, one Program, and one Offer against the live parent release and signed identity context.

## Certification

- [x] I changed only one allowed Entity YAML file.
- [x] The first-party source substantiates the submitted economics, eligibility, and access facts.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] The commit includes a DCO Signed-off-by line.

AI-assisted contribution, source-checked and reviewed by the operator.