### PR TITLE
data: add Innovation Match startup discount

### DIFF
--- a/entities/in/innovation-match.yaml
+++ b/entities/in/innovation-match.yaml
@@ -71,9 +71,9 @@ offers:
       access_operator_entity_id: ent_y2mw7aqj95h2b0xh6s17bs3rav
     access:
       availability: public
-      method: form
+      method: automatic
       url: https://payments-eu1.hubspot.com/payments/TJ2z7yRSQPCw
-      instructions: Register the company on Innovation Match, then use the PRIME STARTUP Subscribe Now checkout.
+      instructions: Register the company on Innovation Match, then open the published PRIME STARTUP Subscribe Now link and complete checkout.
     terms_url: https://www.innovationmatch.io/business-match/
     source_ids:
       - src_311929614e871403c9016e5d62372fd31e126aafc4c5c3a17d4c3bc1ca6d4d66

--- a/entities/in/innovation-match.yaml
+++ b/entities/in/innovation-match.yaml
@@ -71,7 +71,7 @@ offers:
       access_operator_entity_id: ent_y2mw7aqj95h2b0xh6s17bs3rav
     access:
       availability: public
-      method: automatic
+      method: other
       url: https://payments-eu1.hubspot.com/payments/TJ2z7yRSQPCw
       instructions: Register the company on Innovation Match, then open the published PRIME STARTUP Subscribe Now link and complete checkout.
     terms_url: https://www.innovationmatch.io/business-match/

--- a/entities/in/innovation-match.yaml
+++ b/entities/in/innovation-match.yaml
@@ -8,7 +8,7 @@ entity:
     - value: innovationmatch.io
       role: primary
       valid_from: 2026-09-01T06:45:00.000Z
-  category: crm-sales
+  category: marketing
 profile:
   summary: Business matchmaking, commercial introductions, visibility, and sales outreach.
   description: Innovation Match provides business matchmaking, commercial introductions, events, visibility, and sales-outreach services for innovative companies and solution providers.
@@ -37,9 +37,8 @@ offers:
       effective_from: 2026-09-01T06:45:00.000Z
     economics:
       benefits:
-        - applies_to: Innovation Match PRIME subscription
-          benefit_id: ben_01
-          description: 50% off the PRIME monthly subscription, reducing the price from €599 to €299 per month.
+        - benefit_id: ben_01
+          description: 50% startup discount on the PRIME subscription.
           kind: discount
           percentage:
             kind: exact

--- a/entities/in/innovation-match.yaml
+++ b/entities/in/innovation-match.yaml
@@ -17,6 +17,8 @@ profile:
 sources:
   - source_id: src_311929614e871403c9016e5d62372fd31e126aafc4c5c3a17d4c3bc1ca6d4d66
     url: https://www.innovationmatch.io/business-match/
+  - source_id: src_ca52748e9b69f8dfb4583315c2c3f0cbe89bf8220f39b16c1402320d2ba0669f
+    url: https://payments-eu1.hubspot.com/payments/TJ2z7yRSQPCw?referrer=PAYMENT_LINK
 programs:
   - program_id: prg_mn9x6z64waa30rq92r8f0w5bxw
     program_slug: prime-startup
@@ -50,18 +52,29 @@ offers:
           minor_units: 29900
     eligibility:
       rule:
-        criterion_id: cri_01
-        kind: manual
-        reason: external-verification
-        statement: The company must be registered on Innovation Match, have been founded in 2023 or later, and use the startup discount only once for a new activation.
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: The company is registered on Innovation Match.
+          - criterion_id: cri_02
+            kind: manual
+            reason: external-verification
+            statement: The company was founded in 2023 or later.
+          - criterion_id: cri_03
+            kind: manual
+            reason: external-verification
+            statement: The startup promotion is used only once and only for a new activation.
     roles:
       terms_authority_entity_id: ent_y2mw7aqj95h2b0xh6s17bs3rav
       access_operator_entity_id: ent_y2mw7aqj95h2b0xh6s17bs3rav
     access:
       availability: public
       method: form
-      url: https://www.innovationmatch.io/business-match/
-      instructions: Register the company on Innovation Match, then use the PRIME STARTUP subscription route on the business-match page.
+      url: https://payments-eu1.hubspot.com/payments/TJ2z7yRSQPCw?referrer=PAYMENT_LINK
+      instructions: Register the company on Innovation Match, then use the PRIME STARTUP Subscribe Now checkout.
     terms_url: https://www.innovationmatch.io/business-match/
     source_ids:
       - src_311929614e871403c9016e5d62372fd31e126aafc4c5c3a17d4c3bc1ca6d4d66
+      - src_ca52748e9b69f8dfb4583315c2c3f0cbe89bf8220f39b16c1402320d2ba0669f

--- a/entities/in/innovation-match.yaml
+++ b/entities/in/innovation-match.yaml
@@ -38,7 +38,7 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: 50% startup discount on the PRIME subscription.
+          description: "50% STARTUP DISCOUNT ON PRIME SUBSCRIPTION, only 299€/month."
           kind: discount
           percentage:
             kind: exact

--- a/entities/in/innovation-match.yaml
+++ b/entities/in/innovation-match.yaml
@@ -10,6 +10,7 @@ entity:
       valid_from: 2026-09-01T06:45:00.000Z
   category: crm-sales
 profile:
+  summary: Business matchmaking, commercial introductions, visibility, and sales outreach.
   description: Innovation Match provides business matchmaking, commercial introductions, events, visibility, and sales-outreach services for innovative companies and solution providers.
   links:
     site: https://www.innovationmatch.io/
@@ -50,28 +51,10 @@ offers:
           minor_units: 29900
     eligibility:
       rule:
-        kind: all
-        rules:
-          - criterion_id: cri_01
-            fact: company.age_months
-            kind: predicate
-            operator: lt
-            statement: The startup was founded less than three years ago.
-            value:
-              type: number
-              value: 36
-          - criterion_id: cri_02
-            fact: applicant.is_new_customer
-            kind: predicate
-            operator: eq
-            statement: The discount is valid only once and only for a new activation.
-            value:
-              type: boolean
-              value: true
-          - criterion_id: cri_03
-            kind: manual
-            reason: external-verification
-            statement: The company must be registered on Innovation Match.
+        criterion_id: cri_01
+        kind: manual
+        reason: external-verification
+        statement: The company must be registered on Innovation Match, have been founded in 2023 or later, and use the startup discount only once for a new activation.
     roles:
       terms_authority_entity_id: ent_y2mw7aqj95h2b0xh6s17bs3rav
       access_operator_entity_id: ent_y2mw7aqj95h2b0xh6s17bs3rav

--- a/entities/in/innovation-match.yaml
+++ b/entities/in/innovation-match.yaml
@@ -17,8 +17,8 @@ profile:
 sources:
   - source_id: src_311929614e871403c9016e5d62372fd31e126aafc4c5c3a17d4c3bc1ca6d4d66
     url: https://www.innovationmatch.io/business-match/
-  - source_id: src_ca52748e9b69f8dfb4583315c2c3f0cbe89bf8220f39b16c1402320d2ba0669f
-    url: https://payments-eu1.hubspot.com/payments/TJ2z7yRSQPCw?referrer=PAYMENT_LINK
+  - source_id: src_59e3b3c3d78e2ab8d3a43022b05f9f0a148e82714b86e522a5f6ccd4761399d3
+    url: https://payments-eu1.hubspot.com/payments/TJ2z7yRSQPCw
 programs:
   - program_id: prg_mn9x6z64waa30rq92r8f0w5bxw
     program_slug: prime-startup
@@ -72,9 +72,9 @@ offers:
     access:
       availability: public
       method: form
-      url: https://payments-eu1.hubspot.com/payments/TJ2z7yRSQPCw?referrer=PAYMENT_LINK
+      url: https://payments-eu1.hubspot.com/payments/TJ2z7yRSQPCw
       instructions: Register the company on Innovation Match, then use the PRIME STARTUP Subscribe Now checkout.
     terms_url: https://www.innovationmatch.io/business-match/
     source_ids:
       - src_311929614e871403c9016e5d62372fd31e126aafc4c5c3a17d4c3bc1ca6d4d66
-      - src_ca52748e9b69f8dfb4583315c2c3f0cbe89bf8220f39b16c1402320d2ba0669f
+      - src_59e3b3c3d78e2ab8d3a43022b05f9f0a148e82714b86e522a5f6ccd4761399d3

--- a/entities/in/innovation-match.yaml
+++ b/entities/in/innovation-match.yaml
@@ -8,7 +8,7 @@ entity:
     - value: innovationmatch.io
       role: primary
       valid_from: 2026-09-01T06:45:00.000Z
-  category: marketing
+  category: crm-sales
 profile:
   summary: Business matchmaking, commercial introductions, visibility, and sales outreach.
   description: Innovation Match provides business matchmaking, commercial introductions, events, visibility, and sales-outreach services for innovative companies and solution providers.

--- a/entities/in/innovation-match.yaml
+++ b/entities/in/innovation-match.yaml
@@ -1,0 +1,85 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_y2mw7aqj95h2b0xh6s17bs3rav
+  slug: innovation-match
+  slug_aliases: []
+  name: Innovation Match
+  domains:
+    - value: innovationmatch.io
+      role: primary
+      valid_from: 2026-09-01T06:45:00.000Z
+  category: crm-sales
+profile:
+  description: Innovation Match provides business matchmaking, commercial introductions, events, visibility, and sales-outreach services for innovative companies and solution providers.
+  links:
+    site: https://www.innovationmatch.io/
+sources:
+  - source_id: src_311929614e871403c9016e5d62372fd31e126aafc4c5c3a17d4c3bc1ca6d4d66
+    url: https://www.innovationmatch.io/business-match/
+programs:
+  - program_id: prg_mn9x6z64waa30rq92r8f0w5bxw
+    program_slug: prime-startup
+    program_slug_aliases: []
+    title: PRIME STARTUP
+    summary: Innovation Match gives eligible young companies a discounted PRIME subscription for business matchmaking and visibility.
+    source_ids:
+      - src_311929614e871403c9016e5d62372fd31e126aafc4c5c3a17d4c3bc1ca6d4d66
+offers:
+  - offer_id: off_51wse5f6s9twang6z5c6fy23fm
+    program_id: prg_mn9x6z64waa30rq92r8f0w5bxw
+    offer_slug: fifty-percent-off-prime-subscription
+    offer_slug_aliases: []
+    title: 50% Off Innovation Match PRIME
+    summary: Eligible startups pay €299 per month instead of €599 per month for PRIME, including community membership, advanced visibility, priority matchmaking, and access to Innovation Match's 2026 events.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-01T06:45:00.000Z
+    economics:
+      benefits:
+        - applies_to: Innovation Match PRIME subscription
+          benefit_id: ben_01
+          description: 50% off the PRIME monthly subscription, reducing the price from €599 to €299 per month.
+          kind: discount
+          percentage:
+            kind: exact
+            basis_points: 5000
+      consideration:
+        kind: fixed
+        amount:
+          currency: EUR
+          minor_units: 29900
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: The startup was founded less than three years ago.
+            value:
+              type: number
+              value: 36
+          - criterion_id: cri_02
+            fact: applicant.is_new_customer
+            kind: predicate
+            operator: eq
+            statement: The discount is valid only once and only for a new activation.
+            value:
+              type: boolean
+              value: true
+          - criterion_id: cri_03
+            kind: manual
+            reason: external-verification
+            statement: The company must be registered on Innovation Match.
+    roles:
+      terms_authority_entity_id: ent_y2mw7aqj95h2b0xh6s17bs3rav
+      access_operator_entity_id: ent_y2mw7aqj95h2b0xh6s17bs3rav
+    access:
+      availability: public
+      method: form
+      url: https://www.innovationmatch.io/business-match/
+      instructions: Register the company on Innovation Match, then use the PRIME STARTUP subscription route on the business-match page.
+    terms_url: https://www.innovationmatch.io/business-match/
+    source_ids:
+      - src_311929614e871403c9016e5d62372fd31e126aafc4c5c3a17d4c3bc1ca6d4d66

--- a/entities/in/innovation-match.yaml
+++ b/entities/in/innovation-match.yaml
@@ -38,7 +38,7 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: 50% STARTUP DISCOUNT ON PRIME SUBSCRIPTION
+          description: STARTUP DISCOUNT ON PRIME SUBSCRIPTION
           kind: discount
           percentage:
             kind: exact

--- a/entities/in/innovation-match.yaml
+++ b/entities/in/innovation-match.yaml
@@ -38,7 +38,7 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: "50% STARTUP DISCOUNT ON PRIME SUBSCRIPTION, only 299€/month."
+          description: 50% STARTUP DISCOUNT ON PRIME SUBSCRIPTION
           kind: discount
           percentage:
             kind: exact


### PR DESCRIPTION
## Summary

- add Innovation Match and the current PRIME STARTUP offer
- encode the published 50% discount (€299 instead of €599 per month)
- include the company-age, registration, and new-activation eligibility
- use only Innovation Match's live first-party business-match page

Closes #1119

## Verification

- pinned catalog verifier: passed (`entities: 1, programs: 1, offers: 1`)
- DCO signed