### PR TITLE
data: add LegionEdge startup program

### DIFF
--- a/entities/le/legionedge.yaml
+++ b/entities/le/legionedge.yaml
@@ -1,0 +1,119 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1d98re9dhpj49fffmjj2sj5
+  slug: legionedge
+  slug_aliases: []
+  name: LegionEdge
+  domains:
+    - value: legionedge.ai
+      role: primary
+      valid_from: 2026-08-17T01:43:29.909Z
+  category: ai-ml
+profile:
+  description: LegionEdge is an AI research lab building protocols, datasets, and efficient methods for intelligent applications.
+  links:
+    site: https://legionedge.ai
+    pricing: https://legionedge.ai/pricing
+sources:
+  - source_id: src_41b15c073e3b29108ece0abb36c0aa918d70220215f0f1dc6232bf3f8c2563c9
+    url: https://legionedge.ai/programs/startup
+  - source_id: src_2460ca63c615f04c0c01a410bb9fb5ad2151a39e95dc044cbc83977e48c5eb40
+    url: https://legionedge.ai/pricing
+programs:
+  - program_id: prg_01m1d98rh210pr7ew2c58xgfpv
+    program_slug: legionedge-startup-program
+    program_slug_aliases: []
+    title: LegionEdge Startup Program
+    summary: LegionEdge supports early-stage AI-native product teams with product credits, technical guidance, early access, community, and launch support.
+    source_ids:
+      - src_41b15c073e3b29108ece0abb36c0aa918d70220215f0f1dc6232bf3f8c2563c9
+offers:
+  - offer_id: off_01m1d98rh26g2r1tggxbvtnbrp
+    program_id: prg_01m1d98rh210pr7ew2c58xgfpv
+    offer_slug: legionedge-startup-program
+    offer_slug_aliases: []
+    title: LegionEdge Startup Program
+    summary: Eligible AI-native startups can get up to $25,000 in Nokuva, Tavoc, and Foltrac product credits for 12 months, plus expert guidance, early access, community, and launch support.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-17T01:43:29.909Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $25,000 in product credits across Nokuva, Tavoc, and Foltrac for 12 months.
+          duration:
+            kind: exact
+            value: P1Y
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 2500000
+            kind: up-to
+        - benefit_id: ben_02
+          description: Monthly efficiency office hours with LegionEdge researchers.
+          kind: other
+        - benefit_id: ben_03
+          description: One-to-one architecture reviews with LegionEdge engineers.
+          kind: other
+        - benefit_id: ben_04
+          description: Early access to protocol drafts, product betas, and dataset releases.
+          kind: other
+        - benefit_id: ben_05
+          description: Private founder community and quarterly cohort calls.
+          kind: other
+        - benefit_id: ben_06
+          description: Launch support with potential newsletter and customer-story promotion.
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.stage
+            kind: predicate
+            operator: in
+            statement: Company is at pre-seed, seed, or Series A stage.
+            value:
+              type: string-set
+              values:
+                - pre-seed
+                - seed
+                - series-a
+          - criterion_id: cri_02
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: Company has raised less than $5,000,000.
+            value:
+              type: number
+              value: 5000000
+          - criterion_id: cri_03
+            fact: company.employee_count
+            kind: predicate
+            operator: lt
+            statement: Team has fewer than 20 people.
+            value:
+              type: number
+              value: 20
+          - criterion_id: cri_04
+            kind: manual
+            statement: The company is building a product where AI is core rather than an add-on feature.
+            reason: not-machine-evaluable
+          - criterion_id: cri_05
+            kind: manual
+            statement: The company has not previously participated in the LegionEdge Startup Program.
+            reason: external-verification
+    roles:
+      terms_authority_entity_id: ent_01m1d98re9dhpj49fffmjj2sj5
+      access_operator_entity_id: ent_01m1d98re9dhpj49fffmjj2sj5
+    access:
+      availability: public
+      method: form
+      url: https://legionedge.ai/programs/startup
+    terms_url: https://legionedge.ai/programs/startup
+    source_ids:
+      - src_41b15c073e3b29108ece0abb36c0aa918d70220215f0f1dc6232bf3f8c2563c9
+      - src_2460ca63c615f04c0c01a410bb9fb5ad2151a39e95dc044cbc83977e48c5eb40

--- a/entities/le/legionedge.yaml
+++ b/entities/le/legionedge.yaml
@@ -10,6 +10,7 @@ entity:
       valid_from: 2026-08-17T01:43:29.909Z
   category: ai-ml
 profile:
+  summary: AI research lab building protocols, datasets, and efficient methods for intelligent applications.
   description: LegionEdge is an AI research lab building protocols, datasets, and efficient methods for intelligent applications.
   links:
     site: https://legionedge.ai


### PR DESCRIPTION
## Summary
- add LegionEdge as a canonical Entity record after the repository's schema cutover
- model the current LegionEdge Startup Program and its 12-month product-credit package
- encode the published $25,000 cap, program benefits, eligibility, and public application route

## Validation
- pinned public Sourcey verifier: passed (1 entity, 1 program, 1 offer)
- `git diff origin/main...HEAD --check`: passed
- DCO sign-off: included

This is the current-schema re-authoring invited by the maintainer after legacy PR #624 was closed for the vendors-to-entities cutover. I understand the new-entity admission threshold may still require the human decision noted there.

Closes #623