### PR TITLE
data: add TESS startup program

### DIFF
--- a/entities/te/tess.yaml
+++ b/entities/te/tess.yaml
@@ -1,0 +1,89 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_89sp9by2zr7vwqk87nakyz6wnv
+  slug: tess
+  slug_aliases: []
+  name: TESS
+  domains:
+    - value: tess.im
+      role: primary
+      valid_from: 2026-09-01T07:38:46.486Z
+  category: ai-ml
+profile:
+  description: TESS is an AI agent platform that orchestrates multiple models for research, engineering, marketing, operations, content creation, and business workflows.
+  links:
+    site: https://tess.im
+sources:
+  - source_id: src_58ae94fc790bc26224d8ffdab1a5e5d2e0882b97235fa83bc3906ab06bf9ed43
+    url: https://tess.im/startup
+programs:
+  - program_id: prg_9gh33ms8j4sxp0758ajrjjw14g
+    program_slug: tess-for-startups
+    program_slug_aliases: []
+    title: TESS for Startups
+    summary: TESS gives approved eligible startups 50% off their first subscription year and guided onboarding with TESS staff.
+    source_ids:
+      - src_58ae94fc790bc26224d8ffdab1a5e5d2e0882b97235fa83bc3906ab06bf9ed43
+offers:
+  - offer_id: off_yzdnwc56dt7pz0j234hmt3agp1
+    program_id: prg_9gh33ms8j4sxp0758ajrjjw14g
+    offer_slug: fifty-percent-off-first-year
+    offer_slug_aliases: []
+    title: 50% off the first year of TESS
+    summary: Approved startups founded less than five years ago with no more than USD 10 million raised receive 50% off the first year of a TESS subscription plus guided onboarding.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-01T07:38:46.486Z
+    economics:
+      benefits:
+        - applies_to: TESS subscription
+          benefit_id: ben_01
+          description: 50% off the first year of a TESS subscription
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            basis_points: 5000
+            kind: exact
+        - benefit_id: ben_02
+          description: Guided onboarding with TESS staff
+          kind: other
+      consideration:
+        kind: variable
+        description: The approved startup pays the remaining 50% of its TESS subscription price during the first year.
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: The startup must have been founded less than five years ago.
+            value:
+              type: number
+              value: 60
+          - criterion_id: cri_02
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lte
+            statement: The startup must have raised no more than USD 10 million in total funding.
+            value:
+              type: number
+              value: 10000000
+          - criterion_id: cri_03
+            kind: manual
+            reason: vendor-discretion
+            statement: The applicant must not be a direct competitor and is subject to TESS review and approval.
+    roles:
+      terms_authority_entity_id: ent_89sp9by2zr7vwqk87nakyz6wnv
+      access_operator_entity_id: ent_89sp9by2zr7vwqk87nakyz6wnv
+    access:
+      availability: public
+      instructions: Submit the TESS Startup Program application form for review.
+      method: form
+      url: https://tess-im.typeform.com/to/cIlZaEOa
+    terms_url: https://tess.im/startup
+    source_ids:
+      - src_58ae94fc790bc26224d8ffdab1a5e5d2e0882b97235fa83bc3906ab06bf9ed43


### PR DESCRIPTION
## Summary

- add TESS as a new AI agent-platform vendor
- document its current startup offer from its English first-party page
- capture the 50% first-year discount, guided onboarding, age and funding thresholds, non-competitor review, and exact application form

## Source

- https://tess.im/startup

## Verification

- exact pinned catalog verifier: `entities: 1, programs: 1, offers: 1`
- `git diff --check`
- DCO signed-off commit

Closes #1141