### PR TITLE
data: add Yotta Data Services Rudra offer

### DIFF
--- a/entities/yo/yotta-data-services.yaml
+++ b/entities/yo/yotta-data-services.yaml
@@ -1,0 +1,95 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1d6zn1qbh3b572ezpy0z15d
+  slug: yotta-data-services
+  slug_aliases: []
+  name: Yotta Data Services
+  domains:
+    - value: yotta.com
+      role: primary
+      valid_from: 2026-08-21T18:40:42.000Z
+  category: hosting-infra
+profile:
+  description: Yotta Data Services provides sovereign cloud, AI infrastructure, data centers, and managed technology services for businesses and public-sector organizations.
+  links:
+    site: https://yotta.com
+sources:
+  - source_id: src_b810e0289390b79531258c0a8c52247b2da7e6cc377d5a2c3c73b9f91d1ef9bf
+    url: https://yotta.com/rudra/
+  - source_id: src_e4dad87273de0c193fd98cf1bfb98a1c4e89084dea993868e2b96fbbec724fa3
+    url: https://yotta.com/rudra/eligibility-criteria.html
+  - source_id: src_630d02baffbcfcbb7fcdbd6e09fcb39dda7c544eb811f45fa71b6e500fc90359
+    url: https://yotta.com/rudra/program-structure.html
+  - source_id: src_e0bc660e1b1f96194b2e4170224a4cb054357cfa3268bf08975b408fea2bd09f
+    url: https://yotta.com/rudra/apply-now.html
+programs:
+  - program_id: prg_01m1d6zn1wvpb0d30gydfvx156
+    program_slug: rudra
+    program_slug_aliases: []
+    title: Rudra
+    summary: Yotta's accelerator program supports startups building in AI, machine learning, data science, and high-performance computing with infrastructure, credits, and strategic support.
+    source_ids:
+      - src_b810e0289390b79531258c0a8c52247b2da7e6cc377d5a2c3c73b9f91d1ef9bf
+      - src_e4dad87273de0c193fd98cf1bfb98a1c4e89084dea993868e2b96fbbec724fa3
+offers:
+  - offer_id: off_01m1d6zn1wass13cznbhrxh11r
+    program_id: prg_01m1d6zn1wvpb0d30gydfvx156
+    offer_slug: rudra-launch-tier
+    offer_slug_aliases: []
+    title: Rudra Launch Tier
+    summary: Eligible startups in Rudra's Launch stage can receive up to $10,000 in Shakti Cloud credits, issued in two tranches and valid for six months.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-21T18:40:42.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $10,000 in Shakti Cloud credits, issued as $1,000 and $9,000 tranches.
+          duration:
+            kind: exact
+            value: P6M
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 1000000
+            kind: up-to
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: Startup works on an innovative project in AI, machine learning, data science, or high-performance computing.
+          - criterion_id: cri_02
+            kind: manual
+            reason: external-verification
+            statement: Startup has an active company website and existing LinkedIn profiles for both the applicant and the company.
+          - criterion_id: cri_03
+            kind: manual
+            reason: external-verification
+            statement: Startup is bootstrapped or funded through no later than Series A, including pre-seed, angel, seed, or debt financing.
+          - criterion_id: cri_04
+            kind: manual
+            reason: external-verification
+            statement: Startup has not previously received Yotta credits of the same or greater value through another program.
+          - criterion_id: cri_05
+            kind: manual
+            reason: external-verification
+            statement: Launch-stage company has been operating for less than one year and has annual revenue or funding below $50,000.
+    roles:
+      terms_authority_entity_id: ent_01m1d6zn1qbh3b572ezpy0z15d
+      access_operator_entity_id: ent_01m1d6zn1qbh3b572ezpy0z15d
+    access:
+      availability: public
+      instructions: Complete Yotta's Rudra application form for review.
+      method: form
+      url: https://yotta.com/rudra/apply-now.html
+    source_ids:
+      - src_b810e0289390b79531258c0a8c52247b2da7e6cc377d5a2c3c73b9f91d1ef9bf
+      - src_e4dad87273de0c193fd98cf1bfb98a1c4e89084dea993868e2b96fbbec724fa3
+      - src_630d02baffbcfcbb7fcdbd6e09fcb39dda7c544eb811f45fa71b6e500fc90359
+      - src_e0bc660e1b1f96194b2e4170224a4cb054357cfa3268bf08975b408fea2bd09f

--- a/entities/yo/yotta-data-services.yaml
+++ b/entities/yo/yotta-data-services.yaml
@@ -10,6 +10,7 @@ entity:
       valid_from: 2026-08-21T18:40:42.000Z
   category: hosting-infra
 profile:
+  summary: Sovereign-cloud, AI-infrastructure, data-center, and managed-technology provider.
   description: Yotta Data Services provides sovereign cloud, AI infrastructure, data centers, and managed technology services for businesses and public-sector organizations.
   links:
     site: https://yotta.com


### PR DESCRIPTION
## Summary
- add Yotta Data Services as a new catalog entity
- model the Rudra accelerator and its Launch-tier Shakti Cloud credit offer
- encode the published $10,000 cap, six-month validity, stage requirements, and application route from Yotta's current first-party pages

## Validation
- pinned public Sourcey verifier: passed (1 entity, 1 program, 1 offer)
- `git diff origin/main...HEAD --check`: passed
- DCO sign-off: included

Closes #669