### PR TITLE
data: add Uome startup program

### DIFF
--- a/entities/uo/uome.yaml
+++ b/entities/uo/uome.yaml
@@ -1,0 +1,74 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_2nz24mb2w5yc5s4764jhdnbgc7
+  slug: uome
+  slug_aliases: []
+  name: Uome
+  domains:
+    - value: myuome.com
+      role: primary
+      valid_from: 2026-09-01T05:24:00.000Z
+  category: apis-integration
+profile:
+  summary: APIs and business infrastructure for accounts, billing, payments, point of sale, customer management, and tax workflows.
+  description: Uome provides APIs and business infrastructure for accounts, billing, payments, point of sale, customer management, and tax workflows.
+  links:
+    site: https://www.myuome.com/
+sources:
+  - source_id: src_1dca0be91a944d0e82d1322e26fd8db6973a55246cbc3e737b938754646cd72c
+    url: https://www.myuome.com/us/platform/startups
+programs:
+  - program_id: prg_72w1pmrnjvjjmqzbvwn5mrhtym
+    program_slug: uome-for-startups
+    program_slug_aliases: []
+    title: Uome for Startups
+    summary: Uome gives eligible young companies 50% off their first year of its API and business-infrastructure platform.
+    source_ids:
+      - src_1dca0be91a944d0e82d1322e26fd8db6973a55246cbc3e737b938754646cd72c
+offers:
+  - offer_id: off_jst0mkw3se9zcyms13jn3ma0xa
+    program_id: prg_72w1pmrnjvjjmqzbvwn5mrhtym
+    offer_slug: fifty-percent-off-first-year
+    offer_slug_aliases: []
+    title: 50% Off the First Year of Uome
+    summary: Approved companies receive 50% off Uome for their first year and access to its API-backed accounts, billing, payments, POS, CRM, and tax capabilities.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-01T05:24:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Get 50% off the first year.
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            kind: exact
+            basis_points: 5000
+      consideration:
+        kind: variable
+        description: Pay for what you use with no hidden fees.
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: The company has raised no more than £2,000,000 in funding.
+          - criterion_id: cri_02
+            kind: manual
+            reason: external-verification
+            statement: The company is under 3 years old.
+    roles:
+      terms_authority_entity_id: ent_2nz24mb2w5yc5s4764jhdnbgc7
+      access_operator_entity_id: ent_2nz24mb2w5yc5s4764jhdnbgc7
+    access:
+      availability: public
+      method: form
+      url: https://to8mlbj4i8s.typeform.com/to/Hpl79hEo
+      instructions: Submit the application form linked from Uome's startup-program page.
+    terms_url: https://www.myuome.com/us/platform/startups
+    source_ids:
+      - src_1dca0be91a944d0e82d1322e26fd8db6973a55246cbc3e737b938754646cd72c


### PR DESCRIPTION
## Summary

Adds one current-schema Entity record for **Uome** and its startup-specific discount program.

Resolves #1107.

## Current first-party evidence

- https://www.myuome.com/us/platform/startups

The live English page publishes:
- 50% off the first year
- eligibility for companies under three years old with no more than £2 million raised
- API-backed accounts, billing, payments, POS, CRM, and tax capabilities
- a public application Typeform that resolves successfully

## Scope and verification

- [x] Exactly one new file: `entities/uo/uome.yaml`
- [x] Current `sourcey.entity-authoring/v1alpha1` shape
- [x] One Entity, one Program, one Offer
- [x] Only a live English first-party Uome terms source
- [x] Fresh identifiers and `apis-integration` pinned-taxonomy category
- [x] Digest-pinned Sourcey verifier passed against a live identity context
- [x] `git diff --check` passed
- [x] Commit is DCO-signed
- [x] No competing Uome record exists