### PR TITLE
data: add Appsmith Startup Program

### DIFF
--- a/entities/ap/appsmith.yaml
+++ b/entities/ap/appsmith.yaml
@@ -1,0 +1,97 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_6br01mq0rfb1v8bwz7xkd6tmaz
+  slug: appsmith
+  slug_aliases: []
+  name: Appsmith
+  domains:
+    - value: appsmith.com
+      role: primary
+      valid_from: 2026-09-01T10:07:37.339Z
+  category: no-code
+profile:
+  description: Appsmith is a platform for building internal applications and tools with visual components, data-source connections, and custom code.
+  links:
+    site: https://www.appsmith.com
+sources:
+  - source_id: src_1acf478a66e0d3a4d67b1be92a47b4bdd85739d2b2f5acddf284b7289661a7e7
+    url: https://www.appsmith.com/startup-program
+programs:
+  - program_id: prg_42nzeg5aypsrn32qvpww7nm3gp
+    program_slug: appsmith-startup-program
+    program_slug_aliases: []
+    title: Appsmith Startup Program
+    summary: Appsmith gives qualifying early-stage startups platform credits, Business-plan features, and access to its developer advocates.
+    source_ids:
+      - src_1acf478a66e0d3a4d67b1be92a47b4bdd85739d2b2f5acddf284b7289661a7e7
+offers:
+  - offer_id: off_et5ear8taxrtjx6n4apmccvxe1
+    program_id: prg_42nzeg5aypsrn32qvpww7nm3gp
+    offer_slug: 30000-appsmith-credits
+    offer_slug_aliases: []
+    title: $30,000 in Appsmith credits for 12 months
+    summary: Qualifying startups receive $30,000 in Appsmith credits valid for 12 months, all Business-plan features, and access to Appsmith developer advocates.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-01T10:07:37.339Z
+    economics:
+      consideration:
+        kind: none
+      benefits:
+        - benefit_id: ben_01
+          description: $30,000 worth of Appsmith credits valid for 12 months
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 3000000
+            kind: exact
+          duration:
+            kind: exact
+            value: P1Y
+        - benefit_id: ben_02
+          description: Access to all Appsmith Business-plan features
+          kind: free-service
+          service: Appsmith Business plan
+        - benefit_id: ben_03
+          description: Access to Appsmith developer advocates
+          kind: other
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            statement: Applicant plans to use Appsmith for its own startup.
+            reason: not-machine-evaluable
+          - criterion_id: cri_02
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: Applicant has raised less than $10 million in funding.
+            value:
+              type: number
+              value: 10000000
+          - criterion_id: cri_03
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: Applicant was incorporated less than two years ago.
+            value:
+              type: number
+              value: 24
+          - criterion_id: cri_04
+            kind: manual
+            statement: Applicant is looking to host Appsmith on its own infrastructure.
+            reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_6br01mq0rfb1v8bwz7xkd6tmaz
+      access_operator_entity_id: ent_6br01mq0rfb1v8bwz7xkd6tmaz
+    access:
+      availability: membership
+      instructions: Use the Join now link on Appsmith's public startup-program page to submit the enrollment form; Appsmith states that its team will schedule a call afterward.
+      method: form
+      url: https://www.appsmith.com/startup-program
+    terms_url: https://www.appsmith.com/startup-program
+    source_ids:
+      - src_1acf478a66e0d3a4d67b1be92a47b4bdd85739d2b2f5acddf284b7289661a7e7

--- a/entities/ap/appsmith.yaml
+++ b/entities/ap/appsmith.yaml
@@ -74,13 +74,9 @@ offers:
               type: number
               value: 10000000
           - criterion_id: cri_03
-            fact: company.age_months
-            kind: predicate
-            operator: lt
+            kind: manual
+            reason: external-verification
             statement: Applicant was incorporated less than two years ago.
-            value:
-              type: number
-              value: 24
           - criterion_id: cri_04
             kind: manual
             statement: Applicant is looking to host Appsmith on its own infrastructure.

--- a/entities/ap/appsmith.yaml
+++ b/entities/ap/appsmith.yaml
@@ -10,9 +10,10 @@ entity:
       valid_from: 2026-09-01T10:07:37.339Z
   category: no-code
 profile:
+  summary: Platform for building internal applications and tools.
   description: Appsmith is a platform for building internal applications and tools with visual components, data-source connections, and custom code.
   links:
-    site: https://www.appsmith.com/startup-program
+    site: https://www.appsmith.com
 sources:
   - source_id: src_1acf478a66e0d3a4d67b1be92a47b4bdd85739d2b2f5acddf284b7289661a7e7
     url: https://www.appsmith.com/startup-program
@@ -39,7 +40,7 @@ offers:
         kind: none
       benefits:
         - benefit_id: ben_01
-          description: $30,000 worth of Appsmith credits valid for 12 months
+          description: $30,000 worth of Appsmith credits
           kind: credit
           value:
             amount:
@@ -50,11 +51,11 @@ offers:
             kind: exact
             value: P1Y
         - benefit_id: ben_02
-          description: Access to all Appsmith Business-plan features
+          description: All Business plan features
           kind: free-service
           service: Appsmith Business plan
         - benefit_id: ben_03
-          description: Access to Appsmith developer advocates
+          description: Get access to our dev advocates
           kind: other
     eligibility:
       rule:
@@ -91,6 +92,6 @@ offers:
       availability: public
       instructions: Use the Join now link on Appsmith's public startup-program page to submit the enrollment form; Appsmith states that its team will schedule a call afterward.
       method: form
-      url: https://www.appsmith.com/startup-program
+      url: https://docs.google.com/forms/d/e/1FAIpQLSeoKy2M_2jhzu_hhBd2DTuev93R-AvDBf1N1KK6DGrFm9E4ag/viewform
     source_ids:
       - src_1acf478a66e0d3a4d67b1be92a47b4bdd85739d2b2f5acddf284b7289661a7e7

--- a/entities/ap/appsmith.yaml
+++ b/entities/ap/appsmith.yaml
@@ -12,7 +12,7 @@ entity:
 profile:
   description: Appsmith is a platform for building internal applications and tools with visual components, data-source connections, and custom code.
   links:
-    site: https://www.appsmith.com
+    site: https://www.appsmith.com/startup-program
 sources:
   - source_id: src_1acf478a66e0d3a4d67b1be92a47b4bdd85739d2b2f5acddf284b7289661a7e7
     url: https://www.appsmith.com/startup-program
@@ -88,10 +88,9 @@ offers:
       terms_authority_entity_id: ent_6br01mq0rfb1v8bwz7xkd6tmaz
       access_operator_entity_id: ent_6br01mq0rfb1v8bwz7xkd6tmaz
     access:
-      availability: membership
+      availability: public
       instructions: Use the Join now link on Appsmith's public startup-program page to submit the enrollment form; Appsmith states that its team will schedule a call afterward.
       method: form
       url: https://www.appsmith.com/startup-program
-    terms_url: https://www.appsmith.com/startup-program
     source_ids:
       - src_1acf478a66e0d3a4d67b1be92a47b4bdd85739d2b2f5acddf284b7289661a7e7


### PR DESCRIPTION
## Summary
- add Appsmith as a current-schema entity
- document the live Appsmith Startup Program from its first-party program page
- record the published $30,000 credit grant, 12-month term, Business-plan features, developer-advocate access, and all four stated eligibility requirements
- replace retired-schema PR #628 with the canonical entity format the maintainer requested

## Verification
- exact pinned catalog verifier: 1 entity, 1 program, 1 offer
- DCO signed

Source: https://www.appsmith.com/startup-program

Closes #1184