### PR TITLE
data: add Zeller for Startups cashback

### DIFF
--- a/entities/ze/zeller.yaml
+++ b/entities/ze/zeller.yaml
@@ -1,0 +1,84 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_2m72y6dwr3mxt4bcrkyt3pgfb4
+  slug: zeller
+  slug_aliases: []
+  name: Zeller
+  domains:
+    - value: myzeller.com
+      role: primary
+      valid_from: 2026-09-01T07:08:28.830Z
+  category: banking
+profile:
+  description: Zeller provides business accounts, debit and corporate cards, expense management, invoicing, point-of-sale, and payment-acceptance tools.
+  links:
+    site: https://www.myzeller.com/
+sources:
+  - source_id: src_d561c3fc4dc978bbdead38dc6432b5464030746f04db0eefb28522ef62cfcf6d
+    url: https://www.myzeller.com/au/startups
+  - source_id: src_4e992114a06135ae66561fa04c6d282812a84a855e519d5e99312c3c95541db2
+    url: https://www.myzeller.com/au/promotion-terms-conditions
+programs:
+  - program_id: prg_dag761srkbwatwmwr3jcjfnj2n
+    program_slug: zeller-for-startups
+    program_slug_aliases: []
+    title: Zeller for Startups
+    summary: Zeller gives Australian startup founders an integrated financial account, cards, expense management, reporting, and startup-specific rewards.
+    source_ids:
+      - src_d561c3fc4dc978bbdead38dc6432b5464030746f04db0eefb28522ef62cfcf6d
+      - src_4e992114a06135ae66561fa04c6d282812a84a855e519d5e99312c3c95541db2
+offers:
+  - offer_id: off_spd0zvzpvkfvxc4g2jc2advkg1
+    program_id: prg_dag761srkbwatwmwr3jcjfnj2n
+    offer_slug: five-percent-debit-card-cashback
+    offer_slug_aliases: []
+    title: 5% Zeller Debit Card Cashback for Startups
+    summary: New Zeller for Startups customers earn 5% cash back on qualifying business purchases made with an active Zeller Debit Card, up to the first AUD $2,000 of eligible spending.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-01T07:08:28.830Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: 5% cash back on qualifying Zeller Debit Card business purchases, capped at the first AUD $2,000 of eligible spending for a maximum AUD $100 benefit.
+          kind: cashback
+          value:
+            kind: percentage
+            value:
+              basis_points: 500
+              kind: exact
+      consideration:
+        kind: variable
+        description: The customer must make qualifying business purchases with an activated Zeller Debit Card; only the first AUD $2,000 of eligible spending earns cash back.
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: The applicant is a new Zeller for Startups customer that successfully activates and onboards a new account.
+          - criterion_id: cri_02
+            kind: manual
+            reason: external-verification
+            statement: The customer has an activated Zeller Transaction Account and Zeller Debit Card.
+          - criterion_id: cri_03
+            kind: manual
+            reason: external-verification
+            statement: Purchases are genuine qualifying business transactions and are not invalid transactions under Zeller's terms.
+          - criterion_id: cri_04
+            kind: manual
+            reason: external-verification
+            statement: The applicant satisfies Zeller's Australian business onboarding and verification requirements.
+    roles:
+      terms_authority_entity_id: ent_2m72y6dwr3mxt4bcrkyt3pgfb4
+      access_operator_entity_id: ent_2m72y6dwr3mxt4bcrkyt3pgfb4
+    access:
+      availability: public
+      method: form
+      url: https://www.myzeller.com/au/startups
+      instructions: Sign up for Zeller for Startups and complete Zeller's account activation and onboarding process.
+    terms_url: https://www.myzeller.com/au/promotion-terms-conditions
+    source_ids:
+      - src_d561c3fc4dc978bbdead38dc6432b5464030746f04db0eefb28522ef62cfcf6d
+      - src_4e992114a06135ae66561fa04c6d282812a84a855e519d5e99312c3c95541db2

--- a/entities/ze/zeller.yaml
+++ b/entities/ze/zeller.yaml
@@ -40,7 +40,7 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: 5% cash back on qualifying Zeller Debit Card business purchases, capped at the first AUD $2,000 of eligible spending for a maximum AUD $100 benefit.
+          description: For Eligible Customers who make qualified business payments using a Zeller Debit Card, you will earn 5% cash back on the total transaction value for valid transactions processed with an active Zeller Debit Card, on up to your first $2,000 of payments processed.
           kind: cashback
           value:
             kind: percentage
@@ -49,7 +49,7 @@ offers:
               kind: exact
       consideration:
         kind: variable
-        description: The customer must make qualifying business purchases with an activated Zeller Debit Card; only the first AUD $2,000 of eligible spending earns cash back.
+        description: Qualified business payments must not be Invalid Transactions (as defined in Zeller’s Terms of Service). Refunded transactions are ineligible for cash back.
     eligibility:
       rule:
         kind: all
@@ -66,10 +66,6 @@ offers:
             kind: manual
             reason: external-verification
             statement: Purchases are genuine qualifying business transactions and are not invalid transactions under Zeller's terms.
-          - criterion_id: cri_04
-            kind: manual
-            reason: external-verification
-            statement: The applicant satisfies Zeller's Australian business onboarding and verification requirements.
     roles:
       terms_authority_entity_id: ent_2m72y6dwr3mxt4bcrkyt3pgfb4
       access_operator_entity_id: ent_2m72y6dwr3mxt4bcrkyt3pgfb4

--- a/entities/ze/zeller.yaml
+++ b/entities/ze/zeller.yaml
@@ -10,6 +10,7 @@ entity:
       valid_from: 2026-09-01T07:08:28.830Z
   category: banking
 profile:
+  summary: Business accounts, cards, expense management, invoicing, and payment-acceptance tools.
   description: Zeller provides business accounts, debit and corporate cards, expense management, invoicing, point-of-sale, and payment-acceptance tools.
   links:
     site: https://www.myzeller.com/
@@ -33,14 +34,14 @@ offers:
     offer_slug: five-percent-debit-card-cashback
     offer_slug_aliases: []
     title: 5% Zeller Debit Card Cashback for Startups
-    summary: New Zeller for Startups customers earn 5% cash back on qualifying business purchases made with an active Zeller Debit Card, up to the first AUD $2,000 of eligible spending.
+    summary: New Zeller for Startups customers earn 5% cash back on valid business payments made with an active Zeller Debit Card, on up to the first $2,000 of payments processed.
     lifecycle:
       status: active
       effective_from: 2026-09-01T07:08:28.830Z
     economics:
       benefits:
         - benefit_id: ben_01
-          description: For Eligible Customers who make qualified business payments using a Zeller Debit Card, you will earn 5% cash back on the total transaction value for valid transactions processed with an active Zeller Debit Card, on up to your first $2,000 of payments processed.
+          description: 5% cash back on transactions processed with Zeller Debit Card.
           kind: cashback
           value:
             kind: percentage
@@ -48,24 +49,13 @@ offers:
               basis_points: 500
               kind: exact
       consideration:
-        kind: variable
-        description: Qualified business payments must not be Invalid Transactions (as defined in Zeller’s Terms of Service). Refunded transactions are ineligible for cash back.
+        kind: none
     eligibility:
       rule:
-        kind: all
-        rules:
-          - criterion_id: cri_01
-            kind: manual
-            reason: external-verification
-            statement: The applicant is a new Zeller for Startups customer that successfully activates and onboards a new account.
-          - criterion_id: cri_02
-            kind: manual
-            reason: external-verification
-            statement: The customer has an activated Zeller Transaction Account and Zeller Debit Card.
-          - criterion_id: cri_03
-            kind: manual
-            reason: external-verification
-            statement: Purchases are genuine qualifying business transactions and are not invalid transactions under Zeller's terms.
+        criterion_id: cri_01
+        kind: manual
+        reason: external-verification
+        statement: Offer is valid only for new Zeller for Startups customers who activate and successfully onboard for a new Zeller for Startups account.
     roles:
       terms_authority_entity_id: ent_2m72y6dwr3mxt4bcrkyt3pgfb4
       access_operator_entity_id: ent_2m72y6dwr3mxt4bcrkyt3pgfb4


### PR DESCRIPTION
## Summary

Adds a current-schema entry for the ongoing Zeller for Startups debit-card cashback offer.

The first-party program and promotion terms document 5% cash back for new Zeller for Startups customers on qualifying business purchases, capped at the first AUD $2,000 of eligible spending (AUD $100 maximum benefit).

## Sources

- https://www.myzeller.com/au/startups
- https://www.myzeller.com/au/promotion-terms-conditions

## Verification

- Pinned Sourcey verifier: `Sourcey verification passed (entities: 1, programs: 1, offers: 1)`
- `git diff --check`
- DCO sign-off included

Closes #1133