### PR TITLE
data: add Rho Stripe Atlas statement credits

### DIFF
--- a/entities/rh/rho.yaml
+++ b/entities/rh/rho.yaml
@@ -1,0 +1,80 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1dfe5zwa62yyb70rrcgx54j
+  slug: rho
+  slug_aliases: []
+  name: Rho
+  domains:
+    - value: rho.co
+      role: primary
+      valid_from: 2026-08-31T23:45:00.000Z
+  category: banking
+profile:
+  description: Rho provides business banking, corporate cards, treasury, expense management, and accounts-payable services.
+  links:
+    site: https://www.rho.co/
+sources:
+  - source_id: src_a5c97ec1968f408fdf4b29f9fca339a42232d2335bdde0275f3db00102f5351e
+    url: https://www.rho.co/partner/stripe-atlas
+programs: []
+offers:
+  - offer_id: off_01m1dfe60ea31jf36vh4ndg2jx
+    offer_slug: stripe-atlas-founder-statement-credits
+    offer_slug_aliases: []
+    title: Rho Statement Credits for Stripe Atlas Founders
+    summary: Stripe Atlas founders can earn a $1,600 Rho statement credit by maintaining a $20,000 daily balance for 60 days and a separate $500 credit after $10,000 in Rho Card spend within 90 days.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-31T23:45:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: A $1,600 statement credit after maintaining at least $20,000 as the end-of-day Rho checking balance on every day of the first 60 days after account opening; applied within 30 days after that period.
+          kind: cashback
+          value:
+            kind: money
+            value:
+              kind: exact
+              amount:
+                currency: USD
+                minor_units: 160000
+        - benefit_id: ben_02
+          description: A $500 statement credit after spending $10,000 on the Rho Card within 90 days of account opening.
+          kind: cashback
+          value:
+            kind: money
+            value:
+              kind: exact
+              amount:
+                currency: USD
+                minor_units: 50000
+      consideration:
+        kind: variable
+        description: The two credits are earned independently through the published Rho checking-balance and Rho Card-spend conditions.
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: The applicant is a Stripe Atlas founder opening a Rho account through this partner offer.
+          - criterion_id: cri_02
+            kind: manual
+            reason: external-verification
+            statement: The Rho account remains open and in good standing when a statement credit is applied.
+          - criterion_id: cri_03
+            kind: manual
+            reason: external-verification
+            statement: The offer is limited to one per customer and cannot be combined with another promotional offer.
+    roles:
+      terms_authority_entity_id: ent_01m1dfe5zwa62yyb70rrcgx54j
+      access_operator_entity_id: ent_01m1dfe5zwa62yyb70rrcgx54j
+    access:
+      availability: public
+      method: form
+      url: https://signup.rho.co
+      instructions: Open a Rho account from the Stripe Atlas partner page and complete Rho's account application.
+    terms_url: https://www.rho.co/partner/stripe-atlas
+    source_ids:
+      - src_a5c97ec1968f408fdf4b29f9fca339a42232d2335bdde0275f3db00102f5351e


### PR DESCRIPTION
## Summary

- adds a current-schema Rho Entity record
- records the two independently earnable Rho statement credits for Stripe Atlas founders
- uses Rho's live first-party partner page as the terms authority and access path

## Current terms captured

- $1,600 statement credit after maintaining at least a $20,000 end-of-day Rho checking balance on every day of the first 60 days after account opening
- $500 statement credit after $10,000 in Rho Card spend within 90 days of account opening
- credits may be earned independently; one offer per customer

## Source

- https://www.rho.co/partner/stripe-atlas

## Validation

- pinned Sourcey Catalog Verifier passed: 1 Entity, 0 Programs, 1 Offer
- exact live identity-context protocol and current root set used
- one data-only Entity file
- DCO sign-off included

Closes #561