### PR TITLE
Data: Add Clientia Startup Program

### DIFF
--- a/entities/cl/clientia.yaml
+++ b/entities/cl/clientia.yaml
@@ -1,0 +1,80 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1cy2hc06yp3xe7yzksryb54
+  slug: clientia
+  slug_aliases: []
+  name: Clientia
+  domains:
+    - value: clientia.app
+      role: primary
+      valid_from: 2026-08-31T22:12:11.042Z
+  category: crm-sales
+profile:
+  description: Clientia is a client operations platform for professional services firms and software businesses, combining records, contracts, billing, and payments.
+  links:
+    site: https://clientia.app
+sources:
+  - source_id: src_b13ad6896d3b219bb61d7e086b00eac26860307c79647128478ece78797de4c2
+    url: https://clientia.app/startups
+programs:
+  - program_id: prg_01m1cy2hc62c34wq99zmjmbpzz
+    program_slug: clientia-founders-programme
+    program_slug_aliases: []
+    title: Clientia Founders Programme
+    summary: Clientia's 12-month programme gives eligible young companies discounted access to its Studio or Atelier client operations plans.
+    source_ids:
+      - src_b13ad6896d3b219bb61d7e086b00eac26860307c79647128478ece78797de4c2
+offers:
+  - offer_id: off_01m1cy2hc67t6rjfgah97qavhf
+    program_id: prg_01m1cy2hc62c34wq99zmjmbpzz
+    offer_slug: clientia-founders-plan-discount
+    offer_slug_aliases: []
+    title: Clientia Founders Plan Discount
+    summary: Eligible companies receive 50% off Clientia Studio or Atelier for 12 months when they are no more than three years old and have under €500,000 annual revenue.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-31T22:12:11.042Z
+    economics:
+      consideration:
+        kind: unknown
+        description: Access requires payment at the discounted Studio or Atelier plan price.
+      benefits:
+        - benefit_id: ben_01
+          applies_to: Studio or Atelier plans
+          description: 50% off Clientia Studio or Atelier for 12 months
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            kind: exact
+            basis_points: 5000
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.age_years
+            kind: predicate
+            operator: lte
+            statement: Company must be no more than three years old from its original incorporation date
+            value:
+              type: number
+              value: 3
+          - criterion_id: cri_02
+            fact: company.annual_revenue_eur
+            kind: predicate
+            operator: lt
+            statement: Annualized revenue must be below EUR 500,000
+            value:
+              type: number
+              value: 500000
+    roles:
+      terms_authority_entity_id: ent_01m1cy2hc06yp3xe7yzksryb54
+      access_operator_entity_id: ent_01m1cy2hc06yp3xe7yzksryb54
+    access:
+      availability: public
+      method: form
+      url: https://clientia.app/startups
+    source_ids:
+      - src_b13ad6896d3b219bb61d7e086b00eac26860307c79647128478ece78797de4c2

--- a/entities/cl/clientia.yaml
+++ b/entities/cl/clientia.yaml
@@ -10,6 +10,7 @@ entity:
       valid_from: 2026-08-31T22:12:11.042Z
   category: crm-sales
 profile:
+  summary: Client operations, contracts, billing, and payments for service firms.
   description: Clientia is a client operations platform for professional services firms and software businesses, combining records, contracts, billing, and payments.
   links:
     site: https://clientia.app
@@ -36,7 +37,7 @@ offers:
       effective_from: 2026-08-31T22:12:11.042Z
     economics:
       consideration:
-        kind: unknown
+        kind: variable
         description: Access requires payment at the discounted Studio or Atelier plan price.
       benefits:
         - benefit_id: ben_01

--- a/entities/cl/clientia.yaml
+++ b/entities/cl/clientia.yaml
@@ -37,8 +37,8 @@ offers:
       effective_from: 2026-08-31T22:12:11.042Z
     economics:
       consideration:
-        kind: unknown
-        description: The cited source does not establish separate consideration beyond the offer terms.
+        kind: variable
+        description: A Clientia Studio or Atelier plan is discounted by 50% for 12 months.
       benefits:
         - benefit_id: ben_01
           applies_to: Studio or Atelier plans

--- a/entities/cl/clientia.yaml
+++ b/entities/cl/clientia.yaml
@@ -38,11 +38,11 @@ offers:
     economics:
       consideration:
         kind: variable
-        description: A Clientia Studio or Atelier plan is discounted by 50% for 12 months.
+        description: Clientia Founders Plan Discount
       benefits:
         - benefit_id: ben_01
           applies_to: Studio or Atelier plans
-          description: 50% off Clientia Studio or Atelier for 12 months
+          description: Clientia Founders Plan Discount
           duration:
             kind: exact
             value: P1Y

--- a/entities/cl/clientia.yaml
+++ b/entities/cl/clientia.yaml
@@ -38,7 +38,6 @@ offers:
     economics:
       consideration:
         kind: variable
-        description: Access requires payment at the discounted Studio or Atelier plan price.
       benefits:
         - benefit_id: ben_01
           applies_to: Studio or Atelier plans

--- a/entities/cl/clientia.yaml
+++ b/entities/cl/clientia.yaml
@@ -38,11 +38,11 @@ offers:
     economics:
       consideration:
         kind: variable
-        description: Clientia Founders Plan Discount
+        description: Founders rate billed monthly through Stripe.
       benefits:
         - benefit_id: ben_01
           applies_to: Studio or Atelier plans
-          description: Clientia Founders Plan Discount
+          description: Half off Studio or Atelier for 12 months.
           duration:
             kind: exact
             value: P1Y

--- a/entities/cl/clientia.yaml
+++ b/entities/cl/clientia.yaml
@@ -37,7 +37,8 @@ offers:
       effective_from: 2026-08-31T22:12:11.042Z
     economics:
       consideration:
-        kind: variable
+        kind: unknown
+        description: The cited source does not establish separate consideration beyond the offer terms.
       benefits:
         - benefit_id: ben_01
           applies_to: Studio or Atelier plans


### PR DESCRIPTION
## Summary
- add Clientia as a canonical startup-credit entity
- document the 50% discount on Studio or Atelier for 12 months
- encode the published company-age and annual-revenue eligibility limits
- cite Clientia's first-party startup-program page

Closes #1065