### PR TITLE
data: add Denvr AI Ascend program

### DIFF
--- a/entities/de/denvr.yaml
+++ b/entities/de/denvr.yaml
@@ -28,10 +28,10 @@ programs:
 offers:
   - offer_id: off_xhtwqp34z0adstgb4jybddwfqx
     program_id: prg_2npvvcyhws75xzmkfmfdjb9ssm
-    offer_slug: initial-one-thousand-dollar-credit
+    offer_slug: ai-ascend-compute-credits
     offer_slug_aliases: []
-    title: USD 1,000 in initial Denvr AI Compute credits
-    summary: Approved early-stage AI startups, research teams, AI-driven enterprises, and other qualified AI builders receive an initial USD 1,000 in Denvr AI Compute credits.
+    title: USD 1,000 initial credit and up to USD 500,000 in Denvr production credits
+    summary: Approved AI builders receive an initial USD 1,000 in Denvr AI Compute credits and may receive up to USD 500,000 in production credits based on needs and potential.
     lifecycle:
       status: active
       effective_from: 2026-09-01T08:40:32.9428776Z
@@ -45,6 +45,14 @@ offers:
               currency: USD
               minor_units: 100000
             kind: exact
+        - benefit_id: ben_02
+          description: Up to USD 500,000 in production credits based on the approved team's needs and potential
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 50000000
+            kind: up-to
       consideration:
         kind: none
     eligibility:
@@ -65,50 +73,6 @@ offers:
     access:
       availability: public
       instructions: Complete and submit the Denvr AI Ascend application form. Denvr evaluates the project's AI focus and resource requirements before onboarding approved applicants.
-      method: form
-      url: https://www.denvr.com/ai-ascend
-    terms_url: https://www.denvr.com/ai-ascend
-    source_ids:
-      - src_2018463513f271e5a693efb8d69aeb50658ce9a4f17031fbc70efe61a790fc3d
-  - offer_id: off_sypx827dn1gmjj1cgek6wtxbb0
-    program_id: prg_2npvvcyhws75xzmkfmfdjb9ssm
-    offer_slug: up-to-five-hundred-thousand-production-credits
-    offer_slug_aliases: []
-    title: Up to USD 500,000 in Denvr production credits
-    summary: Eligible AI Ascend teams can receive up to USD 500,000 in Denvr AI Compute production credits based on their needs and potential.
-    lifecycle:
-      status: active
-      effective_from: 2026-09-01T08:40:32.9428776Z
-    economics:
-      benefits:
-        - benefit_id: ben_01
-          description: Up to USD 500,000 in production credits based on the approved team's needs and potential
-          kind: credit
-          value:
-            amount:
-              currency: USD
-              minor_units: 50000000
-            kind: up-to
-      consideration:
-        kind: none
-    eligibility:
-      rule:
-        kind: all
-        rules:
-          - criterion_id: cri_01
-            kind: manual
-            reason: vendor-discretion
-            statement: The applicant must be an approved Denvr AI Ascend team building or scaling AI workloads.
-          - criterion_id: cri_02
-            kind: manual
-            reason: vendor-discretion
-            statement: Denvr determines the production-credit amount based on the team's needs and potential.
-    roles:
-      terms_authority_entity_id: ent_0mxg2tn5q2cvz2dnr0z73jvxyw
-      access_operator_entity_id: ent_0mxg2tn5q2cvz2dnr0z73jvxyw
-    access:
-      availability: public
-      instructions: Apply through the Denvr AI Ascend form and describe the applicant's AI project and expected resource requirements for Denvr's review.
       method: form
       url: https://www.denvr.com/ai-ascend
     terms_url: https://www.denvr.com/ai-ascend

--- a/entities/de/denvr.yaml
+++ b/entities/de/denvr.yaml
@@ -11,7 +11,7 @@ entity:
   category: ai-ml
 profile:
   summary: AI cloud compute, inference, storage, and private infrastructure services.
-  description: Denvr provides GPU compute, AI inference, data systems, clusters, preconfigured machine-learning environments, APIs, and private AI infrastructure from sovereign data centers in Canada and the United States.
+  description: Denvr provides high-performance AI compute, inference, private AI infrastructure, flexible deployment, and expert support.
   links:
     site: https://www.denvr.com
 sources:
@@ -57,16 +57,10 @@ offers:
         kind: none
     eligibility:
       rule:
-        kind: all
-        rules:
-          - criterion_id: cri_01
-            kind: manual
-            reason: vendor-discretion
-            statement: The applicant must be an early-stage AI startup, a research and development team running real-world AI workloads, an AI-driven enterprise, or another qualified team building and scaling AI applications.
-          - criterion_id: cri_02
-            kind: manual
-            reason: vendor-discretion
-            statement: Denvr must approve the project based on alignment with program goals, including AI development focus and resource requirements.
+        criterion_id: cri_01
+        kind: manual
+        reason: vendor-discretion
+        statement: Denvr reviews early-stage AI startups, research and development teams running real-world AI workloads, AI-driven enterprises, and other qualified teams building and scaling AI applications for alignment with AI-development focus and resource requirements.
     roles:
       terms_authority_entity_id: ent_0mxg2tn5q2cvz2dnr0z73jvxyw
       access_operator_entity_id: ent_0mxg2tn5q2cvz2dnr0z73jvxyw

--- a/entities/de/denvr.yaml
+++ b/entities/de/denvr.yaml
@@ -30,7 +30,7 @@ offers:
     program_id: prg_2npvvcyhws75xzmkfmfdjb9ssm
     offer_slug: ai-ascend-compute-credits
     offer_slug_aliases: []
-    title: USD 1,000 initial credit and up to USD 500,000 in Denvr production credits
+    title: Credits to Help You Start & Scale
     summary: Approved AI builders receive an initial USD 1,000 in Denvr AI Compute credits and may receive up to USD 500,000 in production credits based on needs and potential.
     lifecycle:
       status: active
@@ -38,21 +38,11 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: USD 1,000 in initial startup credits for Denvr AI Compute Services
+          description: Kick-off with initial $1,000 of start-up credits for Denvr AI Compute Services.
           kind: credit
-          value:
-            amount:
-              currency: USD
-              minor_units: 100000
-            kind: exact
         - benefit_id: ben_02
-          description: Up to USD 500,000 in production credits based on the approved team's needs and potential
+          description: Eligible teams can receive up to $500,000 in production credits based on needs and potential.
           kind: credit
-          value:
-            amount:
-              currency: USD
-              minor_units: 50000000
-            kind: up-to
       consideration:
         kind: none
     eligibility:

--- a/entities/de/denvr.yaml
+++ b/entities/de/denvr.yaml
@@ -1,0 +1,116 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_0mxg2tn5q2cvz2dnr0z73jvxyw
+  slug: denvr
+  slug_aliases: []
+  name: Denvr
+  domains:
+    - value: denvr.com
+      role: primary
+      valid_from: 2026-09-01T08:40:32.9428776Z
+  category: ai-ml
+profile:
+  summary: AI cloud compute, inference, storage, and private infrastructure services.
+  description: Denvr provides GPU compute, AI inference, data systems, clusters, preconfigured machine-learning environments, APIs, and private AI infrastructure from sovereign data centers in Canada and the United States.
+  links:
+    site: https://www.denvr.com
+sources:
+  - source_id: src_2018463513f271e5a693efb8d69aeb50658ce9a4f17031fbc70efe61a790fc3d
+    url: https://www.denvr.com/ai-ascend
+programs:
+  - program_id: prg_2npvvcyhws75xzmkfmfdjb9ssm
+    program_slug: denvr-ai-ascend
+    program_slug_aliases: []
+    title: Denvr AI Ascend
+    summary: Approved AI builders start with USD 1,000 in Denvr AI Compute credits, while eligible teams can receive up to USD 500,000 in production credits based on needs and potential.
+    source_ids:
+      - src_2018463513f271e5a693efb8d69aeb50658ce9a4f17031fbc70efe61a790fc3d
+offers:
+  - offer_id: off_xhtwqp34z0adstgb4jybddwfqx
+    program_id: prg_2npvvcyhws75xzmkfmfdjb9ssm
+    offer_slug: initial-one-thousand-dollar-credit
+    offer_slug_aliases: []
+    title: USD 1,000 in initial Denvr AI Compute credits
+    summary: Approved early-stage AI startups, research teams, AI-driven enterprises, and other qualified AI builders receive an initial USD 1,000 in Denvr AI Compute credits.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-01T08:40:32.9428776Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: USD 1,000 in initial startup credits for Denvr AI Compute Services
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 100000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: vendor-discretion
+            statement: The applicant must be an early-stage AI startup, a research and development team running real-world AI workloads, an AI-driven enterprise, or another qualified team building and scaling AI applications.
+          - criterion_id: cri_02
+            kind: manual
+            reason: vendor-discretion
+            statement: Denvr must approve the project based on alignment with program goals, including AI development focus and resource requirements.
+    roles:
+      terms_authority_entity_id: ent_0mxg2tn5q2cvz2dnr0z73jvxyw
+      access_operator_entity_id: ent_0mxg2tn5q2cvz2dnr0z73jvxyw
+    access:
+      availability: public
+      instructions: Complete and submit the Denvr AI Ascend application form. Denvr evaluates the project's AI focus and resource requirements before onboarding approved applicants.
+      method: form
+      url: https://www.denvr.com/ai-ascend
+    terms_url: https://www.denvr.com/ai-ascend
+    source_ids:
+      - src_2018463513f271e5a693efb8d69aeb50658ce9a4f17031fbc70efe61a790fc3d
+  - offer_id: off_sypx827dn1gmjj1cgek6wtxbb0
+    program_id: prg_2npvvcyhws75xzmkfmfdjb9ssm
+    offer_slug: up-to-five-hundred-thousand-production-credits
+    offer_slug_aliases: []
+    title: Up to USD 500,000 in Denvr production credits
+    summary: Eligible AI Ascend teams can receive up to USD 500,000 in Denvr AI Compute production credits based on their needs and potential.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-01T08:40:32.9428776Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to USD 500,000 in production credits based on the approved team's needs and potential
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 50000000
+            kind: up-to
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: vendor-discretion
+            statement: The applicant must be an approved Denvr AI Ascend team building or scaling AI workloads.
+          - criterion_id: cri_02
+            kind: manual
+            reason: vendor-discretion
+            statement: Denvr determines the production-credit amount based on the team's needs and potential.
+    roles:
+      terms_authority_entity_id: ent_0mxg2tn5q2cvz2dnr0z73jvxyw
+      access_operator_entity_id: ent_0mxg2tn5q2cvz2dnr0z73jvxyw
+    access:
+      availability: public
+      instructions: Apply through the Denvr AI Ascend form and describe the applicant's AI project and expected resource requirements for Denvr's review.
+      method: form
+      url: https://www.denvr.com/ai-ascend
+    terms_url: https://www.denvr.com/ai-ascend
+    source_ids:
+      - src_2018463513f271e5a693efb8d69aeb50658ce9a4f17031fbc70efe61a790fc3d

--- a/entities/de/denvr.yaml
+++ b/entities/de/denvr.yaml
@@ -40,9 +40,19 @@ offers:
         - benefit_id: ben_01
           description: Kick-off with initial $1,000 of start-up credits for Denvr AI Compute Services.
           kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 100000
+            kind: exact
         - benefit_id: ben_02
           description: Eligible teams can receive up to $500,000 in production credits based on needs and potential.
           kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 50000000
+            kind: up-to
       consideration:
         kind: none
     eligibility:


### PR DESCRIPTION
## Summary
- add Denvr and the current Denvr AI Ascend program
- model the published USD 1,000 initial AI Compute credit separately from the discretionary production-credit ceiling
- preserve the up-to USD 500,000 scale benefit and Denvr's project-fit and resource-needs review

## Source
- https://www.denvr.com/ai-ascend

## Verification
- pinned public Sourcey verifier passed: 1 entity, 1 program, 2 offers
- commit includes DCO sign-off

Closes #1165