### PR TITLE
data: add ProductBridge Early Stage Program

### DIFF
--- a/entities/pr/productbridge.yaml
+++ b/entities/pr/productbridge.yaml
@@ -71,7 +71,7 @@ offers:
             kind: exact
             value: P6M
       consideration:
-        kind: unknown
+        kind: variable
         description: Nothing for the first six months; $14 a month for months 7–12, $29 for months 13–18, and $44 for months 19–24.
     eligibility:
       rule:

--- a/entities/pr/productbridge.yaml
+++ b/entities/pr/productbridge.yaml
@@ -37,15 +37,13 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: Full Growth plan access at no cost during months one through six
+          description: $0 a month; the full product is free for six months.
           kind: free-service
-          service: ProductBridge Growth plan
           duration:
             kind: exact
             value: P6M
-        - applies_to: ProductBridge Growth plan during months seven through twelve
-          benefit_id: ben_02
-          description: 75% off the $59 monthly Growth plan list price during months seven through twelve
+        - benefit_id: ben_02
+          description: 75% off; $14 a month against the $59 list price during months 7–12.
           kind: discount
           percentage:
             basis_points: 7500
@@ -53,9 +51,8 @@ offers:
           duration:
             kind: exact
             value: P6M
-        - applies_to: ProductBridge Growth plan during months thirteen through eighteen
-          benefit_id: ben_03
-          description: 50% off the $59 monthly Growth plan list price during months thirteen through eighteen
+        - benefit_id: ben_03
+          description: 50% off; $29 a month against the $59 list price during months 13–18.
           kind: discount
           percentage:
             basis_points: 5000
@@ -63,9 +60,8 @@ offers:
           duration:
             kind: exact
             value: P6M
-        - applies_to: ProductBridge Growth plan during months nineteen through twenty-four
-          benefit_id: ben_04
-          description: 25% off the $59 monthly Growth plan list price during months nineteen through twenty-four
+        - benefit_id: ben_04
+          description: 25% off; $44 a month against the $59 list price during months 19–24.
           kind: discount
           percentage:
             basis_points: 2500
@@ -75,7 +71,7 @@ offers:
             value: P6M
       consideration:
         kind: variable
-        description: The startup pays $14 per month in months 7–12, $29 per month in months 13–18, and $44 per month in months 19–24; billing is monthly with no contract.
+        description: Nothing for the first six months; $14 a month for months 7–12, $29 for months 13–18, and $44 for months 19–24.
     eligibility:
       rule:
         kind: all

--- a/entities/pr/productbridge.yaml
+++ b/entities/pr/productbridge.yaml
@@ -39,6 +39,7 @@ offers:
         - benefit_id: ben_01
           description: $0 a month; the full product is free for six months.
           kind: free-service
+          service: ProductBridge Growth plan
           duration:
             kind: exact
             value: P6M

--- a/entities/pr/productbridge.yaml
+++ b/entities/pr/productbridge.yaml
@@ -1,0 +1,113 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1bnbt8wayga8xzknz1m6kfk
+  slug: productbridge
+  slug_aliases: []
+  name: ProductBridge
+  domains:
+    - value: productbridge.io
+      role: primary
+      valid_from: 2026-08-31T10:20:44.791Z
+  category: support
+profile:
+  description: ProductBridge combines customer feedback, surveys, support chat, help-center content, roadmaps, and changelogs in one product platform.
+  links:
+    site: https://productbridge.io
+sources:
+  - source_id: src_829de5df3d3714388a987b97d46da22149c2abb3d5d00866312bf8f17c70fc17
+    url: https://productbridge.io/early-stage-program
+programs:
+  - program_id: prg_01m1bnbt93q1vrvzc8p5ve36s5
+    program_slug: early-stage-program
+    program_slug_aliases: []
+    title: ProductBridge Early Stage Program
+    summary: ProductBridge gives eligible young startups six free months, followed by stepped discounts through month 24 on its Growth plan.
+    source_ids:
+      - src_829de5df3d3714388a987b97d46da22149c2abb3d5d00866312bf8f17c70fc17
+offers:
+  - offer_id: off_01m1bnbt93hhagce71y66sv6wf
+    program_id: prg_01m1bnbt93q1vrvzc8p5ve36s5
+    offer_slug: growth-plan-two-year-stepped-discount
+    offer_slug_aliases: []
+    title: Six months free, then stepped Growth plan discounts
+    summary: Eligible startups get the Growth plan free for six months, then pay $14, $29, and $44 per month in successive six-month periods through month 24.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-31T10:20:44.791Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Full Growth plan access at no cost during months one through six
+          kind: free-service
+          service: ProductBridge Growth plan
+          duration:
+            kind: exact
+            value: P6M
+        - applies_to: ProductBridge Growth plan during months seven through twelve
+          benefit_id: ben_02
+          description: 75% off the $59 monthly Growth plan list price during months seven through twelve
+          kind: discount
+          percentage:
+            basis_points: 7500
+            kind: exact
+          duration:
+            kind: exact
+            value: P6M
+        - applies_to: ProductBridge Growth plan during months thirteen through eighteen
+          benefit_id: ben_03
+          description: 50% off the $59 monthly Growth plan list price during months thirteen through eighteen
+          kind: discount
+          percentage:
+            basis_points: 5000
+            kind: exact
+          duration:
+            kind: exact
+            value: P6M
+        - applies_to: ProductBridge Growth plan during months nineteen through twenty-four
+          benefit_id: ben_04
+          description: 25% off the $59 monthly Growth plan list price during months nineteen through twenty-four
+          kind: discount
+          percentage:
+            basis_points: 2500
+            kind: exact
+          duration:
+            kind: exact
+            value: P6M
+      consideration:
+        kind: variable
+        description: The startup pays $14 per month in months 7–12, $29 per month in months 13–18, and $44 per month in months 19–24; billing is monthly with no contract.
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: The company has raised less than $1,000,000 in funding.
+            value:
+              type: number
+              value: 1000000
+          - criterion_id: cri_02
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: The company was founded less than two years ago.
+            value:
+              type: number
+              value: 24
+          - criterion_id: cri_03
+            kind: manual
+            reason: external-verification
+            statement: The company has never previously been on a paid ProductBridge plan.
+    roles:
+      terms_authority_entity_id: ent_01m1bnbt8wayga8xzknz1m6kfk
+      access_operator_entity_id: ent_01m1bnbt8wayga8xzknz1m6kfk
+    access:
+      availability: public
+      instructions: Apply through ProductBridge's Early Stage Program form; applications are reviewed manually.
+      method: form
+      url: https://productbridge.io/early-stage-program
+    terms_url: https://productbridge.io/early-stage-program
+    source_ids:
+      - src_829de5df3d3714388a987b97d46da22149c2abb3d5d00866312bf8f17c70fc17

--- a/entities/pr/productbridge.yaml
+++ b/entities/pr/productbridge.yaml
@@ -10,6 +10,7 @@ entity:
       valid_from: 2026-08-31T10:20:44.791Z
   category: support
 profile:
+  summary: Customer-feedback and product-management platform.
   description: ProductBridge combines customer feedback, surveys, support chat, help-center content, roadmaps, and changelogs in one product platform.
   links:
     site: https://productbridge.io
@@ -72,7 +73,7 @@ offers:
             value: P6M
       consideration:
         kind: variable
-        description: Nothing for the first six months; $14 a month for months 7–12, $29 for months 13–18, and $44 for months 19–24.
+        description: No charge for the first six months; for each later month the subscription remains active, the recipient pays $14 a month in months 7–12, $29 a month in months 13–18, $44 a month in months 19–24, and the standard $59 a month from month 25. The subscription may be cancelled in any month without paying out the remaining discount.
     eligibility:
       rule:
         kind: all

--- a/entities/pr/productbridge.yaml
+++ b/entities/pr/productbridge.yaml
@@ -71,7 +71,7 @@ offers:
             kind: exact
             value: P6M
       consideration:
-        kind: variable
+        kind: unknown
         description: Nothing for the first six months; $14 a month for months 7–12, $29 for months 13–18, and $44 for months 19–24.
     eligibility:
       rule:


### PR DESCRIPTION
## What changed

Adds ProductBridge as one new catalog entity with exactly one Early Stage Program offer. The offer records the vendor-published 24-month schedule: six months free, then 75%, 50%, and 25% discounts in successive six-month periods, plus the published funding, company-age, and new-customer eligibility rules.

Closes #1049.

## Sources

- https://productbridge.io/early-stage-program

## Certification

- [x] I changed only allowed repository content and did not mix Entity YAML with other paths.
- [x] Public sources substantiate every submitted factual value; any Sourcey-written prose is a neutral summary, not a fabricated vendor quote.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commits include a `Signed-off-by` line.