### PR TITLE
data: add HyperComply startup package

### DIFF
--- a/entities/hy/hypercomply.yaml
+++ b/entities/hy/hypercomply.yaml
@@ -10,6 +10,7 @@ entity:
       valid_from: 2026-08-14T14:43:48.471Z
   category: legal-compliance
 profile:
+  summary: Security-questionnaire automation and trust-document sharing platform.
   description: HyperComply helps companies respond to security questionnaires and share security documentation through Trust Pages and Data Rooms.
   links:
     site: https://www.hypercomply.com
@@ -37,24 +38,23 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: 60% off the HyperComply Startup Package.
+          description: 60% off for startups
           kind: discount
           percentage:
             kind: exact
             basis_points: 6000
-          applies_to: HyperComply Startup Package
         - benefit_id: ben_02
-          description: Unlimited security questionnaire responses with a 3-day response SLA.
+          description: Unlimited security questionnaire responses
           kind: other
         - benefit_id: ben_03
-          description: A public Trust Page and Data Rooms for sharing security documentation.
+          description: Public Trust Page and Data Rooms
           kind: other
         - benefit_id: ben_04
           description: Flexible payment terms.
           kind: other
       consideration:
         kind: variable
-        description: Approved startups pay the remaining package price after the 60% discount.
+        description: Eligible startups receive the package for one low price.
     eligibility:
       rule:
         criterion_id: cri_01

--- a/entities/hy/hypercomply.yaml
+++ b/entities/hy/hypercomply.yaml
@@ -47,20 +47,23 @@ offers:
           description: Unlimited security questionnaire responses
           kind: other
         - benefit_id: ben_03
-          description: Public Trust Page and Data Rooms
+          description: Public Trust Page to showcase your security posture
           kind: other
         - benefit_id: ben_04
-          description: Flexible payment terms.
+          description: Data Rooms to securely share documents with customers
+          kind: other
+        - benefit_id: ben_05
+          description: Flexible payment terms
           kind: other
       consideration:
-        kind: variable
-        description: Eligible startups receive the package for one low price.
+        kind: unknown
+        description: Eligible startups get advanced HyperComply features and unlimited security questionnaire responses for one low price.
     eligibility:
       rule:
         criterion_id: cri_01
         kind: manual
         reason: vendor-discretion
-        statement: HyperComply determines which startups are eligible through its application process.
+        statement: The applicant must be an eligible startup.
     roles:
       terms_authority_entity_id: ent_01m1ddg6j0rw6hwp1encpkxdbn
       access_operator_entity_id: ent_01m1ddg6j0rw6hwp1encpkxdbn

--- a/entities/hy/hypercomply.yaml
+++ b/entities/hy/hypercomply.yaml
@@ -1,0 +1,73 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1ddg6j0rw6hwp1encpkxdbn
+  slug: hypercomply
+  slug_aliases: []
+  name: HyperComply
+  domains:
+    - value: hypercomply.com
+      role: primary
+      valid_from: 2026-08-14T14:43:48.471Z
+  category: legal-compliance
+profile:
+  description: HyperComply helps companies respond to security questionnaires and share security documentation through Trust Pages and Data Rooms.
+  links:
+    site: https://www.hypercomply.com
+sources:
+  - source_id: src_e4b21c79e6898f52b1c8a88f52f9be4918a2503f1bcd4276662732ce7ae3fa4d
+    url: https://www.hypercomply.com/startup
+programs:
+  - program_id: prg_01m1ddg6jdn290y15qf1dg1nsw
+    program_slug: hypercomply-startup-package
+    program_slug_aliases: []
+    title: HyperComply Startup Package
+    summary: HyperComply gives eligible startups discounted access to unlimited security questionnaire responses, a response SLA, a Trust Page, Data Rooms, and flexible payment terms.
+    source_ids:
+      - src_e4b21c79e6898f52b1c8a88f52f9be4918a2503f1bcd4276662732ce7ae3fa4d
+offers:
+  - offer_id: off_01m1ddg6je6wqcc86vdcza4bf5
+    program_id: prg_01m1ddg6jdn290y15qf1dg1nsw
+    offer_slug: startup-package-discount
+    offer_slug_aliases: []
+    title: 60% off the HyperComply Startup Package
+    summary: Eligible startups get 60% off a package with unlimited questionnaire responses, a 3-day response SLA, a public Trust Page, Data Rooms, and flexible payment terms.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-14T14:43:48.471Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: 60% off the HyperComply Startup Package.
+          kind: discount
+          percentage:
+            kind: exact
+            basis_points: 6000
+          applies_to: HyperComply Startup Package
+        - benefit_id: ben_02
+          description: Unlimited security questionnaire responses with a 3-day response SLA.
+          kind: other
+        - benefit_id: ben_03
+          description: A public Trust Page and Data Rooms for sharing security documentation.
+          kind: other
+        - benefit_id: ben_04
+          description: Flexible payment terms.
+          kind: other
+      consideration:
+        kind: variable
+        description: Approved startups pay the remaining package price after the 60% discount.
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: vendor-discretion
+        statement: HyperComply determines which startups are eligible through its application process.
+    roles:
+      terms_authority_entity_id: ent_01m1ddg6j0rw6hwp1encpkxdbn
+      access_operator_entity_id: ent_01m1ddg6j0rw6hwp1encpkxdbn
+    access:
+      availability: public
+      method: form
+      url: https://www.hypercomply.com/startup
+    terms_url: https://www.hypercomply.com/startup
+    source_ids:
+      - src_e4b21c79e6898f52b1c8a88f52f9be4918a2503f1bcd4276662732ce7ae3fa4d


### PR DESCRIPTION
## Summary
- add HyperComply as a canonical Entity record after the repository's schema cutover
- model the live HyperComply Startup Package and its 60% discount
- encode current questionnaire, SLA, Trust Page, Data Room, payment, eligibility, and application facts

## Validation
- pinned public Sourcey verifier: passed (1 entity, 1 program, 1 offer)
- `git diff origin/main...HEAD --check`: passed
- DCO sign-off: included

This is the current-schema re-authoring invited by the maintainer after legacy PR #590 was closed for the vendors-to-entities cutover.

Closes #589