### PR TITLE
data: add QuickEstimate startup program

### DIFF
--- a/entities/qu/quickestimate.yaml
+++ b/entities/qu/quickestimate.yaml
@@ -38,6 +38,7 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
+          description: Approved contractors receive 40% off QuickEstimate for 12 months.
           duration:
             kind: exact
             value: P1Y
@@ -46,7 +47,8 @@ offers:
             kind: exact
             basis_points: 4000
       consideration:
-        kind: variable
+        kind: unknown
+        description: The cited source does not establish separate consideration beyond the offer terms.
     eligibility:
       rule:
         kind: all

--- a/entities/qu/quickestimate.yaml
+++ b/entities/qu/quickestimate.yaml
@@ -10,6 +10,7 @@ entity:
       valid_from: 2026-09-01T05:32:00.000Z
   category: productivity
 profile:
+  summary: Construction-estimating software for producing, managing, and tracking contractor estimates.
   description: QuickEstimate is construction-estimating software for producing, managing, and tracking contractor estimates.
   links:
     site: https://quickestimate.io/
@@ -37,7 +38,6 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: The Startup Program offers 40% off for the first 12 months.
           duration:
             kind: exact
             value: P1Y
@@ -47,7 +47,6 @@ offers:
             basis_points: 4000
       consideration:
         kind: variable
-        description: QuickEstimate paid plans start at $29 per month before the Startup Program discount.
     eligibility:
       rule:
         kind: all

--- a/entities/qu/quickestimate.yaml
+++ b/entities/qu/quickestimate.yaml
@@ -38,7 +38,7 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: Approved contractors receive 40% off QuickEstimate for 12 months.
+          description: 40% off for the first 12 months
           duration:
             kind: exact
             value: P1Y
@@ -47,8 +47,8 @@ offers:
             kind: exact
             basis_points: 4000
       consideration:
-        kind: unknown
-        description: The cited source does not establish separate consideration beyond the offer terms.
+        kind: variable
+        description: Startup Program pricing is 40% off the selected QuickEstimate plan for the first 12 months.
     eligibility:
       rule:
         kind: all

--- a/entities/qu/quickestimate.yaml
+++ b/entities/qu/quickestimate.yaml
@@ -48,7 +48,7 @@ offers:
             basis_points: 4000
       consideration:
         kind: variable
-        description: Basic is $29 per month, Gold is $79 per month, and Premium is $149 per month; the Startup Program offers 40% off for the first 12 months.
+        description: Basic costs $29 per month, Gold costs $79 per month, and Premium costs $149 per month.
     eligibility:
       rule:
         criterion_id: cri_01

--- a/entities/qu/quickestimate.yaml
+++ b/entities/qu/quickestimate.yaml
@@ -1,0 +1,82 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_6r086m75r6fn9knh0jxf7vxt0g
+  slug: quickestimate
+  slug_aliases: []
+  name: QuickEstimate
+  domains:
+    - value: quickestimate.io
+      role: primary
+      valid_from: 2026-09-01T05:32:00.000Z
+  category: productivity
+profile:
+  description: QuickEstimate is construction-estimating software for producing, managing, and tracking contractor estimates.
+  links:
+    site: https://quickestimate.io/
+sources:
+  - source_id: src_de3013b30946d461632ec76437bbf132db6d8865fee919e6bfca46564f90faaa
+    url: https://quickestimate.io/pricing
+programs:
+  - program_id: prg_avqcgpc6pvvwgh4kezhfndy0qa
+    program_slug: quickestimate-startup-program
+    program_slug_aliases: []
+    title: QuickEstimate Startup Program
+    summary: QuickEstimate gives eligible new contracting businesses 40% off its estimating software for their first 12 months.
+    source_ids:
+      - src_de3013b30946d461632ec76437bbf132db6d8865fee919e6bfca46564f90faaa
+offers:
+  - offer_id: off_mtrdyxmp8dmwejgr14eyny0vk3
+    program_id: prg_avqcgpc6pvvwgh4kezhfndy0qa
+    offer_slug: forty-percent-off-first-twelve-months
+    offer_slug_aliases: []
+    title: 40% Off QuickEstimate for 12 Months
+    summary: Approved contractors that have been in business for less than two years receive 40% off QuickEstimate for 12 months.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-01T05:32:00.000Z
+    economics:
+      benefits:
+        - applies_to: QuickEstimate subscription
+          benefit_id: ben_01
+          description: 40% off QuickEstimate for the first 12 months.
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            kind: exact
+            basis_points: 4000
+      consideration:
+        kind: variable
+        description: The contractor pays the remaining discounted QuickEstimate subscription price.
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: The applicant is a contracting business.
+          - criterion_id: cri_02
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: The business has been operating for less than two years.
+            value:
+              type: number
+              value: 24
+          - criterion_id: cri_03
+            kind: manual
+            reason: external-verification
+            statement: The applicant provides proof of the business registration date.
+    roles:
+      terms_authority_entity_id: ent_6r086m75r6fn9knh0jxf7vxt0g
+      access_operator_entity_id: ent_6r086m75r6fn9knh0jxf7vxt0g
+    access:
+      availability: public
+      method: contact
+      url: https://quickestimate.io/pricing
+      instructions: Use the contact route published on the pricing page and provide proof of the business registration date.
+    terms_url: https://quickestimate.io/pricing
+    source_ids:
+      - src_de3013b30946d461632ec76437bbf132db6d8865fee919e6bfca46564f90faaa

--- a/entities/qu/quickestimate.yaml
+++ b/entities/qu/quickestimate.yaml
@@ -36,9 +36,8 @@ offers:
       effective_from: 2026-09-01T05:32:00.000Z
     economics:
       benefits:
-        - applies_to: QuickEstimate subscription
-          benefit_id: ben_01
-          description: 40% off QuickEstimate for the first 12 months.
+        - benefit_id: ben_01
+          description: The Startup Program offers 40% off for the first 12 months.
           duration:
             kind: exact
             value: P1Y
@@ -48,7 +47,7 @@ offers:
             basis_points: 4000
       consideration:
         kind: variable
-        description: The contractor pays the remaining discounted QuickEstimate subscription price.
+        description: QuickEstimate paid plans start at $29 per month before the Startup Program discount.
     eligibility:
       rule:
         kind: all

--- a/entities/qu/quickestimate.yaml
+++ b/entities/qu/quickestimate.yaml
@@ -48,27 +48,13 @@ offers:
             basis_points: 4000
       consideration:
         kind: variable
-        description: Startup Program pricing is 40% off the selected QuickEstimate plan for the first 12 months.
+        description: Basic is $29 per month, Gold is $79 per month, and Premium is $149 per month; the Startup Program offers 40% off for the first 12 months.
     eligibility:
       rule:
-        kind: all
-        rules:
-          - criterion_id: cri_01
-            kind: manual
-            reason: external-verification
-            statement: The applicant is a contracting business.
-          - criterion_id: cri_02
-            fact: company.age_months
-            kind: predicate
-            operator: lt
-            statement: The business has been operating for less than two years.
-            value:
-              type: number
-              value: 24
-          - criterion_id: cri_03
-            kind: manual
-            reason: external-verification
-            statement: The applicant provides proof of the business registration date.
+        criterion_id: cri_01
+        kind: manual
+        reason: external-verification
+        statement: Contractors must have been in business less than two years and provide proof of the business registration date.
     roles:
       terms_authority_entity_id: ent_6r086m75r6fn9knh0jxf7vxt0g
       access_operator_entity_id: ent_6r086m75r6fn9knh0jxf7vxt0g


### PR DESCRIPTION
## Summary

Adds one current-schema Entity record for **QuickEstimate** and its startup-specific contractor discount.

Resolves #1109.

## Current first-party evidence

- https://quickestimate.io/pricing

The live English page publishes:
- 40% off for the first 12 months
- eligibility for contractors that have been in business for less than two years
- an application by contacting QuickEstimate with proof of the business registration date

## Scope and verification

- [x] Exactly one new file: `entities/qu/quickestimate.yaml`
- [x] Current `sourcey.entity-authoring/v1alpha1` shape
- [x] One Entity, one Program, one Offer
- [x] Only a live English first-party QuickEstimate source
- [x] Fresh identifiers and `productivity` pinned-taxonomy category
- [x] Digest-pinned Sourcey verifier passed for 1 Entity, 1 Program, and 1 Offer against a live identity context
- [x] `git diff --check origin/main..HEAD` passed
- [x] Commit is DCO-signed
- [x] No competing QuickEstimate record exists