### PR TITLE
data: add MYFUNDBOX Startup Program

### DIFF
--- a/entities/my/myfundbox.yaml
+++ b/entities/my/myfundbox.yaml
@@ -1,0 +1,74 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1cx37k357fxfrvarkx2r0qy
+  slug: myfundbox
+  slug_aliases: []
+  name: MYFUNDBOX
+  domains:
+    - value: myfundbox.com
+      role: primary
+      valid_from: 2026-08-31T21:55:05.224Z
+  category: payments-fintech
+profile:
+  description: MYFUNDBOX provides subscription billing, recurring payments, invoicing, tax management, and revenue analytics for SaaS companies.
+  links:
+    site: https://myfundbox.com
+sources:
+  - source_id: src_7f3557ce594aa03c71bb498beeef80e2f07c9b32a1a18ed57d1f42e6ceeeff9a
+    url: https://myfundbox.com/startup-program
+programs:
+  - program_id: prg_01m1cx37kbxsxmxrz3w2zgkmth
+    program_slug: myfundbox-startup-program
+    program_slug_aliases: []
+    title: MYFUNDBOX Startup Program
+    summary: A two-year subscription-billing program for early-stage SaaS companies, including a free first year and discounted second year.
+    source_ids:
+      - src_7f3557ce594aa03c71bb498beeef80e2f07c9b32a1a18ed57d1f42e6ceeeff9a
+offers:
+  - offer_id: off_01m1cx37kb2n731h7mzpfd8js9
+    program_id: prg_01m1cx37kbxsxmxrz3w2zgkmth
+    offer_slug: myfundbox-startup-two-year-billing-benefit
+    offer_slug_aliases: []
+    title: MYFUNDBOX Two-Year Startup Billing Benefit
+    summary: Eligible SaaS companies receive MYFUNDBOX free for one year on up to $100,000 processed, then 50% off for one year on up to $250,000 processed.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-31T21:55:05.224Z
+    economics:
+      consideration:
+        kind: unknown
+        description: The first year is free; second-year access requires payment at a 50% discount.
+      benefits:
+        - benefit_id: ben_01
+          description: Free MYFUNDBOX subscription billing for the first year, with up to $100,000 in transactions processed
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            kind: exact
+            basis_points: 10000
+        - benefit_id: ben_02
+          description: 50% off MYFUNDBOX for the second year, with up to $250,000 in transactions processed
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            kind: exact
+            basis_points: 5000
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_01
+        statement: Available to SaaS companies, including businesses that are launching or already have customers.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m1cx37k357fxfrvarkx2r0qy
+      access_operator_entity_id: ent_01m1cx37k357fxfrvarkx2r0qy
+    access:
+      availability: public
+      method: form
+      url: https://myfundbox.com/startup-program
+    source_ids:
+      - src_7f3557ce594aa03c71bb498beeef80e2f07c9b32a1a18ed57d1f42e6ceeeff9a


### PR DESCRIPTION
Adds the MYFUNDBOX Startup Program from the vendor's current first-party program page.

The record captures:
- free first-year subscription billing with up to $100,000 processed;
- a 50% second-year discount with up to $250,000 processed;
- the public application path and SaaS-company eligibility described by MYFUNDBOX.

Validation:
- YAML parses successfully.
- The exact public validator reached identity-context validation, but Sourcey's service returned a signer-registry rotation mismatch (`expected sha256:a7c4…`, `received sha256:541b…`) on two fresh unchanged contexts. No validation rule was bypassed.

Closes #1066