### PR TITLE
data: add Frienton startup offer

### DIFF
--- a/entities/fr/frienton.yaml
+++ b/entities/fr/frienton.yaml
@@ -1,0 +1,79 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1d52ythvc612506vw2wewev
+  slug: frienton
+  slug_aliases: []
+  name: Frienton
+  domains:
+    - value: frienton.com
+      role: primary
+      valid_from: 2026-09-01T00:00:00.000Z
+  category: finance-accounting
+profile:
+  description: Frienton is a financial operating system for German small and medium-sized businesses, covering banking, bookkeeping, controlling, and reporting.
+  links:
+    site: https://www.frienton.com
+sources:
+  - source_id: src_96a35277a9b72946fc76f76fd80355810dd52c32023eff30bcef173f8c170362
+    url: https://www.frienton.com/startup-offer
+programs:
+  - program_id: prg_01m1d52ytm1ten9hwa6xvjrq7m
+    program_slug: frienton-startup-offer
+    program_slug_aliases: []
+    title: Frienton Startup Offer
+    summary: Frienton's startup offer gives eligible bootstrapping companies a graduated subscription discount, beginning with up to 75% off in the first year.
+    source_ids:
+      - src_96a35277a9b72946fc76f76fd80355810dd52c32023eff30bcef173f8c170362
+offers:
+  - offer_id: off_01m1d52ytn2kzhd2g2vx1mb6yj
+    program_id: prg_01m1d52ytm1ten9hwa6xvjrq7m
+    offer_slug: up-to-75-percent-off-frienton-first-year
+    offer_slug_aliases: []
+    title: Up to 75% Off Frienton in the First Year
+    summary: Eligible bootstrapping startups receive up to 75% off Frienton in the first year when founded within the last three years and spending under EUR 10,000 monthly.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-01T00:00:00.000Z
+    economics:
+      benefits:
+        - applies_to: Frienton subscription
+          benefit_id: ben_01
+          description: Up to 75% off Frienton in the first year.
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            basis_points: 7500
+            kind: up-to
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: Applicant must be a bootstrapping startup.
+          - criterion_id: cri_02
+            fact: company.age_months
+            kind: predicate
+            operator: lte
+            statement: Startup must have been founded within the last three years.
+            value:
+              type: number
+              value: 36
+          - criterion_id: cri_03
+            kind: manual
+            reason: external-verification
+            statement: Startup must have less than EUR 10,000 in monthly expenditures.
+    roles:
+      terms_authority_entity_id: ent_01m1d52ythvc612506vw2wewev
+      access_operator_entity_id: ent_01m1d52ythvc612506vw2wewev
+    access:
+      availability: public
+      method: form
+      url: https://www.frienton.com/startup-offer
+    source_ids:
+      - src_96a35277a9b72946fc76f76fd80355810dd52c32023eff30bcef173f8c170362

--- a/entities/fr/frienton.yaml
+++ b/entities/fr/frienton.yaml
@@ -48,8 +48,8 @@ offers:
             basis_points: 7500
             kind: up-to
       consideration:
-        kind: variable
-        description: The startup pays the subscription price remaining after Frienton's graduated discount.
+        kind: unknown
+        description: Frienton's startup page publishes percentage discounts but not the resulting subscription price.
     eligibility:
       rule:
         criterion_id: cri_01

--- a/entities/fr/frienton.yaml
+++ b/entities/fr/frienton.yaml
@@ -10,6 +10,7 @@ entity:
       valid_from: 2026-09-01T00:00:00.000Z
   category: finance-accounting
 profile:
+  summary: Financial operating system for German small and medium-sized businesses.
   description: Frienton is a financial operating system for German small and medium-sized businesses, covering banking, bookkeeping, controlling, and reporting.
   links:
     site: https://www.frienton.com
@@ -47,27 +48,14 @@ offers:
             basis_points: 7500
             kind: up-to
       consideration:
-        kind: none
+        kind: variable
+        description: The startup pays the subscription price remaining after Frienton's graduated discount.
     eligibility:
       rule:
-        kind: all
-        rules:
-          - criterion_id: cri_01
-            kind: manual
-            reason: external-verification
-            statement: Applicant must be a bootstrapping startup.
-          - criterion_id: cri_02
-            fact: company.age_months
-            kind: predicate
-            operator: lte
-            statement: Startup must have been founded within the last three years.
-            value:
-              type: number
-              value: 36
-          - criterion_id: cri_03
-            kind: manual
-            reason: external-verification
-            statement: Startup must have less than EUR 10,000 in monthly expenditures.
+        criterion_id: cri_01
+        kind: manual
+        reason: external-verification
+        statement: Applicants must be bootstrapping startups founded within the last three years with less than EUR 10,000 in monthly expenditures.
     roles:
       terms_authority_entity_id: ent_01m1d52ythvc612506vw2wewev
       access_operator_entity_id: ent_01m1d52ythvc612506vw2wewev

--- a/entities/fr/frienton.yaml
+++ b/entities/fr/frienton.yaml
@@ -47,8 +47,8 @@ offers:
             basis_points: 7500
             kind: up-to
       consideration:
-        kind: unknown
-        description: The cited source does not establish separate consideration beyond the offer terms.
+        kind: variable
+        description: All shown prices are net.
     eligibility:
       rule:
         criterion_id: cri_01

--- a/entities/fr/frienton.yaml
+++ b/entities/fr/frienton.yaml
@@ -47,7 +47,7 @@ offers:
             basis_points: 7500
             kind: up-to
       consideration:
-        kind: variable
+        kind: unknown
         description: All shown prices are net.
     eligibility:
       rule:

--- a/entities/fr/frienton.yaml
+++ b/entities/fr/frienton.yaml
@@ -37,9 +37,7 @@ offers:
       effective_from: 2026-09-01T00:00:00.000Z
     economics:
       benefits:
-        - applies_to: Frienton subscription
-          benefit_id: ben_01
-          description: Up to 75% off Frienton in the first year.
+        - benefit_id: ben_01
           duration:
             kind: exact
             value: P1Y
@@ -49,7 +47,6 @@ offers:
             kind: up-to
       consideration:
         kind: unknown
-        description: Frienton's startup page publishes percentage discounts but not the resulting subscription price.
     eligibility:
       rule:
         criterion_id: cri_01

--- a/entities/fr/frienton.yaml
+++ b/entities/fr/frienton.yaml
@@ -38,6 +38,7 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
+          description: Eligible startups receive a first-year Frienton subscription discount.
           duration:
             kind: exact
             value: P1Y
@@ -47,6 +48,7 @@ offers:
             kind: up-to
       consideration:
         kind: unknown
+        description: The cited source does not establish separate consideration beyond the offer terms.
     eligibility:
       rule:
         criterion_id: cri_01


### PR DESCRIPTION
## Summary

- add Frienton as a current-schema catalog entity
- model the official startup offer as one program and one first-year discount offer
- encode the published bootstrapping, company-age, and monthly-expenditure eligibility requirements

Closes #698.

## Verification

- `Sourcey verification passed (entities: 1, programs: 1, offers: 1)`
- `git diff origin/main...HEAD --check`
- DCO-signed commit