### PR TITLE
data: add Userback startup program

### DIFF
--- a/entities/us/userback.yaml
+++ b/entities/us/userback.yaml
@@ -43,8 +43,7 @@ offers:
             kind: exact
             basis_points: 2500
       consideration:
-        kind: unknown
-        description: The payable amount depends on the annual plan selected and is not stated on the program page.
+        kind: variable
     eligibility:
       rule:
         kind: manual

--- a/entities/us/userback.yaml
+++ b/entities/us/userback.yaml
@@ -44,8 +44,8 @@ offers:
             kind: exact
             basis_points: 2500
       consideration:
-        kind: variable
-        description: Price per month, billed annually, varies by plan.
+        kind: unknown
+        description: Discounted annual-plan pricing applies.
     eligibility:
       rule:
         kind: manual

--- a/entities/us/userback.yaml
+++ b/entities/us/userback.yaml
@@ -44,8 +44,8 @@ offers:
             kind: exact
             basis_points: 2500
       consideration:
-        kind: unknown
-        description: Discounted annual-plan pricing applies.
+        kind: variable
+        description: The startup pays the discounted annual price of its selected Userback plan.
     eligibility:
       rule:
         kind: manual

--- a/entities/us/userback.yaml
+++ b/entities/us/userback.yaml
@@ -36,51 +36,21 @@ offers:
       effective_from: 2026-09-01T06:49:52.445Z
     economics:
       benefits:
-        - applies_to: Userback annual plans
-          benefit_id: ben_01
-          description: 25% off any Userback annual plan for the first year.
-          duration:
-            kind: exact
-            value: P1Y
+        - benefit_id: ben_01
+          description: 25% off all annual plans for the first year.
           kind: discount
           percentage:
             kind: exact
             basis_points: 2500
       consideration:
-        kind: variable
-        description: The startup pays the annual-plan price remaining after the 25% discount.
+        kind: unknown
+        description: The payable amount depends on the annual plan selected and is not stated on the program page.
     eligibility:
       rule:
-        kind: all
-        rules:
-          - criterion_id: cri_01
-            kind: manual
-            reason: external-verification
-            statement: The applicant is primarily a SaaS business.
-          - criterion_id: cri_02
-            fact: company.funding_raised_usd
-            kind: predicate
-            operator: lte
-            statement: The company has raised no more than $1 million.
-            value:
-              type: number
-              value: 1000000
-          - criterion_id: cri_03
-            fact: company.employee_count
-            kind: predicate
-            operator: lt
-            statement: The company has fewer than 10 employees.
-            value:
-              type: number
-              value: 10
-          - criterion_id: cri_04
-            fact: company.age_months
-            kind: predicate
-            operator: lte
-            statement: The company was founded within the last two years.
-            value:
-              type: number
-              value: 24
+        kind: manual
+        criterion_id: cri_01
+        reason: external-verification
+        statement: Applicants must have fewer than 10 employees, be primarily a SaaS business, have raised less than $1M in funding, and have been founded within the last two years.
     roles:
       terms_authority_entity_id: ent_ga5fqb1awsf71jftecx9pq9skw
       access_operator_entity_id: ent_ga5fqb1awsf71jftecx9pq9skw

--- a/entities/us/userback.yaml
+++ b/entities/us/userback.yaml
@@ -1,0 +1,94 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_ga5fqb1awsf71jftecx9pq9skw
+  slug: userback
+  slug_aliases: []
+  name: Userback
+  domains:
+    - value: userback.io
+      role: primary
+      valid_from: 2026-09-01T06:49:52.445Z
+  category: support
+profile:
+  description: Userback is a customer-feedback platform for collecting bug reports, in-app feedback, surveys, session replays, feature requests, and product insights.
+  links:
+    site: https://userback.io/
+sources:
+  - source_id: src_1da5a4f2c8ee9f24f125fe78536b86543a5f897be3bf8597ab1f599384623435
+    url: https://userback.io/offer/startups/
+programs:
+  - program_id: prg_pbb41tsbnm0wd6ftgz0btz7czp
+    program_slug: userback-startup-program
+    program_slug_aliases: []
+    title: Userback Startup Program
+    summary: Userback gives eligible early-stage SaaS companies 25% off all annual plans for their first year.
+    source_ids:
+      - src_1da5a4f2c8ee9f24f125fe78536b86543a5f897be3bf8597ab1f599384623435
+offers:
+  - offer_id: off_atm6v4n9dree4795bjzdxpdkat
+    program_id: prg_pbb41tsbnm0wd6ftgz0btz7czp
+    offer_slug: twenty-five-percent-off-annual-plans-first-year
+    offer_slug_aliases: []
+    title: 25% Off Userback Annual Plans for One Year
+    summary: Eligible startups receive 25% off any Userback annual plan during their first year in the program.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-01T06:49:52.445Z
+    economics:
+      benefits:
+        - applies_to: Userback annual plans
+          benefit_id: ben_01
+          description: 25% off any Userback annual plan for the first year.
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            kind: exact
+            basis_points: 2500
+      consideration:
+        kind: variable
+        description: The startup pays the annual-plan price remaining after the 25% discount.
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: The applicant is primarily a SaaS business.
+          - criterion_id: cri_02
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lte
+            statement: The company has raised no more than $1 million.
+            value:
+              type: number
+              value: 1000000
+          - criterion_id: cri_03
+            fact: company.employee_count
+            kind: predicate
+            operator: lt
+            statement: The company has fewer than 10 employees.
+            value:
+              type: number
+              value: 10
+          - criterion_id: cri_04
+            fact: company.age_months
+            kind: predicate
+            operator: lte
+            statement: The company was founded within the last two years.
+            value:
+              type: number
+              value: 24
+    roles:
+      terms_authority_entity_id: ent_ga5fqb1awsf71jftecx9pq9skw
+      access_operator_entity_id: ent_ga5fqb1awsf71jftecx9pq9skw
+    access:
+      availability: public
+      method: form
+      url: https://userback.io/offer/startups/
+      instructions: Complete the startup-program application form on Userback's offer page.
+    terms_url: https://userback.io/offer/startups/
+    source_ids:
+      - src_1da5a4f2c8ee9f24f125fe78536b86543a5f897be3bf8597ab1f599384623435

--- a/entities/us/userback.yaml
+++ b/entities/us/userback.yaml
@@ -44,6 +44,7 @@ offers:
             basis_points: 2500
       consideration:
         kind: variable
+        description: 25% off all annual plans for the first year.
     eligibility:
       rule:
         kind: manual

--- a/entities/us/userback.yaml
+++ b/entities/us/userback.yaml
@@ -45,7 +45,7 @@ offers:
             basis_points: 2500
       consideration:
         kind: variable
-        description: The startup pays the discounted annual price of its selected Userback plan.
+        description: Price per month (billed annually).
     eligibility:
       rule:
         kind: manual

--- a/entities/us/userback.yaml
+++ b/entities/us/userback.yaml
@@ -10,6 +10,7 @@ entity:
       valid_from: 2026-09-01T06:49:52.445Z
   category: support
 profile:
+  summary: Customer-feedback tools for in-app feedback, surveys, session replays, and insights.
   description: Userback is a customer-feedback platform for collecting bug reports, in-app feedback, surveys, session replays, feature requests, and product insights.
   links:
     site: https://userback.io/
@@ -44,7 +45,7 @@ offers:
             basis_points: 2500
       consideration:
         kind: variable
-        description: 25% off all annual plans for the first year.
+        description: Price per month, billed annually, varies by plan.
     eligibility:
       rule:
         kind: manual


### PR DESCRIPTION
## Summary

- add Userback as a new startup-credit entity
- document the current 25% first-year discount on all annual plans
- encode the published SaaS, funding, team-size, and company-age requirements

## Sources

- https://userback.io/offer/startups/

## Verification

- committed diff contains exactly 1 entity, 1 program, and 1 offer
- commit includes DCO sign-off
- Sourcey changed-closure verifier is expected to validate the exact pull-request head

Closes #1127