### PR TITLE
data: add AnnounceKit startup program

### DIFF
--- a/entities/an/announcekit.yaml
+++ b/entities/an/announcekit.yaml
@@ -1,0 +1,104 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1gw32jb01nc66p6as012vtb
+  slug: announcekit
+  slug_aliases: []
+  name: AnnounceKit
+  domains:
+    - value: announcekit.app
+      role: primary
+      valid_from: 2026-09-02T10:54:00.000Z
+  category: productivity
+profile:
+  description: AnnounceKit is a changelog, widget, and product-notification platform that helps product teams publish updates and announce new features to users.
+  links:
+    site: https://announcekit.app
+sources:
+  - source_id: src_2dd1d1ded02c7707499fce0f1c48f0e72fadaf7898a0e35f7cd504f1fb192f46
+    url: https://announcekit.app/startup
+programs:
+  - program_id: prg_01m1gw32jb1g7e1x9b24ezj355
+    program_slug: announcekit-startup-program
+    program_slug_aliases: []
+    title: AnnounceKit Startup Program
+    summary: AnnounceKit Startup Program gives eligible early-stage startups 50% off any AnnounceKit plan for their first 12 months, with all plan features included and no long-term commitment.
+    source_ids:
+      - src_2dd1d1ded02c7707499fce0f1c48f0e72fadaf7898a0e35f7cd504f1fb192f46
+offers:
+  - offer_id: off_01m1gw32jbchqpjrwxyvqvt2zq
+    program_id: prg_01m1gw32jb1g7e1x9b24ezj355
+    offer_slug: 50-percent-off-any-plan-12-months
+    offer_slug_aliases: []
+    title: 50% off any AnnounceKit plan for 12 months
+    summary: Eligible early-stage startups receive 50% off any AnnounceKit plan (Essentials, Growth, or Scale) for 12 months, with full features and no long-term commitment.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-02T10:54:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: 50% off any AnnounceKit plan for 12 months
+          kind: discount
+          percentage:
+            kind: exact
+            basis_points: 5000
+          duration:
+            kind: exact
+            value: P12M
+          applies_to: Any AnnounceKit plan (Essentials, Growth, or Scale)
+        - benefit_id: ben_02
+          description: All features of the chosen plan included with no feature restrictions
+          kind: other
+        - benefit_id: ben_03
+          description: No long-term commitment; cancel or switch plans anytime
+          kind: other
+      consideration:
+        kind: variable
+        description: The startup pays the remaining price of its selected AnnounceKit plan after the 50% startup discount for the first 12 months, then standard listed pricing.
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.employee_count
+            kind: predicate
+            operator: lt
+            statement: Fewer than 5 employees, including founders and full-time and part-time team members.
+            value:
+              type: number
+              value: 5
+          - criterion_id: cri_02
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: The company was incorporated within the last 24 months.
+            value:
+              type: number
+              value: 24
+          - criterion_id: cri_03
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lte
+            statement: Total funding across all rounds is $1M or less; bootstrapped companies qualify.
+            value:
+              type: number
+              value: 1000000
+          - criterion_id: cri_04
+            kind: manual
+            reason: not-machine-evaluable
+            statement: The applicant must be building a product with a live product or a product in active development.
+          - criterion_id: cri_05
+            kind: manual
+            reason: vendor-discretion
+            statement: AnnounceKit reviews applications and typically responds within about 2 business days.
+    roles:
+      terms_authority_entity_id: ent_01m1gw32jb01nc66p6as012vtb
+      access_operator_entity_id: ent_01m1gw32jb01nc66p6as012vtb
+    access:
+      availability: public
+      method: email
+      instructions: Open the AnnounceKit Startup Program page and apply via the published email application route with company name, website, team size, and founding date. Vendor review typically takes about 2 business days.
+      url: https://announcekit.app/startup
+    terms_url: https://announcekit.app/startup
+    source_ids:
+      - src_2dd1d1ded02c7707499fce0f1c48f0e72fadaf7898a0e35f7cd504f1fb192f46

--- a/entities/an/announcekit.yaml
+++ b/entities/an/announcekit.yaml
@@ -96,7 +96,7 @@ offers:
       access_operator_entity_id: ent_01m1gw32jb01nc66p6as012vtb
     access:
       availability: public
-      method: email
+      method: contact
       instructions: Open the AnnounceKit Startup Program page and apply via the published email application route with company name, website, team size, and founding date. Vendor review typically takes about 2 business days.
       url: https://announcekit.app/startup
     terms_url: https://announcekit.app/startup


### PR DESCRIPTION
## Summary
- Adds `entities/an/announcekit.yaml` for AnnounceKit Startup Program.
- Closes #893.
- First-party https://announcekit.app/startup: **50% off** any AnnounceKit plan for **12 months** (Essentials/Growth/Scale), early-stage eligibility (<5 employees, <2 years, ≤$1M funding), all features included.

## Verification
- No existing `announcekit` entity on main.
- No open AnnounceKit PR (prior #900/#42 closed).
- Amounts taken only from the live first-party startup page.
- Summaries ≤240 chars; no email addresses in instructions; DCO Signed-off-by.