### PR TITLE
data: add Signzy startup offer

### DIFF
--- a/entities/si/signzy.yaml
+++ b/entities/si/signzy.yaml
@@ -1,0 +1,77 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1d8pm5vg0pk22wwffhnsjcz
+  slug: signzy
+  slug_aliases: []
+  name: Signzy
+  domains:
+    - value: signzy.com
+      role: primary
+      valid_from: 2026-08-16T02:02:06.000Z
+  category: auth-security
+profile:
+  description: Signzy provides identity and business verification, background checks, fraud detection, credit assessment, and no-code compliance workflows.
+  links:
+    site: https://www.signzy.com
+sources:
+  - source_id: src_5f20bf17099dbd6233cc1165e63d05d786a490452998f6fe5098aba372e682b4
+    url: https://www.signzy.com/fintech-apis/startups
+  - source_id: src_5108f0a90b3cc4604f42f43db370dbcee5758da8df03f76851886d892ada3894
+    url: https://www.signzy.com/contact-us
+programs:
+  - program_id: prg_01m1d8pm6r6h0thd7p77e8sj4p
+    program_slug: signzy-for-startups
+    program_slug_aliases: []
+    title: Signzy for Startups
+    summary: Signzy's startup initiative provides API sandbox credits, startup-friendly rates, expert mentoring, and access to financial institutions and venture capitalists.
+    source_ids:
+      - src_5f20bf17099dbd6233cc1165e63d05d786a490452998f6fe5098aba372e682b4
+offers:
+  - offer_id: off_01m1d8pm6reaww64jf62svg7xg
+    program_id: prg_01m1d8pm6r6h0thd7p77e8sj4p
+    offer_slug: signzy-for-startups-api-sandbox-credits
+    offer_slug_aliases: []
+    title: INR 5,000 in Signzy API sandbox credits
+    summary: Startups receive INR 5,000 in Signzy API sandbox credits, plus startup-friendly rates, mentoring, and access to financial-institution and venture-capital networks.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-16T02:02:06.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: INR 5,000 in credits for Signzy's API sandbox.
+          kind: credit
+          value:
+            amount:
+              currency: INR
+              minor_units: 500000
+            kind: exact
+        - benefit_id: ben_02
+          description: Startup-friendly rates for Signzy services.
+          kind: other
+        - benefit_id: ben_03
+          description: Access to financial institutions through Signzy's partner network and to venture capitalists.
+          kind: other
+        - benefit_id: ben_04
+          description: Mentoring from seasoned professionals and industry experts.
+          kind: other
+      consideration:
+        kind: unknown
+        description: The public startup page does not publish a program price or other consideration.
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: not-machine-evaluable
+        statement: Applicant is a startup seeking access to Signzy's fintech APIs and startup program benefits.
+    roles:
+      terms_authority_entity_id: ent_01m1d8pm5vg0pk22wwffhnsjcz
+      access_operator_entity_id: ent_01m1d8pm5vg0pk22wwffhnsjcz
+    access:
+      availability: public
+      instructions: Contact Signzy through its public form to request startup program access.
+      method: form
+      url: https://www.signzy.com/contact-us
+    source_ids:
+      - src_5f20bf17099dbd6233cc1165e63d05d786a490452998f6fe5098aba372e682b4
+      - src_5108f0a90b3cc4604f42f43db370dbcee5758da8df03f76851886d892ada3894

--- a/entities/si/signzy.yaml
+++ b/entities/si/signzy.yaml
@@ -40,6 +40,7 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
+          description: Startups receive Signzy API sandbox credits.
           kind: credit
           value:
             amount:
@@ -47,13 +48,17 @@ offers:
               minor_units: 500000
             kind: exact
         - benefit_id: ben_02
+          description: Startups receive startup-friendly rates for Signzy services.
           kind: other
         - benefit_id: ben_03
+          description: Startups receive access to Signzy's financial-institution and venture-capital networks.
           kind: other
         - benefit_id: ben_04
+          description: Startups receive mentoring from Signzy professionals and industry experts.
           kind: other
       consideration:
         kind: unknown
+        description: The cited source does not establish separate consideration beyond the offer terms.
     eligibility:
       rule:
         criterion_id: cri_01
@@ -66,6 +71,7 @@ offers:
     access:
       availability: public
       instructions: Contact Signzy through its public form to request startup program access.
+      method: form
       url: https://www.signzy.com/contact-us
     source_ids:
       - src_5f20bf17099dbd6233cc1165e63d05d786a490452998f6fe5098aba372e682b4

--- a/entities/si/signzy.yaml
+++ b/entities/si/signzy.yaml
@@ -10,6 +10,7 @@ entity:
       valid_from: 2026-08-16T02:02:06.000Z
   category: auth-security
 profile:
+  summary: Identity and business verification, fraud detection, credit assessment, and compliance workflows.
   description: Signzy provides identity and business verification, background checks, fraud detection, credit assessment, and no-code compliance workflows.
   links:
     site: https://www.signzy.com
@@ -39,7 +40,6 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: INR 5,000 in credits for Signzy's API sandbox.
           kind: credit
           value:
             amount:
@@ -47,17 +47,13 @@ offers:
               minor_units: 500000
             kind: exact
         - benefit_id: ben_02
-          description: Startup-friendly rates for Signzy services.
           kind: other
         - benefit_id: ben_03
-          description: Access to financial institutions through Signzy's partner network and to venture capitalists.
           kind: other
         - benefit_id: ben_04
-          description: Mentoring from seasoned professionals and industry experts.
           kind: other
       consideration:
         kind: unknown
-        description: The public startup page does not publish a program price or other consideration.
     eligibility:
       rule:
         criterion_id: cri_01
@@ -70,7 +66,6 @@ offers:
     access:
       availability: public
       instructions: Contact Signzy through its public form to request startup program access.
-      method: form
       url: https://www.signzy.com/contact-us
     source_ids:
       - src_5f20bf17099dbd6233cc1165e63d05d786a490452998f6fe5098aba372e682b4


### PR DESCRIPTION
## Summary
- add Signzy as a canonical Entity record after the repository's schema cutover
- model the Signzy for Startups program and its INR 5,000 API sandbox credit
- include the currently published startup rates, network access, mentoring, and public contact route

## Validation
- pinned public Sourcey verifier: passed (1 entity, 1 program, 1 offer)
- `git diff origin/main...HEAD --check`: passed
- DCO sign-off: included

This is the current-schema re-authoring invited by the maintainer after legacy PR #607 was closed for the vendors-to-entities cutover.

Closes #606