### PR TITLE
data: add Swingvy startup program

### DIFF
--- a/entities/sw/swingvy.yaml
+++ b/entities/sw/swingvy.yaml
@@ -17,6 +17,8 @@ profile:
 sources:
   - source_id: src_c63c7c4b4551b8323a4fe2316757731fce3dbb21957aea66e1278292304c6e8b
     url: https://www.swingvy.com/sg/startups
+  - source_id: src_35578c82dfec00c300cac11bc7405e5f831dca36df321b2bc8332302e87c73b3
+    url: https://www.swingvy.com/sg/pricing
 programs:
   - program_id: prg_tjwnd1zf7nk92np2cnk62fn6y5
     program_slug: swingvy-startup-program
@@ -49,7 +51,7 @@ offers:
             kind: exact
       consideration:
         kind: variable
-        description: 50% off Swingvy for one year
+        description: Pricing is based on the number of employees, with monthly or annual subscriptions.
     eligibility:
       rule:
         criterion_id: cri_01
@@ -66,3 +68,4 @@ offers:
       url: https://secure.swingvy.com/
     source_ids:
       - src_c63c7c4b4551b8323a4fe2316757731fce3dbb21957aea66e1278292304c6e8b
+      - src_35578c82dfec00c300cac11bc7405e5f831dca36df321b2bc8332302e87c73b3

--- a/entities/sw/swingvy.yaml
+++ b/entities/sw/swingvy.yaml
@@ -51,7 +51,7 @@ offers:
             kind: exact
       consideration:
         kind: variable
-        description: Startup programme pricing.
+        description: Swingvy offers monthly or yearly subscriptions, and pricing is based on the number of employees in your business.
     eligibility:
       rule:
         criterion_id: cri_01

--- a/entities/sw/swingvy.yaml
+++ b/entities/sw/swingvy.yaml
@@ -1,0 +1,90 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_bk3mzkpepw8ns7k4z21nf4h8fq
+  slug: swingvy
+  slug_aliases: []
+  name: Swingvy
+  domains:
+    - value: swingvy.com
+      role: primary
+      valid_from: 2026-09-01T07:47:50.213Z
+  category: hr-people
+profile:
+  description: Swingvy provides an integrated people-operations platform for employee records, leave, time and attendance, expense claims, payroll, benefits, insights, and mobile HR workflows.
+  links:
+    site: https://www.swingvy.com
+sources:
+  - source_id: src_c63c7c4b4551b8323a4fe2316757731fce3dbb21957aea66e1278292304c6e8b
+    url: https://www.swingvy.com/sg/startups
+programs:
+  - program_id: prg_tjwnd1zf7nk92np2cnk62fn6y5
+    program_slug: swingvy-startup-program
+    program_slug_aliases: []
+    title: Swingvy Startup Program
+    summary: Swingvy gives eligible early-stage startups 50% off its all-in-one HR platform for one year.
+    source_ids:
+      - src_c63c7c4b4551b8323a4fe2316757731fce3dbb21957aea66e1278292304c6e8b
+offers:
+  - offer_id: off_dtacg5473vdw13fs9qc5jf5qfy
+    program_id: prg_tjwnd1zf7nk92np2cnk62fn6y5
+    offer_slug: fifty-percent-off-for-one-year
+    offer_slug_aliases: []
+    title: 50% off Swingvy for one year
+    summary: Startups less than three years old with fewer than 15 employees and no more than USD 1 million in funding receive 50% off Swingvy for one year.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-01T07:47:50.213Z
+    economics:
+      benefits:
+        - applies_to: Swingvy all-in-one HR platform
+          benefit_id: ben_01
+          description: 50% off Swingvy for one year
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            basis_points: 5000
+            kind: exact
+      consideration:
+        kind: variable
+        description: The approved startup pays the remaining 50% of its Swingvy subscription price during the one-year offer period.
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: The startup must be less than three years old.
+            value:
+              type: number
+              value: 36
+          - criterion_id: cri_02
+            fact: company.employee_count
+            kind: predicate
+            operator: lt
+            statement: The startup must have fewer than 15 employees.
+            value:
+              type: number
+              value: 15
+          - criterion_id: cri_03
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lte
+            statement: The startup must have raised no more than USD 1 million.
+            value:
+              type: number
+              value: 1000000
+    roles:
+      terms_authority_entity_id: ent_bk3mzkpepw8ns7k4z21nf4h8fq
+      access_operator_entity_id: ent_bk3mzkpepw8ns7k4z21nf4h8fq
+    access:
+      availability: public
+      instructions: Use the Apply Now link on Swingvy's startup-program page and complete the Swingvy signup flow.
+      method: form
+      url: https://secure.swingvy.com/
+    terms_url: https://www.swingvy.com/sg/startups
+    source_ids:
+      - src_c63c7c4b4551b8323a4fe2316757731fce3dbb21957aea66e1278292304c6e8b

--- a/entities/sw/swingvy.yaml
+++ b/entities/sw/swingvy.yaml
@@ -48,36 +48,14 @@ offers:
             basis_points: 5000
             kind: exact
       consideration:
-        kind: unknown
-        description: Swingvy publishes a 50% startup discount but not the resulting subscription price.
+        kind: variable
+        description: "50% off Swingvy's all-in-one HR platform for one year."
     eligibility:
       rule:
-        kind: all
-        rules:
-          - criterion_id: cri_01
-            fact: company.age_months
-            kind: predicate
-            operator: lt
-            statement: The startup must be less than three years old.
-            value:
-              type: number
-              value: 36
-          - criterion_id: cri_02
-            fact: company.employee_count
-            kind: predicate
-            operator: lt
-            statement: The startup must have fewer than 15 employees.
-            value:
-              type: number
-              value: 15
-          - criterion_id: cri_03
-            fact: company.funding_raised_usd
-            kind: predicate
-            operator: lte
-            statement: The startup must have raised no more than USD 1 million.
-            value:
-              type: number
-              value: 1000000
+        criterion_id: cri_01
+        kind: manual
+        reason: external-verification
+        statement: Applicants must be early-stage startups less than three years old, with fewer than 15 employees and up to USD 1 million in funding.
     roles:
       terms_authority_entity_id: ent_bk3mzkpepw8ns7k4z21nf4h8fq
       access_operator_entity_id: ent_bk3mzkpepw8ns7k4z21nf4h8fq

--- a/entities/sw/swingvy.yaml
+++ b/entities/sw/swingvy.yaml
@@ -51,7 +51,6 @@ offers:
             kind: exact
       consideration:
         kind: variable
-        description: Swingvy offers monthly or yearly subscriptions, and pricing is based on the number of employees in your business.
     eligibility:
       rule:
         criterion_id: cri_01

--- a/entities/sw/swingvy.yaml
+++ b/entities/sw/swingvy.yaml
@@ -48,8 +48,7 @@ offers:
             basis_points: 5000
             kind: exact
       consideration:
-        kind: variable
-        description: "50% off Swingvy's all-in-one HR platform for one year."
+        kind: none
     eligibility:
       rule:
         criterion_id: cri_01

--- a/entities/sw/swingvy.yaml
+++ b/entities/sw/swingvy.yaml
@@ -51,6 +51,7 @@ offers:
             kind: exact
       consideration:
         kind: variable
+        description: You qualify for our startup programme pricing.
     eligibility:
       rule:
         criterion_id: cri_01

--- a/entities/sw/swingvy.yaml
+++ b/entities/sw/swingvy.yaml
@@ -48,7 +48,7 @@ offers:
             kind: exact
       consideration:
         kind: variable
-        description: The startup pays the remaining discounted price of its selected Swingvy plan.
+        description: Startup programme pricing.
     eligibility:
       rule:
         criterion_id: cri_01

--- a/entities/sw/swingvy.yaml
+++ b/entities/sw/swingvy.yaml
@@ -48,7 +48,7 @@ offers:
             basis_points: 5000
             kind: exact
       consideration:
-        kind: none
+        kind: variable
     eligibility:
       rule:
         criterion_id: cri_01

--- a/entities/sw/swingvy.yaml
+++ b/entities/sw/swingvy.yaml
@@ -17,8 +17,6 @@ profile:
 sources:
   - source_id: src_c63c7c4b4551b8323a4fe2316757731fce3dbb21957aea66e1278292304c6e8b
     url: https://www.swingvy.com/sg/startups
-  - source_id: src_35578c82dfec00c300cac11bc7405e5f831dca36df321b2bc8332302e87c73b3
-    url: https://www.swingvy.com/sg/pricing
 programs:
   - program_id: prg_tjwnd1zf7nk92np2cnk62fn6y5
     program_slug: swingvy-startup-program
@@ -50,8 +48,8 @@ offers:
             basis_points: 5000
             kind: exact
       consideration:
-        kind: variable
-        description: Pricing is based on the number of employees, with monthly or annual subscriptions.
+        kind: unknown
+        description: Startup programme pricing applies.
     eligibility:
       rule:
         criterion_id: cri_01
@@ -68,4 +66,3 @@ offers:
       url: https://secure.swingvy.com/
     source_ids:
       - src_c63c7c4b4551b8323a4fe2316757731fce3dbb21957aea66e1278292304c6e8b
-      - src_35578c82dfec00c300cac11bc7405e5f831dca36df321b2bc8332302e87c73b3

--- a/entities/sw/swingvy.yaml
+++ b/entities/sw/swingvy.yaml
@@ -49,6 +49,7 @@ offers:
             kind: exact
       consideration:
         kind: variable
+        description: 50% off Swingvy for one year
     eligibility:
       rule:
         criterion_id: cri_01

--- a/entities/sw/swingvy.yaml
+++ b/entities/sw/swingvy.yaml
@@ -48,8 +48,8 @@ offers:
             basis_points: 5000
             kind: exact
       consideration:
-        kind: variable
-        description: Approved startups use Swingvy's 50%-off startup programme pricing for one year.
+        kind: unknown
+        description: Swingvy publishes a 50% startup discount but not the resulting subscription price.
     eligibility:
       rule:
         kind: all

--- a/entities/sw/swingvy.yaml
+++ b/entities/sw/swingvy.yaml
@@ -10,6 +10,7 @@ entity:
       valid_from: 2026-09-01T07:47:50.213Z
   category: hr-people
 profile:
+  summary: All-in-one HR platform for payroll, benefits, leave, time, and people operations.
   description: Swingvy provides an integrated people-operations platform for employee records, leave, time and attendance, expense claims, payroll, benefits, insights, and mobile HR workflows.
   links:
     site: https://www.swingvy.com
@@ -48,7 +49,7 @@ offers:
             kind: exact
       consideration:
         kind: variable
-        description: The approved startup pays the remaining 50% of its Swingvy subscription price during the one-year offer period.
+        description: Approved startups use Swingvy's 50%-off startup programme pricing for one year.
     eligibility:
       rule:
         kind: all
@@ -85,6 +86,5 @@ offers:
       instructions: Use the Apply Now link on Swingvy's startup-program page and complete the Swingvy signup flow.
       method: form
       url: https://secure.swingvy.com/
-    terms_url: https://www.swingvy.com/sg/startups
     source_ids:
       - src_c63c7c4b4551b8323a4fe2316757731fce3dbb21957aea66e1278292304c6e8b

--- a/entities/sw/swingvy.yaml
+++ b/entities/sw/swingvy.yaml
@@ -17,6 +17,8 @@ profile:
 sources:
   - source_id: src_c63c7c4b4551b8323a4fe2316757731fce3dbb21957aea66e1278292304c6e8b
     url: https://www.swingvy.com/sg/startups
+  - source_id: src_35578c82dfec00c300cac11bc7405e5f831dca36df321b2bc8332302e87c73b3
+    url: https://www.swingvy.com/sg/pricing
 programs:
   - program_id: prg_tjwnd1zf7nk92np2cnk62fn6y5
     program_slug: swingvy-startup-program
@@ -25,6 +27,7 @@ programs:
     summary: Swingvy gives eligible early-stage startups 50% off its all-in-one HR platform for one year.
     source_ids:
       - src_c63c7c4b4551b8323a4fe2316757731fce3dbb21957aea66e1278292304c6e8b
+      - src_35578c82dfec00c300cac11bc7405e5f831dca36df321b2bc8332302e87c73b3
 offers:
   - offer_id: off_dtacg5473vdw13fs9qc5jf5qfy
     program_id: prg_tjwnd1zf7nk92np2cnk62fn6y5
@@ -65,3 +68,4 @@ offers:
       url: https://secure.swingvy.com/
     source_ids:
       - src_c63c7c4b4551b8323a4fe2316757731fce3dbb21957aea66e1278292304c6e8b
+      - src_35578c82dfec00c300cac11bc7405e5f831dca36df321b2bc8332302e87c73b3

--- a/entities/sw/swingvy.yaml
+++ b/entities/sw/swingvy.yaml
@@ -37,8 +37,7 @@ offers:
       effective_from: 2026-09-01T07:47:50.213Z
     economics:
       benefits:
-        - applies_to: Swingvy all-in-one HR platform
-          benefit_id: ben_01
+        - benefit_id: ben_01
           description: 50% off Swingvy for one year
           duration:
             kind: exact
@@ -48,8 +47,8 @@ offers:
             basis_points: 5000
             kind: exact
       consideration:
-        kind: unknown
-        description: Startup programme pricing applies.
+        kind: variable
+        description: The startup pays the remaining discounted price of its selected Swingvy plan.
     eligibility:
       rule:
         criterion_id: cri_01


### PR DESCRIPTION
## Summary

- add Swingvy as a new HR and people-operations vendor
- document its current Singapore startup program from its English first-party page
- capture the 50% one-year discount, age, employee and funding criteria, covered platform, and application route

## Source

- https://www.swingvy.com/sg/startups

## Verification

- exact pinned catalog verifier: `entities: 1, programs: 1, offers: 1`
- `git diff --check`
- DCO signed-off commit

Closes #1145