### PR TITLE
data: add StockyTrack startup program

### DIFF
--- a/entities/st/stockytrack.yaml
+++ b/entities/st/stockytrack.yaml
@@ -1,0 +1,74 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_ymf4p8yesv9tpeehh3d28qr141
+  slug: stockytrack
+  slug_aliases: []
+  name: StockyTrack
+  domains:
+    - value: stockytrack.com
+      role: primary
+      valid_from: 2026-09-01T05:36:00.000Z
+  category: commerce
+profile:
+  description: StockyTrack is an inventory platform for stock control, warehouses, forecasting, reporting, and multi-entity operations.
+  links:
+    site: https://stockytrack.com/
+sources:
+  - source_id: src_312d4ac742452a9861d19c339e39640a26c45f9bfe16e1a4c9c76d3498723ad4
+    url: https://stockytrack.com/pricing
+programs:
+  - program_id: prg_kxvzh6nxctz6qycackqvh9zp1w
+    program_slug: stockytrack-startup-program
+    program_slug_aliases: []
+    title: StockyTrack Startup Program
+    summary: StockyTrack gives eligible companies under 18 months old 25% off any plan for 12 months.
+    source_ids:
+      - src_312d4ac742452a9861d19c339e39640a26c45f9bfe16e1a4c9c76d3498723ad4
+offers:
+  - offer_id: off_wgjjg5bhxwwh896wyh0pr09edb
+    program_id: prg_kxvzh6nxctz6qycackqvh9zp1w
+    offer_slug: twenty-five-percent-off-any-plan-for-twelve-months
+    offer_slug_aliases: []
+    title: 25% Off Any StockyTrack Plan for 12 Months
+    summary: Approved companies under 18 months old receive 25% off any StockyTrack plan for 12 months.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-01T05:36:00.000Z
+    economics:
+      benefits:
+        - applies_to: Any StockyTrack plan
+          benefit_id: ben_01
+          description: 25% off any StockyTrack plan for 12 months.
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            kind: exact
+            basis_points: 2500
+      consideration:
+        kind: variable
+        description: The company pays the remaining discounted price of the StockyTrack plan it selects.
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: The company is less than 18 months old.
+            value:
+              type: number
+              value: 18
+    roles:
+      terms_authority_entity_id: ent_ymf4p8yesv9tpeehh3d28qr141
+      access_operator_entity_id: ent_ymf4p8yesv9tpeehh3d28qr141
+    access:
+      availability: public
+      method: contact
+      url: https://stockytrack.com/pricing
+      instructions: Use the contact route published on the pricing page to apply for the startup program.
+    terms_url: https://stockytrack.com/pricing
+    source_ids:
+      - src_312d4ac742452a9861d19c339e39640a26c45f9bfe16e1a4c9c76d3498723ad4

--- a/entities/st/stockytrack.yaml
+++ b/entities/st/stockytrack.yaml
@@ -10,6 +10,7 @@ entity:
       valid_from: 2026-09-01T05:36:00.000Z
   category: commerce
 profile:
+  summary: Inventory management, forecasting, reporting, and warehouse operations platform.
   description: StockyTrack is an inventory platform for stock control, warehouses, forecasting, reporting, and multi-entity operations.
   links:
     site: https://stockytrack.com/
@@ -36,9 +37,8 @@ offers:
       effective_from: 2026-09-01T05:36:00.000Z
     economics:
       benefits:
-        - applies_to: Any StockyTrack plan
-          benefit_id: ben_01
-          description: 25% off any StockyTrack plan for 12 months.
+        - benefit_id: ben_01
+          description: 25% off for 12 months
           duration:
             kind: exact
             value: P1Y
@@ -48,19 +48,17 @@ offers:
             basis_points: 2500
       consideration:
         kind: variable
-        description: The company pays the remaining discounted price of the StockyTrack plan it selects.
+        description: StockyTrack prices the selected plan and publishes a 25% startup discount for 12 months.
     eligibility:
       rule:
-        kind: all
-        rules:
-          - criterion_id: cri_01
-            fact: company.age_months
-            kind: predicate
-            operator: lt
-            statement: The company is less than 18 months old.
-            value:
-              type: number
-              value: 18
+        criterion_id: cri_01
+        fact: company.age_months
+        kind: predicate
+        operator: lt
+        statement: The company is less than 18 months old.
+        value:
+          type: number
+          value: 18
     roles:
       terms_authority_entity_id: ent_ymf4p8yesv9tpeehh3d28qr141
       access_operator_entity_id: ent_ymf4p8yesv9tpeehh3d28qr141

--- a/entities/st/stockytrack.yaml
+++ b/entities/st/stockytrack.yaml
@@ -47,7 +47,8 @@ offers:
             kind: exact
             basis_points: 2500
       consideration:
-        kind: variable
+        kind: unknown
+        description: The cited source does not establish separate consideration beyond the offer terms.
     eligibility:
       rule:
         criterion_id: cri_01

--- a/entities/st/stockytrack.yaml
+++ b/entities/st/stockytrack.yaml
@@ -48,7 +48,6 @@ offers:
             basis_points: 2500
       consideration:
         kind: variable
-        description: StockyTrack prices the selected plan and publishes a 25% startup discount for 12 months.
     eligibility:
       rule:
         criterion_id: cri_01

--- a/entities/st/stockytrack.yaml
+++ b/entities/st/stockytrack.yaml
@@ -48,7 +48,7 @@ offers:
             basis_points: 2500
       consideration:
         kind: variable
-        description: 25% Off Any StockyTrack Plan for 12 Months
+        description: At the end of the trial you pick the plan that fits your team, or your workspace pauses.
     eligibility:
       rule:
         criterion_id: cri_01

--- a/entities/st/stockytrack.yaml
+++ b/entities/st/stockytrack.yaml
@@ -48,7 +48,7 @@ offers:
             basis_points: 2500
       consideration:
         kind: variable
-        description: A StockyTrack plan is discounted by 25% for 12 months.
+        description: 25% Off Any StockyTrack Plan for 12 Months
     eligibility:
       rule:
         criterion_id: cri_01

--- a/entities/st/stockytrack.yaml
+++ b/entities/st/stockytrack.yaml
@@ -47,8 +47,8 @@ offers:
             kind: exact
             basis_points: 2500
       consideration:
-        kind: unknown
-        description: The cited source does not establish separate consideration beyond the offer terms.
+        kind: variable
+        description: A StockyTrack plan is discounted by 25% for 12 months.
     eligibility:
       rule:
         criterion_id: cri_01


### PR DESCRIPTION
## Summary

Adds one current-schema Entity record for **StockyTrack** and its startup-specific discount.

Resolves #1111.

## Current first-party evidence

- https://stockytrack.com/pricing

The live English page publishes:
- 25% off any plan for 12 months
- eligibility for companies under 18 months old
- a public contact application route

## Scope and verification

- [x] Exactly one new file: `entities/st/stockytrack.yaml`
- [x] Current `sourcey.entity-authoring/v1alpha1` shape
- [x] One Entity, one Program, one Offer
- [x] Only a live English first-party StockyTrack source
- [x] Fresh identifiers and `commerce` pinned-taxonomy category
- [x] Digest-pinned Sourcey verifier passed for 1 Entity, 1 Program, and 1 Offer
- [x] `git diff --check origin/main..HEAD` passed
- [x] Commit is DCO-signed
- [x] No competing StockyTrack record exists