### PR TITLE
data: add Routine for Startups

### DIFF
--- a/entities/ro/routine.yaml
+++ b/entities/ro/routine.yaml
@@ -1,0 +1,64 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1gsqpe7gbmbn7m01f18gsgz
+  slug: routine
+  slug_aliases: []
+  name: Routine
+  domains:
+    - value: routine.co
+      role: primary
+      valid_from: 2026-09-02T10:13:29.122Z
+  category: productivity
+profile:
+  description: Routine is a productivity workspace that combines calendar, tasks, projects, notes, knowledge, and team planning.
+  links:
+    site: https://routine.co
+sources:
+  - source_id: src_aa72e94bf16d8d4795bf55fa9f6dca3aaf70a0250768951bd4a78a37c7b28673
+    url: https://routine.co/partnerships/startups
+programs:
+  - program_id: prg_01m1gsqpe7hrbbhmrjackg141b
+    program_slug: routine-for-startups
+    program_slug_aliases: []
+    title: Routine for Startups
+    summary: Routine's startup program gives approved early-stage teams a full year of Routine Business at no charge.
+    source_ids:
+      - src_aa72e94bf16d8d4795bf55fa9f6dca3aaf70a0250768951bd4a78a37c7b28673
+offers:
+  - offer_id: off_01m1gsqpe7zseds0eyn3bcbc8z
+    program_id: prg_01m1gsqpe7hrbbhmrjackg141b
+    offer_slug: one-year-free-routine-business
+    offer_slug_aliases: []
+    title: One year free Routine Business
+    summary: Approved startups receive Routine Business free for one year, with a first-party stated maximum value of up to $2,500 depending on team size.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-02T10:13:29.122Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: One year of Routine Business free, worth up to $2,500 depending on team size
+          kind: free-service
+          service: Routine Business plan
+          duration:
+            kind: exact
+            value: P1Y
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: external-verification
+        statement: The applicant must be a non-paying Routine startup moving to the Business plan, have fewer than 20 employees and less than $2 million in funding, and use a public company website with a unique company email domain; the company must not have undergone a change of control or IPO, and Routine may require partner affiliation or a minimum funding level.
+    roles:
+      terms_authority_entity_id: ent_01m1gsqpe7gbmbn7m01f18gsgz
+      access_operator_entity_id: ent_01m1gsqpe7gbmbn7m01f18gsgz
+    access:
+      availability: public
+      method: form
+      instructions: Submit the Routine for Startups application; Routine verifies eligibility and applies the offer to approved organizations.
+      url: https://routine.co/partnerships/startups
+    terms_url: https://routine.co/partnerships/startups
+    source_ids:
+      - src_aa72e94bf16d8d4795bf55fa9f6dca3aaf70a0250768951bd4a78a37c7b28673

--- a/entities/ro/routine.yaml
+++ b/entities/ro/routine.yaml
@@ -38,7 +38,6 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: One year of Routine Business free
           kind: free-service
           service: Routine Business plan
           duration:

--- a/entities/ro/routine.yaml
+++ b/entities/ro/routine.yaml
@@ -38,7 +38,7 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: Routine Business free for one year.
+          description: One year free Routine Business
           kind: free-service
           service: Routine Business plan
           duration:

--- a/entities/ro/routine.yaml
+++ b/entities/ro/routine.yaml
@@ -38,7 +38,7 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: Approved startups receive Routine Business free for one year.
+          description: Routine Business free for one year.
           kind: free-service
           service: Routine Business plan
           duration:

--- a/entities/ro/routine.yaml
+++ b/entities/ro/routine.yaml
@@ -38,7 +38,7 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: One year free Routine Business
+          description: A full year for free!
           kind: free-service
           service: Routine Business plan
           duration:

--- a/entities/ro/routine.yaml
+++ b/entities/ro/routine.yaml
@@ -10,6 +10,7 @@ entity:
       valid_from: 2026-09-02T10:13:29.122Z
   category: productivity
 profile:
+  summary: Productivity workspace for calendars, tasks, projects, notes, and team planning.
   description: Routine is a productivity workspace that combines calendar, tasks, projects, notes, knowledge, and team planning.
   links:
     site: https://routine.co
@@ -37,7 +38,7 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: One year of Routine Business free, worth up to $2,500 depending on team size
+          description: One year of Routine Business free
           kind: free-service
           service: Routine Business plan
           duration:

--- a/entities/ro/routine.yaml
+++ b/entities/ro/routine.yaml
@@ -38,6 +38,7 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
+          description: Approved startups receive Routine Business free for one year.
           kind: free-service
           service: Routine Business plan
           duration:

--- a/entities/ro/routine.yaml
+++ b/entities/ro/routine.yaml
@@ -48,10 +48,40 @@ offers:
         kind: none
     eligibility:
       rule:
-        criterion_id: cri_01
-        kind: manual
-        reason: external-verification
-        statement: The applicant must be a non-paying Routine startup moving to the Business plan, have fewer than 20 employees and less than $2 million in funding, and use a public company website with a unique company email domain; the company must not have undergone a change of control or IPO, and Routine may require partner affiliation or a minimum funding level.
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: The applicant must be a non-paying Routine customer moving to the Routine Business plan.
+          - criterion_id: cri_02
+            fact: company.employee_count
+            kind: predicate
+            operator: lt
+            statement: The company must have fewer than 20 employees.
+            value:
+              type: number
+              value: 20
+          - criterion_id: cri_03
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lt
+            statement: The company must have received less than $2 million in funding.
+            value:
+              type: number
+              value: 2000000
+          - criterion_id: cri_04
+            kind: manual
+            reason: external-verification
+            statement: The applicant must have a public company website and a unique company email domain.
+          - criterion_id: cri_05
+            kind: manual
+            reason: external-verification
+            statement: The company must not have undergone a change of control or initial public offering.
+          - criterion_id: cri_06
+            kind: manual
+            reason: vendor-discretion
+            statement: Routine may require a minimum funding level when the applicant is not affiliated with a Routine funding partner.
     roles:
       terms_authority_entity_id: ent_01m1gsqpe7gbmbn7m01f18gsgz
       access_operator_entity_id: ent_01m1gsqpe7gbmbn7m01f18gsgz


### PR DESCRIPTION
## Summary
- add one new Routine entity and one startup-specific offer
- record the canonical one-year free Routine Business benefit and the first-party up-to-USD-2,500 qualifier
- preserve the published non-paying-customer, team-size, funding, company-domain, and corporate-status eligibility constraints

## Evidence
- First-party program and terms: https://routine.co/partnerships/startups
- Missing-record issue: #1252

## Validation
- YAML parses successfully
- exactly one new Entity file
- no existing Routine catalog entity, Sourcey issue, or Sourcey PR was present when reserved
- git diff --check passes

Closes #1252