### PR TITLE
data: add LibertAI Sovereign Program

### DIFF
--- a/entities/li/libertai.yaml
+++ b/entities/li/libertai.yaml
@@ -38,7 +38,7 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: Selected companies can receive LibertAI inference credits.
+          description: Up to $10,000 in inference credits for selected companies building on private inference.
           kind: credit
           value:
             amount:
@@ -46,17 +46,16 @@ offers:
               minor_units: 1000000
             kind: up-to
         - benefit_id: ben_02
-          description: Selected companies can receive migration support from LibertAI.
+          description: Migration support from the LibertAI team.
           kind: other
       consideration:
-        kind: unknown
-        description: The cited source does not establish separate consideration beyond the offer terms.
+        kind: none
     eligibility:
       rule:
         kind: manual
         criterion_id: cri_01
         reason: vendor-discretion
-        statement: Selected early-stage companies building on private inference are eligible.
+        statement: Early-stage teams are eligible, with review handled case by case.
     roles:
       terms_authority_entity_id: ent_01m1d5vpvbvxx3jbdjdd942b21
       access_operator_entity_id: ent_01m1d5vpvbvxx3jbdjdd942b21

--- a/entities/li/libertai.yaml
+++ b/entities/li/libertai.yaml
@@ -50,6 +50,7 @@ offers:
           kind: other
       consideration:
         kind: unknown
+        description: The source record did not establish separate consideration.
     eligibility:
       rule:
         kind: manual

--- a/entities/li/libertai.yaml
+++ b/entities/li/libertai.yaml
@@ -49,7 +49,7 @@ offers:
           description: Migration support from the LibertAI team.
           kind: other
       consideration:
-        kind: none
+        kind: unknown
     eligibility:
       rule:
         kind: manual

--- a/entities/li/libertai.yaml
+++ b/entities/li/libertai.yaml
@@ -10,6 +10,7 @@ entity:
       valid_from: 2026-09-01T00:00:00.000Z
   category: ai-ml
 profile:
+  summary: Private, OpenAI-compatible inference for open-weight models on decentralized infrastructure.
   description: LibertAI provides private, OpenAI-compatible inference for open-weight models on decentralized infrastructure.
   links:
     site: https://libertai.io
@@ -37,7 +38,6 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: Up to $10,000 in inference credits.
           kind: credit
           value:
             amount:
@@ -45,11 +45,9 @@ offers:
               minor_units: 1000000
             kind: up-to
         - benefit_id: ben_02
-          description: Migration support from the LibertAI team.
           kind: other
       consideration:
         kind: unknown
-        description: The public Sovereign Program listing does not state whether any payment is required.
     eligibility:
       rule:
         kind: manual

--- a/entities/li/libertai.yaml
+++ b/entities/li/libertai.yaml
@@ -1,0 +1,74 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1d5vpvbvxx3jbdjdd942b21
+  slug: libertai
+  slug_aliases: []
+  name: LibertAI
+  domains:
+    - value: libertai.io
+      role: primary
+      valid_from: 2026-09-01T00:00:00.000Z
+  category: ai-ml
+profile:
+  description: LibertAI provides private, OpenAI-compatible inference for open-weight models on decentralized infrastructure.
+  links:
+    site: https://libertai.io
+sources:
+  - source_id: src_5d5d8394add0ef6dbe279c2a0d4ffbd8026a74f46f8d5b762d691a62190bd837
+    url: https://libertai.io/
+programs:
+  - program_id: prg_01m1d5vpvernbscde8adbvf6dq
+    program_slug: libertai-sovereign-program
+    program_slug_aliases: []
+    title: LibertAI Sovereign Program
+    summary: LibertAI's Sovereign Program gives selected early-stage companies credits and migration support to build on private model inference.
+    source_ids:
+      - src_5d5d8394add0ef6dbe279c2a0d4ffbd8026a74f46f8d5b762d691a62190bd837
+offers:
+  - offer_id: off_01m1d5vpve1pcqkwjgxm0z08m0
+    program_id: prg_01m1d5vpvernbscde8adbvf6dq
+    offer_slug: up-to-10000-libertai-inference-credits
+    offer_slug_aliases: []
+    title: Up to $10,000 in LibertAI Inference Credits
+    summary: Selected early-stage companies building on private inference receive up to $10,000 in credits for GLM-5.3 and LibertAI's full model catalog, plus migration support.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-01T00:00:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $10,000 in private-inference credits for GLM-5.3 and the full LibertAI model catalog.
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 1000000
+            kind: up-to
+        - benefit_id: ben_02
+          description: Migration support from the LibertAI team.
+          kind: free-service
+          service: Private-inference migration support
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: Applicant must be an early-stage team building on private inference.
+          - criterion_id: cri_02
+            kind: manual
+            reason: external-verification
+            statement: Applications are reviewed case by case and the company must be selected by LibertAI.
+    roles:
+      terms_authority_entity_id: ent_01m1d5vpvbvxx3jbdjdd942b21
+      access_operator_entity_id: ent_01m1d5vpvbvxx3jbdjdd942b21
+    access:
+      availability: public
+      method: contact
+      instructions: Contact LibertAI through the Telegram application link published in the Sovereign Program section.
+      url: https://t.me/libertai
+    source_ids:
+      - src_5d5d8394add0ef6dbe279c2a0d4ffbd8026a74f46f8d5b762d691a62190bd837

--- a/entities/li/libertai.yaml
+++ b/entities/li/libertai.yaml
@@ -38,6 +38,7 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
+          description: Selected companies can receive LibertAI inference credits.
           kind: credit
           value:
             amount:
@@ -45,9 +46,11 @@ offers:
               minor_units: 1000000
             kind: up-to
         - benefit_id: ben_02
+          description: Selected companies can receive migration support from LibertAI.
           kind: other
       consideration:
         kind: unknown
+        description: The cited source does not establish separate consideration beyond the offer terms.
     eligibility:
       rule:
         kind: manual

--- a/entities/li/libertai.yaml
+++ b/entities/li/libertai.yaml
@@ -37,7 +37,7 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: Up to $10,000 in private-inference credits for GLM-5.3 and the full LibertAI model catalog.
+          description: Up to $10,000 in inference credits.
           kind: credit
           value:
             amount:
@@ -46,22 +46,16 @@ offers:
             kind: up-to
         - benefit_id: ben_02
           description: Migration support from the LibertAI team.
-          kind: free-service
-          service: Private-inference migration support
+          kind: other
       consideration:
-        kind: none
+        kind: unknown
+        description: The public Sovereign Program listing does not state whether any payment is required.
     eligibility:
       rule:
-        kind: all
-        rules:
-          - criterion_id: cri_01
-            kind: manual
-            reason: external-verification
-            statement: Applicant must be an early-stage team building on private inference.
-          - criterion_id: cri_02
-            kind: manual
-            reason: external-verification
-            statement: Applications are reviewed case by case and the company must be selected by LibertAI.
+        kind: manual
+        criterion_id: cri_01
+        reason: vendor-discretion
+        statement: Selected early-stage companies building on private inference are eligible.
     roles:
       terms_authority_entity_id: ent_01m1d5vpvbvxx3jbdjdd942b21
       access_operator_entity_id: ent_01m1d5vpvbvxx3jbdjdd942b21


### PR DESCRIPTION
## Summary

- add LibertAI as a current-schema catalog entity
- model its live Sovereign Program as one program and one inference-credit offer
- encode the current early-stage, private-inference, and case-by-case selection criteria

Closes #718.

## Verification

- `Sourcey verification passed (entities: 1, programs: 1, offers: 1)`
- `git diff origin/main...HEAD --check`
- DCO-signed commit