### PR TITLE
data: add Browserbase Founder Pack credits

### DIFF
--- a/entities/br/browserbase.yaml
+++ b/entities/br/browserbase.yaml
@@ -12,6 +12,8 @@ entity:
 profile:
   summary: Cloud browser infrastructure, web data APIs, model routing, and agent tooling.
   description: Browserbase provides cloud browsers, web data APIs, model routing, session observability, and the Stagehand SDK for browser agents and web automation.
+  links:
+    site: https://www.browserbase.com
 sources:
   - source_id: src_35c7020601f380ba2d8cf4e1d75b5824a16b25c54c011cce7cc8cc185576494f
     url: https://www.browserbase.com/11labs-founder-pack
@@ -28,6 +30,7 @@ offers:
     economics:
       consideration:
         kind: unknown
+        description: The cited source does not establish separate consideration beyond the offer terms.
       benefits:
         - benefit_id: ben_primary
           description: Redeem your ElevenLabs Founder Pack credits.

--- a/entities/br/browserbase.yaml
+++ b/entities/br/browserbase.yaml
@@ -12,8 +12,6 @@ entity:
 profile:
   summary: Cloud browser infrastructure, web data APIs, model routing, and agent tooling.
   description: Browserbase provides cloud browsers, web data APIs, model routing, session observability, and the Stagehand SDK for browser agents and web automation.
-  links:
-    site: https://www.browserbase.com
 sources:
   - source_id: src_35c7020601f380ba2d8cf4e1d75b5824a16b25c54c011cce7cc8cc185576494f
     url: https://www.browserbase.com/11labs-founder-pack
@@ -30,10 +28,9 @@ offers:
     economics:
       consideration:
         kind: unknown
-        description: The cited source does not establish separate consideration beyond the offer terms.
       benefits:
         - benefit_id: ben_primary
-          description: Eligible ElevenLabs Founder Pack members can redeem Browserbase credits.
+          description: Redeem your ElevenLabs Founder Pack credits.
           kind: other
     eligibility:
       rule:

--- a/entities/br/browserbase.yaml
+++ b/entities/br/browserbase.yaml
@@ -1,0 +1,51 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1gnyp9s6vrv5r5ygyhtjtwx
+  slug: browserbase
+  slug_aliases: []
+  name: Browserbase
+  domains:
+    - value: browserbase.com
+      role: primary
+      valid_from: 2026-09-02T09:07:14.036Z
+  category: data-analytics
+profile:
+  description: Browserbase provides cloud browsers, web data APIs, model routing, session observability, and the Stagehand SDK for browser agents and web automation.
+  links:
+    site: https://www.browserbase.com
+sources:
+  - source_id: src_35c7020601f380ba2d8cf4e1d75b5824a16b25c54c011cce7cc8cc185576494f
+    url: https://www.browserbase.com/11labs-founder-pack
+programs: []
+offers:
+  - offer_id: off_01m1gnyp9zwbjj1ghtnq32d4p3
+    offer_slug: elevenlabs-founder-pack-browserbase-credits
+    offer_slug_aliases: []
+    title: Browserbase credits for ElevenLabs Founder Pack members
+    summary: ElevenLabs Founder Pack members can redeem Browserbase credits for cloud browsers, model routing, session inspection, web data APIs, proxy and CAPTCHA orchestration, and Stagehand.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-02T09:07:14.036Z
+    economics:
+      consideration:
+        kind: unknown
+        description: Browserbase does not publish a separate price or other consideration for redeeming the Founder Pack offer.
+      benefits:
+        - benefit_id: ben_primary
+          description: Browserbase credits; the public redemption page does not state the credit amount or duration.
+          kind: other
+    eligibility:
+      rule:
+        criterion_id: cri_membership_01
+        kind: manual
+        reason: external-verification
+        statement: The applicant must be eligible to redeem benefits through the ElevenLabs Founder Pack.
+    roles:
+      terms_authority_entity_id: ent_01m1gnyp9s6vrv5r5ygyhtjtwx
+      access_operator_entity_id: ent_01m1gnyp9s6vrv5r5ygyhtjtwx
+    access:
+      availability: membership
+      method: form
+      url: https://www.browserbase.com/11labs-founder-pack
+    source_ids:
+      - src_35c7020601f380ba2d8cf4e1d75b5824a16b25c54c011cce7cc8cc185576494f

--- a/entities/br/browserbase.yaml
+++ b/entities/br/browserbase.yaml
@@ -29,10 +29,9 @@ offers:
       effective_from: 2026-09-02T09:07:14.036Z
     economics:
       consideration:
-        kind: none
+        kind: unknown
       benefits:
         - benefit_id: ben_primary
-          description: ElevenLabs Founder Pack credits for Browserbase
           kind: other
     eligibility:
       rule:

--- a/entities/br/browserbase.yaml
+++ b/entities/br/browserbase.yaml
@@ -30,8 +30,10 @@ offers:
     economics:
       consideration:
         kind: unknown
+        description: The cited source does not establish separate consideration beyond the offer terms.
       benefits:
         - benefit_id: ben_primary
+          description: Eligible ElevenLabs Founder Pack members can redeem Browserbase credits.
           kind: other
     eligibility:
       rule:

--- a/entities/br/browserbase.yaml
+++ b/entities/br/browserbase.yaml
@@ -8,8 +8,9 @@ entity:
     - value: browserbase.com
       role: primary
       valid_from: 2026-09-02T09:07:14.036Z
-  category: data-analytics
+  category: apis-integration
 profile:
+  summary: Cloud browser infrastructure, web data APIs, model routing, and agent tooling.
   description: Browserbase provides cloud browsers, web data APIs, model routing, session observability, and the Stagehand SDK for browser agents and web automation.
   links:
     site: https://www.browserbase.com
@@ -28,11 +29,10 @@ offers:
       effective_from: 2026-09-02T09:07:14.036Z
     economics:
       consideration:
-        kind: unknown
-        description: Browserbase does not publish a separate price or other consideration for redeeming the Founder Pack offer.
+        kind: none
       benefits:
         - benefit_id: ben_primary
-          description: Browserbase credits; the public redemption page does not state the credit amount or duration.
+          description: ElevenLabs Founder Pack credits for Browserbase
           kind: other
     eligibility:
       rule:

--- a/entities/br/browserbase.yaml
+++ b/entities/br/browserbase.yaml
@@ -33,7 +33,7 @@ offers:
         description: The cited source does not establish separate consideration beyond the offer terms.
       benefits:
         - benefit_id: ben_primary
-          description: Redeem your ElevenLabs Founder Pack credits.
+          description: Eligible ElevenLabs Founder Pack members can redeem Browserbase credits.
           kind: other
     eligibility:
       rule:


### PR DESCRIPTION
## Summary
- add the missing Browserbase entity and its ElevenLabs Founder Pack credit redemption offer
- preserve the public page's exact information boundary: no invented credit amount, duration, or separate consideration
- describe the supported Browserbase product surface and membership-gated redemption path from the first-party page

Closes #1227

## Evidence
- https://www.browserbase.com/11labs-founder-pack

## Verification
- exact pinned Sourcey catalog verifier: valid (1 entity, 0 programs, 1 offer)
- live identity context issued for the unchanged candidate
- git diff --check
- DCO signed-off commit