### PR TITLE
data: add CNCF startup program

### DIFF
--- a/entities/cl/cloud-native-computing-foundation.yaml
+++ b/entities/cl/cloud-native-computing-foundation.yaml
@@ -11,7 +11,7 @@ entity:
       valid_from: 2026-09-01T07:55:19.1659258Z
   category: other
 profile:
-  description: The Cloud Native Computing Foundation provides a vendor-neutral home for cloud-native open-source projects and supports the organizations and community building the cloud-native ecosystem.
+  description: CNCF offers a Silver Membership for Startups designed to connect and recognize small teams in the cloud-native ecosystem.
   links:
     site: https://www.cncf.io
 sources:
@@ -37,19 +37,18 @@ offers:
       effective_from: 2026-09-01T07:55:19.1659258Z
     economics:
       benefits:
-        - applies_to: KubeCon + CloudNativeCon booth pricing
-          benefit_id: ben_01
-          description: 50% off KubeCon + CloudNativeCon booth pricing
+        - benefit_id: ben_01
+          description: 50% off the KubeCon + CloudNativeCon booth price.
           kind: discount
           percentage:
             basis_points: 5000
             kind: exact
         - benefit_id: ben_02
-          description: Priority booth placement at KubeCon + CloudNativeCon
+          description: Priority placement with a Startup Sponsorship.
           kind: other
       consideration:
-        kind: variable
-        description: The approved startup pays the remaining sponsorship fee for its selected KubeCon + CloudNativeCon booth package.
+        kind: unknown
+        description: The public startup page does not publish the payable Startup Sponsorship booth price.
     eligibility:
       rule:
         kind: all

--- a/entities/cl/cloud-native-computing-foundation.yaml
+++ b/entities/cl/cloud-native-computing-foundation.yaml
@@ -1,0 +1,87 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_04vrv8cq2gm7qzv9ck62yyhe28
+  slug: cloud-native-computing-foundation
+  slug_aliases:
+    - cncf
+  name: Cloud Native Computing Foundation
+  domains:
+    - value: cncf.io
+      role: primary
+      valid_from: 2026-09-01T07:55:19.1659258Z
+  category: other
+profile:
+  description: The Cloud Native Computing Foundation provides a vendor-neutral home for cloud-native open-source projects and supports the organizations and community building the cloud-native ecosystem.
+  links:
+    site: https://www.cncf.io
+sources:
+  - source_id: src_465b2df23cc0822a2871b8fc552461d178be35cd52e4dea0bc9a3759c3d9f374
+    url: https://www.cncf.io/about/join/startups/
+programs:
+  - program_id: prg_2mya4df80mqpxd6nyc1ftpbps2
+    program_slug: cncf-startup-program
+    program_slug_aliases: []
+    title: CNCF Startup Program
+    summary: CNCF gives qualifying cloud-native startups discounted KubeCon + CloudNativeCon booth pricing and priority placement through its startup membership program.
+    source_ids:
+      - src_465b2df23cc0822a2871b8fc552461d178be35cd52e4dea0bc9a3759c3d9f374
+offers:
+  - offer_id: off_b7yd9p1ms23cy7jg6nkshv9h45
+    program_id: prg_2mya4df80mqpxd6nyc1ftpbps2
+    offer_slug: fifty-percent-off-kubecon-cloudnativecon-booth-pricing
+    offer_slug_aliases: []
+    title: 50% off KubeCon + CloudNativeCon booth pricing
+    summary: Qualifying startups with fewer than 50 employees receive 50% off KubeCon + CloudNativeCon booth pricing and priority placement through CNCF Startup Sponsorship.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-01T07:55:19.1659258Z
+    economics:
+      benefits:
+        - applies_to: KubeCon + CloudNativeCon booth pricing
+          benefit_id: ben_01
+          description: 50% off KubeCon + CloudNativeCon booth pricing
+          kind: discount
+          percentage:
+            basis_points: 5000
+            kind: exact
+        - benefit_id: ben_02
+          description: Priority booth placement at KubeCon + CloudNativeCon
+          kind: other
+      consideration:
+        kind: variable
+        description: The approved startup pays the remaining sponsorship fee for its selected KubeCon + CloudNativeCon booth package.
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.employee_count
+            kind: predicate
+            operator: lt
+            statement: The startup must have fewer than 50 employees.
+            value:
+              type: number
+              value: 50
+          - criterion_id: cri_02
+            kind: manual
+            reason: external-verification
+            statement: The company must be an early-stage startup focused on cloud-native technologies.
+          - criterion_id: cri_03
+            kind: manual
+            reason: external-verification
+            statement: The company must demonstrate a commitment to open source and community engagement.
+          - criterion_id: cri_04
+            kind: manual
+            reason: external-verification
+            statement: The company's product or service must align with CNCF's mission and ecosystem.
+    roles:
+      terms_authority_entity_id: ent_04vrv8cq2gm7qzv9ck62yyhe28
+      access_operator_entity_id: ent_04vrv8cq2gm7qzv9ck62yyhe28
+    access:
+      availability: membership
+      instructions: Apply for CNCF membership and select the Startup sponsorship tier. Contact CNCF through the startup-program page for help with eligibility or enrollment.
+      method: contact
+      url: https://www.cncf.io/about/join/startups/
+    terms_url: https://www.cncf.io/about/join/startups/
+    source_ids:
+      - src_465b2df23cc0822a2871b8fc552461d178be35cd52e4dea0bc9a3759c3d9f374

--- a/entities/cl/cloud-native-computing-foundation.yaml
+++ b/entities/cl/cloud-native-computing-foundation.yaml
@@ -11,6 +11,7 @@ entity:
       valid_from: 2026-09-01T07:55:19.1659258Z
   category: other
 profile:
+  summary: Cloud-native open-source foundation and ecosystem.
   description: CNCF offers a Silver Membership for Startups designed to connect and recognize small teams in the cloud-native ecosystem.
   links:
     site: https://www.cncf.io

--- a/entities/cl/cloud-native-computing-foundation.yaml
+++ b/entities/cl/cloud-native-computing-foundation.yaml
@@ -47,8 +47,8 @@ offers:
           description: Priority placement with a Startup Sponsorship.
           kind: other
       consideration:
-        kind: unknown
-        description: The public startup page does not publish the payable Startup Sponsorship booth price.
+        kind: variable
+        description: A Startup Sponsorship is required to receive the booth-price discount and priority placement.
     eligibility:
       rule:
         kind: all


### PR DESCRIPTION
## Summary

- add the Cloud Native Computing Foundation as a catalog entity
- add the current CNCF Startup Program
- model its 50% KubeCon + CloudNativeCon booth discount and priority placement from CNCF's first-party startup-program page

## Verification

- pinned Sourcey catalog verifier: `entities: 1`, `programs: 1`, `offers: 1`
- DCO sign-off included

Closes #1147