### PR TITLE
data: add Uniblock startup program

### DIFF
--- a/entities/un/uniblock.yaml
+++ b/entities/un/uniblock.yaml
@@ -38,7 +38,7 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: Up to $10,000 in credits usable across Uniblock's routed provider stack.
+          description: Up to $10,000 in credits to build your whole stack on Uniblock.
           kind: credit
           value:
             amount:
@@ -46,27 +46,17 @@ offers:
               minor_units: 1000000
             kind: up-to
         - benefit_id: ben_02
-          description: Access to Uniblock engineers for routing monitoring and incident response.
+          description: Engineering on call; Uniblock engineers monitor routing and respond when something breaks.
           kind: other
       consideration:
         kind: variable
-        description: The program uses an annual Uniblock plan; the credit allocation and applicable paid terms are scoped to the startup's stage on a call.
+        description: The offer is an annual Uniblock plan with credits included; credits are applied once terms are set.
     eligibility:
       rule:
-        kind: all
-        rules:
-          - criterion_id: cri_01
-            kind: manual
-            reason: external-verification
-            statement: The applicant is an early-stage team building on blockchain data.
-          - criterion_id: cri_02
-            kind: manual
-            reason: external-verification
-            statement: The applicant has a live product or a product in active development.
-          - criterion_id: cri_03
-            kind: manual
-            reason: external-verification
-            statement: Uniblock confirms fit and sizes the credit allocation on a short call.
+        criterion_id: cri_01
+        kind: manual
+        reason: external-verification
+        statement: Applicants must be early-stage teams building on blockchain data with a product live or in active development; Uniblock confirms fit and scopes the credits on a short call.
     roles:
       terms_authority_entity_id: ent_kf66ej4ar5a1vk5f7akf4qpcm6
       access_operator_entity_id: ent_kf66ej4ar5a1vk5f7akf4qpcm6

--- a/entities/un/uniblock.yaml
+++ b/entities/un/uniblock.yaml
@@ -45,12 +45,9 @@ offers:
               currency: USD
               minor_units: 1000000
             kind: up-to
-        - benefit_id: ben_02
-          description: Engineering on call; Uniblock engineers monitor routing and respond when something breaks.
-          kind: other
       consideration:
-        kind: variable
-        description: The offer is an annual Uniblock plan with credits included; credits are applied once terms are set.
+        kind: unknown
+        description: Uniblock confirms fit, scopes the credits, and sets terms on a short call.
     eligibility:
       rule:
         criterion_id: cri_01

--- a/entities/un/uniblock.yaml
+++ b/entities/un/uniblock.yaml
@@ -5,17 +5,18 @@ entity:
   slug_aliases: []
   name: Uniblock
   domains:
-    - value: uniblock.website
+    - value: uniblock.dev
       role: primary
       valid_from: 2026-09-01T05:03:00.000Z
   category: apis-integration
 profile:
+  summary: One API, credit balance, and billing layer for blockchain data providers.
   description: Uniblock provides one API key, credit balance, and billing layer for routing requests across blockchain-data providers.
   links:
-    site: https://uniblock.website/
+    site: https://uniblock.dev/
 sources:
   - source_id: src_1f59b9d938be567a5b8c22f9747b2e98b8196f819b668a2fb20208051e9f821c
-    url: https://uniblock.website/startup-program
+    url: https://uniblock.dev/startup-program
 programs:
   - program_id: prg_kk19nyhaxxp1g5qba9czjvmnnd
     program_slug: uniblock-startup-program
@@ -72,8 +73,8 @@ offers:
     access:
       availability: public
       method: form
-      url: https://uniblock.website/startup-program
+      url: https://uniblock.dev/startup-program
       instructions: Submit the application form on the startup-program page and complete the short fit-and-scope call.
-    terms_url: https://uniblock.website/startup-program
+    terms_url: https://uniblock.dev/startup-program
     source_ids:
       - src_1f59b9d938be567a5b8c22f9747b2e98b8196f819b668a2fb20208051e9f821c

--- a/entities/un/uniblock.yaml
+++ b/entities/un/uniblock.yaml
@@ -1,0 +1,79 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_kf66ej4ar5a1vk5f7akf4qpcm6
+  slug: uniblock
+  slug_aliases: []
+  name: Uniblock
+  domains:
+    - value: uniblock.website
+      role: primary
+      valid_from: 2026-09-01T05:03:00.000Z
+  category: apis-integration
+profile:
+  description: Uniblock provides one API key, credit balance, and billing layer for routing requests across blockchain-data providers.
+  links:
+    site: https://uniblock.website/
+sources:
+  - source_id: src_1f59b9d938be567a5b8c22f9747b2e98b8196f819b668a2fb20208051e9f821c
+    url: https://uniblock.website/startup-program
+programs:
+  - program_id: prg_kk19nyhaxxp1g5qba9czjvmnnd
+    program_slug: uniblock-startup-program
+    program_slug_aliases: []
+    title: Uniblock Startup Program
+    summary: Uniblock gives eligible early-stage blockchain-data teams up to $10,000 in credits on its annual plan, with provider routing and engineering support.
+    source_ids:
+      - src_1f59b9d938be567a5b8c22f9747b2e98b8196f819b668a2fb20208051e9f821c
+offers:
+  - offer_id: off_sjqk2ng9gm1mkjsgm8012ezxzd
+    program_id: prg_kk19nyhaxxp1g5qba9czjvmnnd
+    offer_slug: up-to-ten-thousand-dollars-in-uniblock-credits
+    offer_slug_aliases: []
+    title: Up to $10,000 in Uniblock Credits
+    summary: Approved startups receive up to $10,000 in credits across Uniblock's routed provider stack, with one key, one balance, and engineering support.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-01T05:03:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $10,000 in credits usable across Uniblock's routed provider stack.
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 1000000
+            kind: up-to
+        - benefit_id: ben_02
+          description: Access to Uniblock engineers for routing monitoring and incident response.
+          kind: other
+      consideration:
+        kind: variable
+        description: The program uses an annual Uniblock plan; the credit allocation and applicable paid terms are scoped to the startup's stage on a call.
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: The applicant is an early-stage team building on blockchain data.
+          - criterion_id: cri_02
+            kind: manual
+            reason: external-verification
+            statement: The applicant has a live product or a product in active development.
+          - criterion_id: cri_03
+            kind: manual
+            reason: external-verification
+            statement: Uniblock confirms fit and sizes the credit allocation on a short call.
+    roles:
+      terms_authority_entity_id: ent_kf66ej4ar5a1vk5f7akf4qpcm6
+      access_operator_entity_id: ent_kf66ej4ar5a1vk5f7akf4qpcm6
+    access:
+      availability: public
+      method: form
+      url: https://uniblock.website/startup-program
+      instructions: Submit the application form on the startup-program page and complete the short fit-and-scope call.
+    terms_url: https://uniblock.website/startup-program
+    source_ids:
+      - src_1f59b9d938be567a5b8c22f9747b2e98b8196f819b668a2fb20208051e9f821c

--- a/entities/un/uniblock.yaml
+++ b/entities/un/uniblock.yaml
@@ -46,14 +46,14 @@ offers:
               minor_units: 1000000
             kind: up-to
       consideration:
-        kind: unknown
-        description: Uniblock confirms fit, scopes the credits, and sets terms on a short call.
+        kind: variable
+        description: "One offer: the annual Uniblock plan, with credits included."
     eligibility:
       rule:
         criterion_id: cri_01
         kind: manual
         reason: external-verification
-        statement: Applicants must be early-stage teams building on blockchain data with a product live or in active development; Uniblock confirms fit and scopes the credits on a short call.
+        statement: Applicants must be early-stage teams building on blockchain data with a product live or in active development.
     roles:
       terms_authority_entity_id: ent_kf66ej4ar5a1vk5f7akf4qpcm6
       access_operator_entity_id: ent_kf66ej4ar5a1vk5f7akf4qpcm6

--- a/entities/un/uniblock.yaml
+++ b/entities/un/uniblock.yaml
@@ -22,7 +22,7 @@ programs:
     program_slug: uniblock-startup-program
     program_slug_aliases: []
     title: Uniblock Startup Program
-    summary: Uniblock gives eligible early-stage blockchain-data teams up to $10,000 in credits on its annual plan, with provider routing and engineering support.
+    summary: Uniblock's startup program offers up to $10,000 in credits on its annual plan.
     source_ids:
       - src_1f59b9d938be567a5b8c22f9747b2e98b8196f819b668a2fb20208051e9f821c
 offers:


### PR DESCRIPTION
## Summary

Adds one current-schema Entity record for **Uniblock** and its startup-specific credit program.

Resolves #1104.

## Current first-party evidence

- https://uniblock.website/startup-program

The live English page publishes:
- up to $10,000 in credits across the Uniblock routed-provider stack
- an annual plan with one key, one balance, and centralized routing
- engineering monitoring and response support
- eligibility for early-stage teams building on blockchain data with a live product or one in active development
- a public application and fit-scoping call

## Scope and verification

- [x] Exactly one new file: `entities/un/uniblock.yaml`
- [x] Current `sourcey.entity-authoring/v1alpha1` shape
- [x] One Entity, one Program, one Offer
- [x] Only a live English first-party Uniblock source
- [x] Fresh identifiers and `apis-integration` pinned-taxonomy category
- [x] Digest-pinned Sourcey verifier passed against a live identity context
- [x] `git diff --check` passed
- [x] Commit is DCO-signed
- [x] No competing Uniblock record exists