### PR TITLE
data: add CrateDB Startup Pack

### DIFF
--- a/entities/cr/cratedb.yaml
+++ b/entities/cr/cratedb.yaml
@@ -1,0 +1,76 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_a78bd21pnxya0djgn5t98c39zs
+  slug: cratedb
+  slug_aliases: []
+  name: CrateDB
+  domains:
+    - value: cratedb.com
+      role: primary
+      valid_from: 2026-09-01T09:30:47.439Z
+  category: databases
+profile:
+  summary: Distributed SQL database for real-time analytics.
+  description: CrateDB provides a distributed SQL database for real-time analytics across relational,
+    time-series, geospatial, full-text, and vector data.
+  links:
+    site: https://cratedb.com
+sources:
+  - source_id: src_d267c407ebe8b02462c66dc625810882c1d58d3dc31b185f0927fbfe4b949691
+    url: https://cratedb.com/
+  - source_id: src_d23ecce237ddccb20a3fa2b714f15afd287826009005ce020c23b808345b776b
+    url: https://cratedb.com/pricing/startups
+programs:
+  - program_id: prg_w0p9dx50e23t8egk8nzmak22gf
+    program_slug: startup-pack
+    program_slug_aliases: []
+    title: CrateDB Startup Pack
+    summary: CrateDB's Startup Pack provides CrateDB Cloud credits and professional services from its data engineering team, including setup, support, and ramp-up assistance.
+    source_ids:
+      - src_d23ecce237ddccb20a3fa2b714f15afd287826009005ce020c23b808345b776b
+offers:
+  - offer_id: off_dyjrxc1zkkhenqa5etedccgysc
+    program_id: prg_w0p9dx50e23t8egk8nzmak22gf
+    offer_slug: cloud-credits-and-data-engineering-services
+    offer_slug_aliases: []
+    title: CrateDB Startup Pack
+    summary: The Startup Pack includes a vendor-determined number of CrateDB Cloud credits plus setup, support, and ramp-up services from CrateDB's data engineering team.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-01T09:30:47.439Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: A specific number of credits for the CrateDB cloud service
+          kind: other
+        - benefit_id: ben_02
+          description: 3 hours of consulting to address use cases, architecture, imports and other miscellaneous topics.
+          kind: other
+        - benefit_id: ben_03
+          description: Technical audit to ensure a future proof and scalable solution.
+          kind: other
+        - benefit_id: ben_04
+          description: Monthly meetings and a full review meeting after 10 months of operation.
+          kind: other
+      consideration:
+        kind: unknown
+        description: The public Startup Pack page does not establish separate consideration.
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: constant
+        statement: The CrateDB Startup Pack is available to startup applicants through the program page.
+        value: true
+    roles:
+      terms_authority_entity_id: ent_a78bd21pnxya0djgn5t98c39zs
+      access_operator_entity_id: ent_a78bd21pnxya0djgn5t98c39zs
+    access:
+      availability: public
+      method: contact
+      url: https://cratedb.com/pricing/startups
+      instructions: Contact CrateDB through the Startup Pack page to ask whether the startup qualifies;
+        applicants may also complete the linked Deployment Assessment to begin use-case evaluation.
+    terms_url: https://cratedb.com/pricing/startups
+    source_ids:
+      - src_d23ecce237ddccb20a3fa2b714f15afd287826009005ce020c23b808345b776b
+      - src_d267c407ebe8b02462c66dc625810882c1d58d3dc31b185f0927fbfe4b949691


### PR DESCRIPTION
## Summary
- add CrateDB as a current-schema catalog entity
- add the active CrateDB Startup Pack from CrateDB's first-party terms page
- represent vendor-determined Cloud credits without inventing an amount
- capture the stated consulting, setup, analysis, support, audit, and recurring-review services

## Verification
- exact pinned `@sourcey/catalog-verifier` passed: 1 entity, 1 program, 1 offer
- live identity-context lookup returned no canonical conflicts
- DCO sign-off included

Source: https://cratedb.com/pricing/startups

Closes #1176