### PR TITLE
data: add Helius Startup Launchpad

### DIFF
--- a/entities/he/helius.yaml
+++ b/entities/he/helius.yaml
@@ -1,0 +1,71 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_hxw819qwwsbkwpnet67tkm2e8j
+  slug: helius
+  slug_aliases: []
+  name: Helius
+  domains:
+    - value: helius.dev
+      role: primary
+      valid_from: 2026-09-01T10:04:16.914Z
+  category: apis-integration
+profile:
+  description: Helius provides Solana infrastructure and developer tooling, including RPC, data, streaming, and transaction-delivery services.
+  links:
+    site: https://www.helius.dev
+sources:
+  - source_id: src_b212f5ba702511b031d62059eec4257f307bb1f04f3e24b6d4d620399c20e1c1
+    url: https://www.helius.dev/startup-launchpad
+programs:
+  - program_id: prg_09gmexebgw7kg6g5awgx65jc1c
+    program_slug: helius-startup-launchpad
+    program_slug_aliases: []
+    title: Helius Startup Launchpad
+    summary: Helius supports early-stage Solana startups with free Business-plan access, mentoring, introductions, education, and founder resources.
+    source_ids:
+      - src_b212f5ba702511b031d62059eec4257f307bb1f04f3e24b6d4d620399c20e1c1
+offers:
+  - offer_id: off_44ht39qkac9116fw8h1r8ehkgw
+    program_id: prg_09gmexebgw7kg6g5awgx65jc1c
+    offer_slug: eight-months-free-business-plan
+    offer_slug_aliases: []
+    title: Eight free months of the Helius Business plan
+    summary: Selected startups receive eight free months of the Helius Business plan, a stated $4,000 value, plus mentoring, introductions, education, and founder-community access.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-01T10:04:16.914Z
+    economics:
+      consideration:
+        kind: unknown
+        description: The public Launchpad page does not establish whether separate consideration is required.
+      benefits:
+        - benefit_id: ben_01
+          description: Eight free months of the Helius Business plan, stated by Helius as a $4,000 value
+          duration:
+            kind: exact
+            value: P8M
+          kind: free-service
+          service: Helius Business plan
+        - benefit_id: ben_02
+          description: Mentoring from experienced operators, strategic advice, and access to private founder groups, workshops, and office hours
+          kind: other
+        - benefit_id: ben_03
+          description: Introductions to investors, customers, talent, and strategic advisors
+          kind: other
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        statement: Helius selects startup teams based on a combination of factors such as having a working product, being earlier than Series A, accelerator participation, investor referrals, or placing in a Solana hackathon.
+        reason: vendor-discretion
+    roles:
+      terms_authority_entity_id: ent_hxw819qwwsbkwpnet67tkm2e8j
+      access_operator_entity_id: ent_hxw819qwwsbkwpnet67tkm2e8j
+    access:
+      availability: membership
+      instructions: Submit the Helius Startup Launchpad application from the public program page.
+      method: form
+      url: https://www.helius.dev/startup-launchpad
+    terms_url: https://www.helius.dev/startup-launchpad
+    source_ids:
+      - src_b212f5ba702511b031d62059eec4257f307bb1f04f3e24b6d4d620399c20e1c1

--- a/entities/he/helius.yaml
+++ b/entities/he/helius.yaml
@@ -10,6 +10,7 @@ entity:
       valid_from: 2026-09-01T10:04:16.914Z
   category: apis-integration
 profile:
+  summary: Helius provides Solana infrastructure and developer tooling, including RPC, data, streaming, and transaction-delivery services.
   description: Helius provides Solana infrastructure and developer tooling, including RPC, data, streaming, and transaction-delivery services.
   links:
     site: https://www.helius.dev
@@ -37,7 +38,6 @@ offers:
     economics:
       consideration:
         kind: variable
-        description: If usage exceeds the Business plan's 100M credit limit, additional credits are charged at the standard rate of $5 per million credits.
       benefits:
         - benefit_id: ben_01
           description: 8 months free Business plan ($4K value)
@@ -46,12 +46,6 @@ offers:
             value: P8M
           kind: free-service
           service: Business plan
-        - benefit_id: ben_02
-          description: Expert advice from veteran operators across marketing, sales, talent, operations, and design.
-          kind: other
-        - benefit_id: ben_03
-          description: Warm introductions to investors, marquee customers, talent, and strategic advisors.
-          kind: other
     eligibility:
       rule:
         criterion_id: cri_01

--- a/entities/he/helius.yaml
+++ b/entities/he/helius.yaml
@@ -37,8 +37,7 @@ offers:
       effective_from: 2026-09-01T10:04:16.914Z
     economics:
       consideration:
-        kind: variable
-        description: If you exceed your plan's 100M credit limit, you will be charged the standard rate of $5 per million credits.
+        kind: none
       benefits:
         - benefit_id: ben_01
           description: 8 months free Business plan ($4K value)

--- a/entities/he/helius.yaml
+++ b/entities/he/helius.yaml
@@ -36,21 +36,21 @@ offers:
       effective_from: 2026-09-01T10:04:16.914Z
     economics:
       consideration:
-        kind: unknown
-        description: The public Launchpad page does not establish whether separate consideration is required.
+        kind: variable
+        description: If usage exceeds the Business plan's 100M credit limit, additional credits are charged at the standard rate of $5 per million credits.
       benefits:
         - benefit_id: ben_01
-          description: Eight free months of the Helius Business plan, stated by Helius as a $4,000 value
+          description: 8 months free Business plan ($4K value)
           duration:
             kind: exact
             value: P8M
           kind: free-service
-          service: Helius Business plan
+          service: Business plan
         - benefit_id: ben_02
-          description: Mentoring from experienced operators, strategic advice, and access to private founder groups, workshops, and office hours
+          description: Expert advice from veteran operators across marketing, sales, talent, operations, and design.
           kind: other
         - benefit_id: ben_03
-          description: Introductions to investors, customers, talent, and strategic advisors
+          description: Warm introductions to investors, marquee customers, talent, and strategic advisors.
           kind: other
     eligibility:
       rule:
@@ -62,7 +62,7 @@ offers:
       terms_authority_entity_id: ent_hxw819qwwsbkwpnet67tkm2e8j
       access_operator_entity_id: ent_hxw819qwwsbkwpnet67tkm2e8j
     access:
-      availability: membership
+      availability: public
       instructions: Submit the Helius Startup Launchpad application from the public program page.
       method: form
       url: https://www.helius.dev/startup-launchpad

--- a/entities/he/helius.yaml
+++ b/entities/he/helius.yaml
@@ -38,6 +38,7 @@ offers:
     economics:
       consideration:
         kind: variable
+        description: If you exceed your plan's 100M credit limit, you will be charged the standard rate of $5 per million credits.
       benefits:
         - benefit_id: ben_01
           description: 8 months free Business plan ($4K value)


### PR DESCRIPTION
## Summary
- add Helius as a current-schema entity
- document the live Helius Startup Launchpad from its first-party program page
- record eight free months of the Business plan, mentoring, introductions, education, and published selection factors
- replace the retired-schema contribution in #637 with the canonical entity format the maintainer requested

## Verification
- exact pinned catalog verifier: 1 entity, 1 program, 1 offer
- DCO signed

Source: https://www.helius.dev/startup-launchpad

Closes #1182