### PR TITLE
data: add Transloadit accelerator startup credits

### DIFF
--- a/entities/tr/transloadit.yaml
+++ b/entities/tr/transloadit.yaml
@@ -1,0 +1,73 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_960vbjxjveh59m31dceczj95ex
+  slug: transloadit
+  slug_aliases: []
+  name: Transloadit
+  domains:
+    - value: transloadit.com
+      role: primary
+      valid_from: 2026-09-01T09:12:44.086Z
+  category: apis-integration
+profile:
+  description: Transloadit provides APIs for uploading, encoding, and processing images, video, audio,
+    and documents.
+  links:
+    site: https://transloadit.com
+sources:
+  - source_id: src_683d370916e5e4408c41d0c20a8086f4b62e8e1be01d2a0572cba71d2409ed60
+    url: https://transloadit.com/blog/2020/02/accelerator-partnerships-first/
+programs:
+  - program_id: prg_vwrc81ft5eshjjgz93vtse5c15
+    program_slug: accelerator-startup-program
+    program_slug_aliases: []
+    title: Transloadit Accelerator Startup Program
+    summary: Transloadit supports founders and alumni of its partner accelerators and incubators with
+      file-processing credits for one year.
+    source_ids:
+      - src_683d370916e5e4408c41d0c20a8086f4b62e8e1be01d2a0572cba71d2409ed60
+offers:
+  - offer_id: off_bev9mcxh1kr4wc6sn66bf4vfjq
+    program_id: prg_vwrc81ft5eshjjgz93vtse5c15
+    offer_slug: up-to-two-thousand-dollars-for-one-year
+    offer_slug_aliases: []
+    title: Up to $2,000 in Transloadit Credits for One Year
+    summary: Current founders and alumni of Transloadit's partner accelerators and incubators can receive
+      up to $2,000 in Transloadit credits valid for one year.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-01T09:12:44.086Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $2,000 in Transloadit file-processing credits valid for one year
+          duration:
+            kind: exact
+            value: P1Y
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 200000
+            kind: up-to
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: external-verification
+        statement: The applicant must be a current founder or alumnus of one of Transloadit's partner
+          accelerators or incubators.
+    roles:
+      terms_authority_entity_id: ent_960vbjxjveh59m31dceczj95ex
+      access_operator_entity_id: ent_960vbjxjveh59m31dceczj95ex
+    access:
+      availability: membership
+      method: contact
+      url: https://transloadit.com/blog/2020/02/accelerator-partnerships-first/
+      instructions: Contact Transloadit from the company account through the program page and identify
+        the qualifying accelerator or incubator affiliation.
+    terms_url: https://transloadit.com/blog/2020/02/accelerator-partnerships-first/
+    source_ids:
+      - src_683d370916e5e4408c41d0c20a8086f4b62e8e1be01d2a0572cba71d2409ed60

--- a/entities/tr/transloadit.yaml
+++ b/entities/tr/transloadit.yaml
@@ -41,7 +41,7 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: Partner portfolio founders can receive up to $2000 in Transloadit credit for their file processing needs.
+          description: $2000 in credits to startup founders in partnered accelerators.
           duration:
             kind: exact
             value: P1Y

--- a/entities/tr/transloadit.yaml
+++ b/entities/tr/transloadit.yaml
@@ -10,6 +10,7 @@ entity:
       valid_from: 2026-09-01T09:12:44.086Z
   category: apis-integration
 profile:
+  summary: APIs for uploading, encoding, and processing images, video, audio, and documents.
   description: Transloadit provides APIs for uploading, encoding, and processing images, video, audio,
     and documents.
   links:
@@ -40,7 +41,6 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: Up to $2,000 in Transloadit file-processing credits valid for one year
           duration:
             kind: exact
             value: P1Y

--- a/entities/tr/transloadit.yaml
+++ b/entities/tr/transloadit.yaml
@@ -41,6 +41,7 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
+          description: Current partner-accelerator founders and alumni can receive Transloadit credits.
           duration:
             kind: exact
             value: P1Y

--- a/entities/tr/transloadit.yaml
+++ b/entities/tr/transloadit.yaml
@@ -67,7 +67,7 @@ offers:
       availability: membership
       method: contact
       url: https://transloadit.com/blog/2020/02/accelerator-partnerships-first/
-      instructions: Current founders or alumni of partner accelerators contact perks@transloadit.com.
+      instructions: Current founders or alumni of partner accelerators should use the contact method published on the vendor page.
     terms_url: https://transloadit.com/blog/2020/02/accelerator-partnerships-first/
     source_ids:
       - src_683d370916e5e4408c41d0c20a8086f4b62e8e1be01d2a0572cba71d2409ed60

--- a/entities/tr/transloadit.yaml
+++ b/entities/tr/transloadit.yaml
@@ -41,7 +41,7 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: For an entire year, our partner’s portfolio founders can receive up to $2000 in Transloadit credit for their file processing needs.
+          description: Up to $2000 in Transloadit credit.
           duration:
             kind: exact
             value: P1Y

--- a/entities/tr/transloadit.yaml
+++ b/entities/tr/transloadit.yaml
@@ -41,7 +41,7 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: Up to $2000 in Transloadit credit.
+          description: Partner portfolio founders can receive up to $2000 in Transloadit credit for their file processing needs.
           duration:
             kind: exact
             value: P1Y

--- a/entities/tr/transloadit.yaml
+++ b/entities/tr/transloadit.yaml
@@ -41,7 +41,7 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: For an entire year, our partner's portfolio founders can receive up to $2000 in Transloadit credit for their file processing needs.
+          description: Partner accelerator portfolio founders can receive up to $2,000 in Transloadit credit for one year.
           duration:
             kind: exact
             value: P1Y

--- a/entities/tr/transloadit.yaml
+++ b/entities/tr/transloadit.yaml
@@ -41,7 +41,7 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: For an entire year, partner accelerator portfolio founders can receive up to $2000 in Transloadit credit for their file processing needs.
+          description: For an entire year, our partner’s portfolio founders can receive up to $2000 in Transloadit credit for their file processing needs.
           duration:
             kind: exact
             value: P1Y

--- a/entities/tr/transloadit.yaml
+++ b/entities/tr/transloadit.yaml
@@ -41,7 +41,7 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: $2000 in credits to startup founders in partnered accelerators.
+          description: For an entire year, our partner's portfolio founders can receive up to $2000 in Transloadit credit for their file processing needs.
           duration:
             kind: exact
             value: P1Y

--- a/entities/tr/transloadit.yaml
+++ b/entities/tr/transloadit.yaml
@@ -41,7 +41,7 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: Partner accelerator portfolio founders can receive up to $2,000 in Transloadit credit for one year.
+          description: For an entire year, partner accelerator portfolio founders can receive up to $2000 in Transloadit credit for their file processing needs.
           duration:
             kind: exact
             value: P1Y

--- a/entities/tr/transloadit.yaml
+++ b/entities/tr/transloadit.yaml
@@ -41,7 +41,7 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: For an entire year, partner portfolio founders can receive up to $2000 in Transloadit credit for their file processing needs.
+          description: For an entire year, our partner’s portfolio founders can receive up to $2000 in Transloadit credit for their file processing needs.
           duration:
             kind: exact
             value: P1Y

--- a/entities/tr/transloadit.yaml
+++ b/entities/tr/transloadit.yaml
@@ -41,7 +41,7 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: Current partner-accelerator founders and alumni can receive Transloadit credits.
+          description: For an entire year, partner portfolio founders can receive up to $2000 in Transloadit credit for their file processing needs.
           duration:
             kind: exact
             value: P1Y
@@ -67,8 +67,7 @@ offers:
       availability: membership
       method: contact
       url: https://transloadit.com/blog/2020/02/accelerator-partnerships-first/
-      instructions: Contact Transloadit from the company account through the program page and identify
-        the qualifying accelerator or incubator affiliation.
+      instructions: Current founders or alumni of partner accelerators contact perks@transloadit.com.
     terms_url: https://transloadit.com/blog/2020/02/accelerator-partnerships-first/
     source_ids:
       - src_683d370916e5e4408c41d0c20a8086f4b62e8e1be01d2a0572cba71d2409ed60

--- a/entities/tr/transloadit.yaml
+++ b/entities/tr/transloadit.yaml
@@ -10,7 +10,7 @@ entity:
       valid_from: 2026-09-01T09:12:44.086Z
   category: apis-integration
 profile:
-  summary: APIs for uploading, encoding, and processing images, video, audio, and documents.
+  summary: "APIs for uploading, encoding, and processing images, video, audio, and documents."
   description: Transloadit provides APIs for uploading, encoding, and processing images, video, audio,
     and documents.
   links:


### PR DESCRIPTION
## Summary
- add Transloadit as an API and integration provider
- add the current accelerator startup program for founders and alumni of partner accelerators and incubators
- model the published one-year, up-to-$2,000 Transloadit credit from the vendor's first-party terms

## Evidence
- first-party program page: https://transloadit.com/blog/2020/02/accelerator-partnerships-first/
- tracking issue: #1173

## Verification
- pinned `@sourcey/catalog-verifier` passed for exactly 1 entity, 1 program, and 1 offer
- commit includes DCO sign-off