### PR TITLE
data: add Definite startup program

### DIFF
--- a/entities/de/definite.yaml
+++ b/entities/de/definite.yaml
@@ -10,6 +10,7 @@ entity:
       valid_from: 2026-09-01T06:13:06.025Z
   category: data-analytics
 profile:
+  summary: AI-native data platform for warehouse, ETL, business intelligence, and analytics.
   description: Definite is an AI-native data platform that combines a warehouse, data integration, business intelligence, and analytics agents in a private deployment within a customer's cloud environment.
   links:
     site: https://www.definite.app/
@@ -37,7 +38,7 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: $25,000 in Definite compute and AI credits.
+          description: $25,000 in Definite credits
           kind: credit
           value:
             amount:
@@ -45,7 +46,7 @@ offers:
               minor_units: 2500000
             kind: exact
         - benefit_id: ben_02
-          description: Definite Platform free for 12 months, including unlimited users, more than 500 connectors, hourly sync, and full Fi access.
+          description: 12 months of Platform, free
           duration:
             kind: exact
             value: P1Y

--- a/entities/de/definite.yaml
+++ b/entities/de/definite.yaml
@@ -38,7 +38,7 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: $25,000 in Definite credits
+          description: Enough compute and AI credits to run analytics for a year.
           kind: credit
           value:
             amount:
@@ -46,12 +46,12 @@ offers:
               minor_units: 2500000
             kind: exact
         - benefit_id: ben_02
-          description: 12 months of Platform, free
+          description: Unlimited users, 500+ connectors, hourly sync, and full Fi access.
           duration:
             kind: exact
             value: P1Y
           kind: free-service
-          service: Definite Platform
+          service: Platform
         - benefit_id: ben_03
           description: White-glove onboarding with a senior data engineer to set up the warehouse, model core metrics, and build initial dashboards.
           kind: free-service

--- a/entities/de/definite.yaml
+++ b/entities/de/definite.yaml
@@ -59,58 +59,17 @@ offers:
         kind: none
     eligibility:
       rule:
-        kind: all
-        rules:
-          - criterion_id: cri_01
-            fact: company.funding_stage
-            kind: predicate
-            operator: in
-            statement: The company is at pre-seed, seed, or Series A stage.
-            value:
-              type: string-set
-              values:
-                - pre-seed
-                - seed
-                - Series A
-          - criterion_id: cri_02
-            fact: company.funding_raised_usd
-            kind: predicate
-            operator: lt
-            statement: The company has raised less than $10 million in total.
-            value:
-              type: number
-              value: 10000000
-          - criterion_id: cri_03
-            fact: company.employee_count
-            kind: predicate
-            operator: lt
-            statement: The company has fewer than 50 people.
-            value:
-              type: number
-              value: 50
-          - criterion_id: cri_04
-            kind: manual
-            reason: external-verification
-            statement: The applicant is a founder or early data hire at the company.
-          - criterion_id: cri_05
-            kind: manual
-            reason: external-verification
-            statement: The company is backed by a leading accelerator or fund such as Y Combinator, Techstars, a16z, Sequoia, or a similar organization.
-          - criterion_id: cri_06
-            fact: applicant.is_new_customer
-            kind: predicate
-            operator: eq
-            statement: The company is new to Definite or still within its first 30 days.
-            value:
-              type: boolean
-              value: true
+        kind: manual
+        criterion_id: cri_01
+        reason: external-verification
+        statement: Definite reviews every application manually and admits applicants when most of its published eligibility checks fit.
     roles:
       terms_authority_entity_id: ent_qz0cyj53t5ng3yph5b5kfctrjv
       access_operator_entity_id: ent_qz0cyj53t5ng3yph5b5kfctrjv
     access:
       availability: public
       method: form
-      url: https://app.definite.app/register
+      url: https://www.definite.app/signup
       instructions: Create a Definite account and complete the in-product startup-program application for manual review.
     terms_url: https://www.definite.app/startups
     source_ids:

--- a/entities/de/definite.yaml
+++ b/entities/de/definite.yaml
@@ -38,7 +38,7 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: Enough compute and AI credits to run analytics for a year.
+          description: Enough compute and AI credits to run your analytics for a year — with plenty of room to experiment.
           kind: credit
           value:
             amount:
@@ -53,7 +53,7 @@ offers:
           kind: free-service
           service: Platform
         - benefit_id: ben_03
-          description: White-glove onboarding with a senior data engineer to set up the warehouse, model core metrics, and build initial dashboards.
+          description: A senior data engineer sets up your warehouse, models your core metrics, and builds your first dashboards.
           kind: free-service
           service: White-glove onboarding
       consideration:

--- a/entities/de/definite.yaml
+++ b/entities/de/definite.yaml
@@ -1,0 +1,117 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_qz0cyj53t5ng3yph5b5kfctrjv
+  slug: definite
+  slug_aliases: []
+  name: Definite
+  domains:
+    - value: definite.app
+      role: primary
+      valid_from: 2026-09-01T06:13:06.025Z
+  category: data-analytics
+profile:
+  description: Definite is an AI-native data platform that combines a warehouse, data integration, business intelligence, and analytics agents in a private deployment within a customer's cloud environment.
+  links:
+    site: https://www.definite.app/
+sources:
+  - source_id: src_418652a7f043ba5bbbcc8dc842b84624934f7c6e36293999ef23ad59bd0c1d9f
+    url: https://www.definite.app/startups
+programs:
+  - program_id: prg_nqve74hyhr9kr8hh59vdqdz14n
+    program_slug: definite-for-startups
+    program_slug_aliases: []
+    title: Definite for Startups
+    summary: Definite gives eligible early-stage companies $25,000 in compute and AI credits, 12 months of its Platform free, and white-glove onboarding.
+    source_ids:
+      - src_418652a7f043ba5bbbcc8dc842b84624934f7c6e36293999ef23ad59bd0c1d9f
+offers:
+  - offer_id: off_2r6egtqqjc0fht2750qtv2cxnw
+    program_id: prg_nqve74hyhr9kr8hh59vdqdz14n
+    offer_slug: twenty-five-thousand-dollars-credits-and-one-year-free-platform
+    offer_slug_aliases: []
+    title: $25,000 in Credits and One Year of Definite Platform Free
+    summary: Eligible startups receive $25,000 in Definite compute and AI credits, 12 months of Definite Platform free, white-glove onboarding, and direct support from the Definite team.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-01T06:13:06.025Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: $25,000 in Definite compute and AI credits.
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 2500000
+            kind: exact
+        - benefit_id: ben_02
+          description: Definite Platform free for 12 months, including unlimited users, more than 500 connectors, hourly sync, and full Fi access.
+          duration:
+            kind: exact
+            value: P1Y
+          kind: free-service
+          service: Definite Platform
+        - benefit_id: ben_03
+          description: White-glove onboarding with a senior data engineer to set up the warehouse, model core metrics, and build initial dashboards.
+          kind: free-service
+          service: White-glove onboarding
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.funding_stage
+            kind: predicate
+            operator: in
+            statement: The company is at pre-seed, seed, or Series A stage.
+            value:
+              type: string-set
+              values:
+                - pre-seed
+                - seed
+                - Series A
+          - criterion_id: cri_02
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: The company has raised less than $10 million in total.
+            value:
+              type: number
+              value: 10000000
+          - criterion_id: cri_03
+            fact: company.employee_count
+            kind: predicate
+            operator: lt
+            statement: The company has fewer than 50 people.
+            value:
+              type: number
+              value: 50
+          - criterion_id: cri_04
+            kind: manual
+            reason: external-verification
+            statement: The applicant is a founder or early data hire at the company.
+          - criterion_id: cri_05
+            kind: manual
+            reason: external-verification
+            statement: The company is backed by a leading accelerator or fund such as Y Combinator, Techstars, a16z, Sequoia, or a similar organization.
+          - criterion_id: cri_06
+            fact: applicant.is_new_customer
+            kind: predicate
+            operator: eq
+            statement: The company is new to Definite or still within its first 30 days.
+            value:
+              type: boolean
+              value: true
+    roles:
+      terms_authority_entity_id: ent_qz0cyj53t5ng3yph5b5kfctrjv
+      access_operator_entity_id: ent_qz0cyj53t5ng3yph5b5kfctrjv
+    access:
+      availability: public
+      method: form
+      url: https://app.definite.app/register
+      instructions: Create a Definite account and complete the in-product startup-program application for manual review.
+    terms_url: https://www.definite.app/startups
+    source_ids:
+      - src_418652a7f043ba5bbbcc8dc842b84624934f7c6e36293999ef23ad59bd0c1d9f


### PR DESCRIPTION
## Summary

- add Definite as a new startup-credit entity
- document its current $25,000 compute and AI credit benefit
- document 12 months of Definite Platform free and white-glove onboarding
- encode the published stage, funding, team-size, backing, role, and new-customer eligibility requirements

## Sources

- https://www.definite.app/startups

## Verification

- exact pinned Sourcey catalog verifier completed successfully for the committed diff
- committed diff contains exactly 1 entity, 1 program, and 1 offer
- commit includes DCO sign-off

Closes #1121