### PR TITLE
data: add Relevate startup program

### DIFF
--- a/entities/re/relevate.yaml
+++ b/entities/re/relevate.yaml
@@ -1,0 +1,93 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_1xfg0bpqbrsv4ymbrtk67njpgp
+  slug: relevate
+  slug_aliases: []
+  name: Relevate
+  domains:
+    - value: relevate.app
+      role: primary
+      valid_from: 2026-09-01T04:36:00.000Z
+  category: devtools-other
+profile:
+  description: Relevate is a documentation platform for publishing product documentation, API references, and AI-assisted reader support.
+  links:
+    site: https://relevate.app/
+sources:
+  - source_id: src_b23df5d4b758912c5f20a49f66a277540c058bd8d4d40bc83a8853a336762b11
+    url: https://relevate.app/startups
+programs:
+  - program_id: prg_hcyy4re36bmt0ga88wk0mfwdf6
+    program_slug: relevate-startup-program
+    program_slug_aliases: []
+    title: Relevate Startup Program
+    summary: Relevate gives eligible early-stage startups 50% off its Pro plan, priority onboarding, and early access to new features.
+    source_ids:
+      - src_b23df5d4b758912c5f20a49f66a277540c058bd8d4d40bc83a8853a336762b11
+offers:
+  - offer_id: off_tq8h3hs2vswpshx68dpwcxpsmy
+    program_id: prg_hcyy4re36bmt0ga88wk0mfwdf6
+    offer_slug: fifty-percent-off-pro-for-eligible-startups
+    offer_slug_aliases: []
+    title: 50% Off Relevate Pro While Eligible
+    summary: Eligible startups receive 50% off Relevate Pro for as long as they continue to qualify, plus priority onboarding and early feature access.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-01T04:36:00.000Z
+    economics:
+      benefits:
+        - applies_to: Relevate Pro plan
+          benefit_id: ben_01
+          description: 50% off Relevate Pro for as long as the startup remains eligible.
+          kind: discount
+          percentage:
+            kind: exact
+            basis_points: 5000
+        - benefit_id: ben_02
+          description: Priority onboarding with setup help, migration support, and technical guidance.
+          kind: other
+        - benefit_id: ben_03
+          description: Early access to new Relevate features.
+          kind: other
+      consideration:
+        kind: variable
+        description: The startup pays the remaining discounted Relevate Pro subscription price.
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: The startup has raised less than $1,000,000 in funding.
+            value:
+              type: number
+              value: 1000000
+          - criterion_id: cri_02
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: The company is less than three years old; Relevate says it may review slightly older companies case by case.
+            value:
+              type: number
+              value: 36
+          - criterion_id: cri_03
+            fact: company.employee_count
+            kind: predicate
+            operator: lt
+            statement: The company has fewer than 20 employees.
+            value:
+              type: number
+              value: 20
+    roles:
+      terms_authority_entity_id: ent_1xfg0bpqbrsv4ymbrtk67njpgp
+      access_operator_entity_id: ent_1xfg0bpqbrsv4ymbrtk67njpgp
+    access:
+      availability: public
+      method: contact
+      url: https://relevate.app/startups
+      instructions: Use the public application contact link on the startup-program page and include details about the company.
+    terms_url: https://relevate.app/startups
+    source_ids:
+      - src_b23df5d4b758912c5f20a49f66a277540c058bd8d4d40bc83a8853a336762b11

--- a/entities/re/relevate.yaml
+++ b/entities/re/relevate.yaml
@@ -36,50 +36,27 @@ offers:
       effective_from: 2026-09-01T04:36:00.000Z
     economics:
       benefits:
-        - applies_to: Relevate Pro plan
-          benefit_id: ben_01
-          description: 50% off Relevate Pro for as long as the startup remains eligible.
+        - benefit_id: ben_01
+          description: 50% off Pro as long as the startup is eligible.
           kind: discount
           percentage:
             kind: exact
             basis_points: 5000
         - benefit_id: ben_02
-          description: Priority onboarding with setup help, migration support, and technical guidance.
+          description: Direct access to the Relevate team for setup help, migration support, and technical questions.
           kind: other
         - benefit_id: ben_03
-          description: Early access to new Relevate features.
+          description: Early access to new features.
           kind: other
       consideration:
-        kind: variable
-        description: The startup pays the remaining discounted Relevate Pro subscription price.
+        kind: unknown
+        description: The public program page states that access is discounted but does not publish the payable price.
     eligibility:
       rule:
-        kind: all
-        rules:
-          - criterion_id: cri_01
-            fact: company.funding_raised_usd
-            kind: predicate
-            operator: lt
-            statement: The startup has raised less than $1,000,000 in funding.
-            value:
-              type: number
-              value: 1000000
-          - criterion_id: cri_02
-            fact: company.age_months
-            kind: predicate
-            operator: lt
-            statement: The company is less than three years old; Relevate says it may review slightly older companies case by case.
-            value:
-              type: number
-              value: 36
-          - criterion_id: cri_03
-            fact: company.employee_count
-            kind: predicate
-            operator: lt
-            statement: The company has fewer than 20 employees.
-            value:
-              type: number
-              value: 20
+        kind: manual
+        criterion_id: cri_01
+        reason: external-verification
+        statement: The program is for venture-backed or bootstrapped startups with less than $1M in funding, less than three years old, and fewer than 20 employees; the three-year limit may be reviewed case by case.
     roles:
       terms_authority_entity_id: ent_1xfg0bpqbrsv4ymbrtk67njpgp
       access_operator_entity_id: ent_1xfg0bpqbrsv4ymbrtk67njpgp

--- a/entities/re/relevate.yaml
+++ b/entities/re/relevate.yaml
@@ -10,6 +10,7 @@ entity:
       valid_from: 2026-09-01T04:36:00.000Z
   category: devtools-other
 profile:
+  summary: Documentation platform for publishing product documentation, API references, and AI-assisted reader support.
   description: Relevate is a documentation platform for publishing product documentation, API references, and AI-assisted reader support.
   links:
     site: https://relevate.app/


### PR DESCRIPTION
## Summary

Adds one current-schema Entity record for **Relevate** and its startup-specific discount program.

Resolves #1100.

## Current first-party evidence

- https://relevate.app/startups
- https://relevate.app/pricing

The live English pages publish:
- 50% off Relevate Pro while the startup remains eligible
- priority onboarding with setup, migration, and technical support
- early access to new features
- less than $1 million raised, less than three years old, and fewer than 20 employees
- a public email-based application route

## Scope and verification

- [x] Exactly one new file: `entities/re/relevate.yaml`
- [x] Current `sourcey.entity-authoring/v1alpha1` shape
- [x] One Entity, one Program, one Offer
- [x] Only live English first-party Relevate sources
- [x] Fresh Entity, Program, and Offer identifiers
- [x] `devtools-other` category from the pinned taxonomy
- [x] Digest-pinned Sourcey verifier passed against a live identity context
- [x] `git diff --check` passed
- [x] Commit is DCO-signed
- [x] Rechecked catalog/issues/PRs immediately before submission; no competing Relevate record exists