### PR TITLE
data: add Keygraph Community Program

### DIFF
--- a/entities/ke/keygraph.yaml
+++ b/entities/ke/keygraph.yaml
@@ -40,28 +40,18 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: Complete managed Keygraph Pro platform with all generally available modules at no cloud-service charge until a graduation event.
+          description: The full Keygraph Pro platform, with every module included, at $0 in cloud service fees.
           kind: free-service
           service: Keygraph Pro
       consideration:
         kind: variable
-        description: Participants provide and pay for their own AI-provider inference usage through bring-your-own-key integrations.
+        description: Participants pay only for their own AI provider usage.
     eligibility:
       rule:
-        kind: all
-        rules:
-          - criterion_id: cri_01
-            kind: manual
-            reason: external-verification
-            statement: Applicant must be a seed or pre-Series-A startup; individual developers are not eligible.
-          - criterion_id: cri_02
-            kind: manual
-            reason: external-verification
-            statement: Startup must have 20 or fewer Active Developers as measured under Keygraph's terms.
-          - criterion_id: cri_03
-            kind: manual
-            reason: external-verification
-            statement: Program access is cloud-hosted and limited to the startup's internal application-security use; managed-service operation and resale are not permitted.
+        kind: manual
+        criterion_id: cri_01
+        reason: external-verification
+        statement: Eligible startup applicants are seed and pre-Series-A startups with 20 or fewer Active Developers; individual developers are not eligible.
     roles:
       terms_authority_entity_id: ent_01m1d67wcpvcmcr3befxgyyz77
       access_operator_entity_id: ent_01m1d67wcpvcmcr3befxgyyz77

--- a/entities/ke/keygraph.yaml
+++ b/entities/ke/keygraph.yaml
@@ -1,0 +1,75 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1d67wcpvcmcr3befxgyyz77
+  slug: keygraph
+  slug_aliases: []
+  name: Keygraph
+  domains:
+    - value: keygraph.io
+      role: primary
+      valid_from: 2026-09-01T00:00:00.000Z
+  category: auth-security
+profile:
+  description: Keygraph provides a hosted application-security platform for penetration testing, code scanning, remediation, and vulnerability management.
+  links:
+    site: https://keygraph.io
+sources:
+  - source_id: src_d49cc59d5fcdf0f7d6ca686ba70e70e7ae56ae6c15b8abfa488331cc3299d894
+    url: https://keygraph.io/community-program
+  - source_id: src_ddbbca4e16fd70fdc25ae83d92ee233a2688fc296b9e989f55905315f8ce3535
+    url: https://keygraph.io/terms
+programs:
+  - program_id: prg_01m1d67wcw7w6dj18p650gkjpv
+    program_slug: keygraph-community-program
+    program_slug_aliases: []
+    title: Keygraph Community Program
+    summary: Keygraph's Community Program provides eligible startups with its complete managed Pro application-security platform free until a graduation event.
+    source_ids:
+      - src_d49cc59d5fcdf0f7d6ca686ba70e70e7ae56ae6c15b8abfa488331cc3299d894
+      - src_ddbbca4e16fd70fdc25ae83d92ee233a2688fc296b9e989f55905315f8ce3535
+offers:
+  - offer_id: off_01m1d67wcwjy8bfvvchzt9h0yr
+    program_id: prg_01m1d67wcw7w6dj18p650gkjpv
+    offer_slug: free-keygraph-pro-for-startups
+    offer_slug_aliases: []
+    title: Free Keygraph Pro for Eligible Startups
+    summary: Eligible seed and pre-Series-A startups with at most 20 Active Developers receive every Keygraph Pro module free until graduation, with a 90-day free conversion window afterward.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-01T00:00:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Complete managed Keygraph Pro platform with all generally available modules at no cloud-service charge until a graduation event.
+          kind: free-service
+          service: Keygraph Pro
+      consideration:
+        kind: variable
+        description: Participants provide and pay for their own AI-provider inference usage through bring-your-own-key integrations.
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: Applicant must be a seed or pre-Series-A startup; individual developers are not eligible.
+          - criterion_id: cri_02
+            kind: manual
+            reason: external-verification
+            statement: Startup must have 20 or fewer Active Developers as measured under Keygraph's terms.
+          - criterion_id: cri_03
+            kind: manual
+            reason: external-verification
+            statement: Program access is cloud-hosted and limited to the startup's internal application-security use; managed-service operation and resale are not permitted.
+    roles:
+      terms_authority_entity_id: ent_01m1d67wcpvcmcr3befxgyyz77
+      access_operator_entity_id: ent_01m1d67wcpvcmcr3befxgyyz77
+    access:
+      availability: public
+      method: form
+      url: https://docs.google.com/forms/d/e/1FAIpQLSeQs4HV97_0p3L4gZnHCAdBLnd2eqrbTnZPhbSuhdLqSQLygQ/viewform
+    terms_url: https://keygraph.io/terms
+    source_ids:
+      - src_d49cc59d5fcdf0f7d6ca686ba70e70e7ae56ae6c15b8abfa488331cc3299d894
+      - src_ddbbca4e16fd70fdc25ae83d92ee233a2688fc296b9e989f55905315f8ce3535

--- a/entities/ke/keygraph.yaml
+++ b/entities/ke/keygraph.yaml
@@ -41,7 +41,7 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: Eligible startups receive Keygraph Pro free until a graduation event.
+          description: 100% free Keygraph Pro, until you graduate from the program.
           kind: free-service
           service: Keygraph Pro
       consideration:
@@ -52,7 +52,7 @@ offers:
         kind: manual
         criterion_id: cri_01
         reason: external-verification
-        statement: Eligible startup applicants are seed and pre-Series-A startups with 20 or fewer Active Developers; individual developers are not eligible.
+        statement: Seed and pre-Series-A startups with 20 or fewer Active Developers.
     roles:
       terms_authority_entity_id: ent_01m1d67wcpvcmcr3befxgyyz77
       access_operator_entity_id: ent_01m1d67wcpvcmcr3befxgyyz77

--- a/entities/ke/keygraph.yaml
+++ b/entities/ke/keygraph.yaml
@@ -41,7 +41,7 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: 100% free Keygraph Pro, until you graduate from the program.
+          description: Every Keygraph Pro module is free until graduation, with a 90-day free conversion window afterward.
           kind: free-service
           service: Keygraph Pro
       consideration:
@@ -52,7 +52,7 @@ offers:
         kind: manual
         criterion_id: cri_01
         reason: external-verification
-        statement: Seed and pre-Series-A startups with 20 or fewer Active Developers.
+        statement: Eligible applicants are seed and pre-Series-A startups with at most 20 Active Developers.
     roles:
       terms_authority_entity_id: ent_01m1d67wcpvcmcr3befxgyyz77
       access_operator_entity_id: ent_01m1d67wcpvcmcr3befxgyyz77

--- a/entities/ke/keygraph.yaml
+++ b/entities/ke/keygraph.yaml
@@ -41,10 +41,12 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
+          description: Eligible startups receive Keygraph Pro free until a graduation event.
           kind: free-service
           service: Keygraph Pro
       consideration:
-        kind: variable
+        kind: unknown
+        description: The cited source does not establish separate consideration beyond the offer terms.
     eligibility:
       rule:
         kind: manual

--- a/entities/ke/keygraph.yaml
+++ b/entities/ke/keygraph.yaml
@@ -45,8 +45,8 @@ offers:
           kind: free-service
           service: Keygraph Pro
       consideration:
-        kind: unknown
-        description: The cited source does not establish separate consideration beyond the offer terms.
+        kind: variable
+        description: You connect your own AI provider key and pay your provider directly for inference usage.
     eligibility:
       rule:
         kind: manual

--- a/entities/ke/keygraph.yaml
+++ b/entities/ke/keygraph.yaml
@@ -10,6 +10,7 @@ entity:
       valid_from: 2026-09-01T00:00:00.000Z
   category: auth-security
 profile:
+  summary: Hosted application-security platform for penetration testing, code scanning, remediation, and vulnerability management.
   description: Keygraph provides a hosted application-security platform for penetration testing, code scanning, remediation, and vulnerability management.
   links:
     site: https://keygraph.io
@@ -40,12 +41,10 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: The full Keygraph Pro platform, with every module included, at $0 in cloud service fees.
           kind: free-service
           service: Keygraph Pro
       consideration:
         kind: variable
-        description: Participants pay only for their own AI provider usage.
     eligibility:
       rule:
         kind: manual

--- a/entities/ke/keygraph.yaml
+++ b/entities/ke/keygraph.yaml
@@ -41,7 +41,7 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: Every Keygraph Pro module is free until graduation, with a 90-day free conversion window afterward.
+          description: 100% free Keygraph Pro, until you graduate from the program.
           kind: free-service
           service: Keygraph Pro
       consideration:


### PR DESCRIPTION
## Summary

- add Keygraph as a current-schema catalog entity
- model the startup track of its Community Program as one program and one free-service offer
- encode the published stage, Active Developer, BYOK, and internal-use terms from Keygraph's first-party pages

Closes #747.

## Verification

- `Sourcey verification passed (entities: 1, programs: 1, offers: 1)`
- `git diff origin/main...HEAD --check`
- DCO-signed commit