### PR TITLE
data: add Wysera startup program

### DIFF
--- a/entities/wy/wysera.yaml
+++ b/entities/wy/wysera.yaml
@@ -36,8 +36,7 @@ offers:
       effective_from: 2026-09-01T06:15:00.000Z
     economics:
       benefits:
-        - applies_to: Wysera founding-member pricing
-          benefit_id: ben_01
+        - benefit_id: ben_01
           description: Founding-member pricing provides 20% to 30% off for 12 months.
           duration:
             kind: exact
@@ -54,28 +53,14 @@ offers:
           kind: free-service
           service: Done-with-you Launch Sprint
       consideration:
-        kind: variable
-        description: Accepted teams that convert after the initial pilot pay the applicable discounted founding-member price.
+        kind: unknown
+        description: The source does not publish the converted founding-member price.
     eligibility:
       rule:
-        kind: all
-        rules:
-          - criterion_id: cri_01
-            kind: manual
-            reason: vendor-discretion
-            statement: Applicant must be an early-stage, B2B-qualified startup with a real product and a genuine need to run marketing, sales, and operations.
-          - criterion_id: cri_02
-            fact: applicant.is_agency
-            kind: predicate
-            operator: eq
-            statement: Agencies reselling the platform are not eligible.
-            value:
-              type: boolean
-              value: false
-          - criterion_id: cri_03
-            kind: manual
-            reason: external-verification
-            statement: One startup-program membership is available per company.
+        criterion_id: cri_01
+        kind: manual
+        reason: vendor-discretion
+        statement: Wysera manually reviews early-stage B2B startups with a real product; agencies reselling the platform and pre-product ideas are not eligible, and membership is limited to one per company.
     roles:
       terms_authority_entity_id: ent_5hhcjbzrafvn4m9akppramvadd
       access_operator_entity_id: ent_5hhcjbzrafvn4m9akppramvadd

--- a/entities/wy/wysera.yaml
+++ b/entities/wy/wysera.yaml
@@ -1,0 +1,89 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_5hhcjbzrafvn4m9akppramvadd
+  slug: wysera
+  slug_aliases: []
+  name: Wysera
+  domains:
+    - value: wysera.ai
+      role: primary
+      valid_from: 2026-09-01T06:15:00.000Z
+  category: crm-sales
+profile:
+  description: Wysera is an agentic platform that brings marketing, sales, CRM, content, automation, and business operations together for lean teams.
+  links:
+    site: https://wysera.ai/
+sources:
+  - source_id: src_3ff2850af068653cf95f20a138237b000afa4dd2ac39123d7f83aa21d8b29780
+    url: https://wysera.ai/startups
+programs:
+  - program_id: prg_aftra9n3vxj1fb7f8k1hde0ycx
+    program_slug: wysera-startup-program
+    program_slug_aliases: []
+    title: Wysera Startup Program
+    summary: Wysera gives accepted early-stage B2B startups founding-member pricing and hands-on launch support.
+    source_ids:
+      - src_3ff2850af068653cf95f20a138237b000afa4dd2ac39123d7f83aa21d8b29780
+offers:
+  - offer_id: off_9zdbp8aj6798g1v9zj32wgjyqa
+    program_id: prg_aftra9n3vxj1fb7f8k1hde0ycx
+    offer_slug: founding-member-pricing-and-launch-sprint
+    offer_slug_aliases: []
+    title: Up to 30% Off Wysera for 12 Months
+    summary: Accepted early-stage B2B startups get 20% to 30% off Wysera for 12 months, full-platform access, and a free two-week done-with-you Launch Sprint.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-01T06:15:00.000Z
+    economics:
+      benefits:
+        - applies_to: Wysera founding-member pricing
+          benefit_id: ben_01
+          description: Founding-member pricing provides 20% to 30% off for 12 months.
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            kind: up-to
+            basis_points: 3000
+        - benefit_id: ben_02
+          description: A free two-week done-with-you Launch Sprint for setup, migration, and initial campaign and automation delivery.
+          duration:
+            kind: exact
+            value: P14D
+          kind: free-service
+          service: Done-with-you Launch Sprint
+      consideration:
+        kind: variable
+        description: Accepted teams that convert after the initial pilot pay the applicable discounted founding-member price.
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: vendor-discretion
+            statement: Applicant must be an early-stage, B2B-qualified startup with a real product and a genuine need to run marketing, sales, and operations.
+          - criterion_id: cri_02
+            fact: applicant.is_agency
+            kind: predicate
+            operator: eq
+            statement: Agencies reselling the platform are not eligible.
+            value:
+              type: boolean
+              value: false
+          - criterion_id: cri_03
+            kind: manual
+            reason: external-verification
+            statement: One startup-program membership is available per company.
+    roles:
+      terms_authority_entity_id: ent_5hhcjbzrafvn4m9akppramvadd
+      access_operator_entity_id: ent_5hhcjbzrafvn4m9akppramvadd
+    access:
+      availability: public
+      method: contact
+      url: https://wysera.ai/startups
+      instructions: Follow the application instructions on the startup-program page to submit the startup name, website, and growth objective.
+    terms_url: https://wysera.ai/startups
+    source_ids:
+      - src_3ff2850af068653cf95f20a138237b000afa4dd2ac39123d7f83aa21d8b29780

--- a/entities/wy/wysera.yaml
+++ b/entities/wy/wysera.yaml
@@ -55,6 +55,7 @@ offers:
           service: Done-with-you Launch Sprint
       consideration:
         kind: unknown
+        description: The cited source does not establish separate consideration beyond the offer terms.
     eligibility:
       rule:
         criterion_id: cri_01

--- a/entities/wy/wysera.yaml
+++ b/entities/wy/wysera.yaml
@@ -10,6 +10,7 @@ entity:
       valid_from: 2026-09-01T06:15:00.000Z
   category: crm-sales
 profile:
+  summary: Agentic platform for marketing, sales, CRM, content, automation, and business operations.
   description: Wysera is an agentic platform that brings marketing, sales, CRM, content, automation, and business operations together for lean teams.
   links:
     site: https://wysera.ai/
@@ -54,7 +55,6 @@ offers:
           service: Done-with-you Launch Sprint
       consideration:
         kind: unknown
-        description: The source does not publish the converted founding-member price.
     eligibility:
       rule:
         criterion_id: cri_01

--- a/entities/wy/wysera.yaml
+++ b/entities/wy/wysera.yaml
@@ -54,8 +54,8 @@ offers:
           kind: free-service
           service: Done-with-you Launch Sprint
       consideration:
-        kind: unknown
-        description: The cited source does not establish separate consideration beyond the offer terms.
+        kind: variable
+        description: Founding-member pricing is locked for 12 months once you convert.
     eligibility:
       rule:
         criterion_id: cri_01


### PR DESCRIPTION
## Summary

- add Wysera and its current startup program
- encode the published 20% to 30% founding-member discount for 12 months
- include the free two-week Launch Sprint and the current eligibility/access contract
- use only Wysera's live first-party startup-program page

Closes #1115

## Verification

- pinned catalog verifier: passed (`entities: 1, programs: 1, offers: 1`)
- DCO signed