### PR TITLE
data: add DMARCwise startup pricing

### DIFF
--- a/entities/dm/dmarcwise.yaml
+++ b/entities/dm/dmarcwise.yaml
@@ -1,0 +1,87 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_ptw8rwmpw3hz8rbh3zp15cnav6
+  slug: dmarcwise
+  slug_aliases: []
+  name: DMARCwise
+  domains:
+    - value: dmarcwise.io
+      role: primary
+      valid_from: 2026-09-01T08:18:14.1911726Z
+  category: auth-security
+profile:
+  summary: DMARC reporting, monitoring, and email-domain authentication platform.
+  description: DMARCwise provides DMARC reporting and monitoring, domain validation, SPF and DKIM monitoring, SMTP TLS reporting, hosted DMARC and MTA-STS services, diagnostics, and DNS history.
+  links:
+    site: https://dmarcwise.io
+sources:
+  - source_id: src_894484940803e197b2a6a9eb0d90bfe03cc36f01b12772efd3927360524ce255
+    url: https://dmarcwise.io/pricing
+programs:
+  - program_id: prg_tktk0xm0es428cx1916nwsbn0z
+    program_slug: dmarcwise-startup-pricing
+    program_slug_aliases: []
+    title: DMARCwise Startup Pricing
+    summary: DMARCwise gives eligible startups 50% off any paid plan for their first 12 months.
+    source_ids:
+      - src_894484940803e197b2a6a9eb0d90bfe03cc36f01b12772efd3927360524ce255
+offers:
+  - offer_id: off_v22v3ns105dxbjfbzvz2p608r2
+    program_id: prg_tktk0xm0es428cx1916nwsbn0z
+    offer_slug: fifty-percent-off-any-paid-plan-for-twelve-months
+    offer_slug_aliases: []
+    title: 50% off any DMARCwise paid plan for 12 months
+    summary: Startups less than five years old, with fewer than 25 employees and no more than EUR 5 million raised, receive 50% off any paid plan for their first 12 months.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-01T08:18:14.1911726Z
+    economics:
+      benefits:
+        - applies_to: Any DMARCwise paid plan
+          benefit_id: ben_01
+          description: 50% off any DMARCwise paid plan for the first 12 months
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            basis_points: 5000
+            kind: exact
+      consideration:
+        kind: variable
+        description: The approved startup pays the remaining 50% of its selected DMARCwise paid plan during the offer period.
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: The company must be less than five years old.
+            value:
+              type: number
+              value: 60
+          - criterion_id: cri_02
+            fact: company.employee_count
+            kind: predicate
+            operator: lt
+            statement: The company must have fewer than 25 employees.
+            value:
+              type: number
+              value: 25
+          - criterion_id: cri_03
+            kind: manual
+            reason: external-verification
+            statement: The company must have raised no more than EUR 5 million.
+    roles:
+      terms_authority_entity_id: ent_ptw8rwmpw3hz8rbh3zp15cnav6
+      access_operator_entity_id: ent_ptw8rwmpw3hz8rbh3zp15cnav6
+    access:
+      availability: public
+      instructions: Contact DMARCwise before subscribing and request startup pricing.
+      method: contact
+      url: https://dmarcwise.io/contact
+    terms_url: https://dmarcwise.io/pricing
+    source_ids:
+      - src_894484940803e197b2a6a9eb0d90bfe03cc36f01b12772efd3927360524ce255

--- a/entities/dm/dmarcwise.yaml
+++ b/entities/dm/dmarcwise.yaml
@@ -38,7 +38,7 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: 50% off any DMARCwise paid plan for 12 months
+          description: Eligible startups can receive a 50% discount on any paid plan for their first 12 months.
           duration:
             kind: exact
             value: P1Y
@@ -48,7 +48,7 @@ offers:
             kind: exact
       consideration:
         kind: variable
-        description: 50% off any DMARCwise paid plan for 12 months
+        description: The discount applies to any paid plan.
     eligibility:
       rule:
         kind: all

--- a/entities/dm/dmarcwise.yaml
+++ b/entities/dm/dmarcwise.yaml
@@ -48,7 +48,7 @@ offers:
             kind: exact
       consideration:
         kind: variable
-        description: The discount applies to any paid plan.
+        description: Eligible startups can receive a 50% discount on any paid plan for their first 12 months.
     eligibility:
       rule:
         kind: all

--- a/entities/dm/dmarcwise.yaml
+++ b/entities/dm/dmarcwise.yaml
@@ -49,7 +49,6 @@ offers:
             kind: exact
       consideration:
         kind: variable
-        description: The approved startup pays the remaining 50% of its selected DMARCwise paid plan during the offer period.
     eligibility:
       rule:
         kind: all

--- a/entities/dm/dmarcwise.yaml
+++ b/entities/dm/dmarcwise.yaml
@@ -37,9 +37,8 @@ offers:
       effective_from: 2026-09-01T08:18:14.1911726Z
     economics:
       benefits:
-        - applies_to: Any DMARCwise paid plan
-          benefit_id: ben_01
-          description: 50% off any DMARCwise paid plan for the first 12 months
+        - benefit_id: ben_01
+          description: A 50% discount for 12 months.
           duration:
             kind: exact
             value: P1Y
@@ -48,8 +47,8 @@ offers:
             basis_points: 5000
             kind: exact
       consideration:
-        kind: unknown
-        description: The cited source does not establish separate consideration beyond the offer terms.
+        kind: variable
+        description: A paid plan is discounted by 50% during the offer period.
     eligibility:
       rule:
         kind: all

--- a/entities/dm/dmarcwise.yaml
+++ b/entities/dm/dmarcwise.yaml
@@ -48,7 +48,8 @@ offers:
             basis_points: 5000
             kind: exact
       consideration:
-        kind: variable
+        kind: unknown
+        description: The cited source does not establish separate consideration beyond the offer terms.
     eligibility:
       rule:
         kind: all

--- a/entities/dm/dmarcwise.yaml
+++ b/entities/dm/dmarcwise.yaml
@@ -38,7 +38,7 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: A 50% discount for 12 months.
+          description: 50% off any DMARCwise paid plan for 12 months
           duration:
             kind: exact
             value: P1Y
@@ -48,7 +48,7 @@ offers:
             kind: exact
       consideration:
         kind: variable
-        description: A paid plan is discounted by 50% during the offer period.
+        description: 50% off any DMARCwise paid plan for 12 months
     eligibility:
       rule:
         kind: all


### PR DESCRIPTION
## Summary

- add DMARCwise as a catalog entity
- add the current DMARCwise Startup Pricing offer
- model its 50% first-12-month discount and current age, team-size, and funding gates from DMARCwise's first-party pricing page

## Verification

- pinned Sourcey catalog verifier: `entities: 1`, `programs: 1`, `offers: 1`
- DCO sign-off included

Closes #1157