### PR TITLE
data: add JigSpace startup pricing

### DIFF
--- a/entities/ji/jigspace.yaml
+++ b/entities/ji/jigspace.yaml
@@ -37,9 +37,8 @@ offers:
       effective_from: 2026-09-01T08:22:22.7278543Z
     economics:
       benefits:
-        - applies_to: JigSpace plans
-          benefit_id: ben_01
-          description: 50% off JigSpace plans for 12 months
+        - benefit_id: ben_01
+          description: 50% off plans for 12 months
           duration:
             kind: exact
             value: P1Y
@@ -48,20 +47,19 @@ offers:
             basis_points: 5000
             kind: exact
       consideration:
-        kind: variable
-        description: The approved startup pays the remaining 50% of its selected JigSpace plan during the offer period.
+        kind: unknown
+        description: The published page specifies the discount but does not state the startup's resulting price.
     eligibility:
       rule:
         criterion_id: cri_01
         kind: manual
         reason: vendor-discretion
-        statement: The applicant must be an eligible startup and receive approval through the JigSpace Startup Program application.
+        statement: The applicant must be an eligible startup.
     roles:
       terms_authority_entity_id: ent_dtrhynzdc01tjj9fq7eg2m39n0
       access_operator_entity_id: ent_dtrhynzdc01tjj9fq7eg2m39n0
     access:
       availability: public
-      instructions: Complete the JigSpace Startup Program Application linked from the investor-pitch page.
       method: form
       url: https://jigspace.typeform.com/startup-offer
     terms_url: https://www.jig.com/use-cases/investor-pitches

--- a/entities/ji/jigspace.yaml
+++ b/entities/ji/jigspace.yaml
@@ -1,0 +1,69 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_dtrhynzdc01tjj9fq7eg2m39n0
+  slug: jigspace
+  slug_aliases: []
+  name: JigSpace
+  domains:
+    - value: jig.com
+      role: primary
+      valid_from: 2026-09-01T08:22:22.7278543Z
+  category: design
+profile:
+  summary: Interactive 3D and augmented-reality presentation platform.
+  description: JigSpace lets teams create interactive 3D and augmented-reality presentations from CAD and other 3D files, add animations and guided steps, and share presentations across mobile, desktop, and spatial-computing devices.
+  links:
+    site: https://www.jig.com
+sources:
+  - source_id: src_845ef46f653563fd9e4bb5c4ba2bf6f03e80b1539969906f66b3d0fe17b49259
+    url: https://www.jig.com/use-cases/investor-pitches
+programs:
+  - program_id: prg_9pkbha26g36a7jfhne5tfxqerf
+    program_slug: jigspace-startup-pricing
+    program_slug_aliases: []
+    title: JigSpace Startup Pricing
+    summary: JigSpace gives eligible startups 50% off its plans for 12 months.
+    source_ids:
+      - src_845ef46f653563fd9e4bb5c4ba2bf6f03e80b1539969906f66b3d0fe17b49259
+offers:
+  - offer_id: off_nm2v1xh9ga6b9h9azcqpvvnahv
+    program_id: prg_9pkbha26g36a7jfhne5tfxqerf
+    offer_slug: fifty-percent-off-plans-for-twelve-months
+    offer_slug_aliases: []
+    title: 50% off JigSpace plans for 12 months
+    summary: Approved eligible startups receive 50% off JigSpace plans for 12 months.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-01T08:22:22.7278543Z
+    economics:
+      benefits:
+        - applies_to: JigSpace plans
+          benefit_id: ben_01
+          description: 50% off JigSpace plans for 12 months
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            basis_points: 5000
+            kind: exact
+      consideration:
+        kind: variable
+        description: The approved startup pays the remaining 50% of its selected JigSpace plan during the offer period.
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: vendor-discretion
+        statement: The applicant must be an eligible startup and receive approval through the JigSpace Startup Program application.
+    roles:
+      terms_authority_entity_id: ent_dtrhynzdc01tjj9fq7eg2m39n0
+      access_operator_entity_id: ent_dtrhynzdc01tjj9fq7eg2m39n0
+    access:
+      availability: public
+      instructions: Complete the JigSpace Startup Program Application linked from the investor-pitch page.
+      method: form
+      url: https://jigspace.typeform.com/startup-offer
+    terms_url: https://www.jig.com/use-cases/investor-pitches
+    source_ids:
+      - src_845ef46f653563fd9e4bb5c4ba2bf6f03e80b1539969906f66b3d0fe17b49259

--- a/entities/ji/jigspace.yaml
+++ b/entities/ji/jigspace.yaml
@@ -48,6 +48,7 @@ offers:
             kind: exact
       consideration:
         kind: unknown
+        description: 50% off plans for 12 months
     eligibility:
       rule:
         criterion_id: cri_01

--- a/entities/ji/jigspace.yaml
+++ b/entities/ji/jigspace.yaml
@@ -48,7 +48,6 @@ offers:
             kind: exact
       consideration:
         kind: unknown
-        description: The published page specifies the discount but does not state the startup's resulting price.
     eligibility:
       rule:
         criterion_id: cri_01


### PR DESCRIPTION
## Summary

- add JigSpace as a catalog entity
- add the current JigSpace Startup Pricing offer
- model its 50% 12-month discount and direct eligibility application from JigSpace's first-party investor-pitch page

## Verification

- pinned Sourcey catalog verifier: `entities: 1`, `programs: 1`, `offers: 1`
- DCO sign-off included

Closes #1159