### PR TITLE
data: add BillBasket startup program

### DIFF
--- a/entities/bi/billbasket.yaml
+++ b/entities/bi/billbasket.yaml
@@ -1,0 +1,72 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1mdrdx305wnks5yegaa0tz3
+  slug: billbasket
+  slug_aliases: []
+  name: BillBasket
+  domains:
+    - value: billbasket.app
+      role: primary
+      valid_from: 2026-09-03T20:00:57.853Z
+  category: finance-accounting
+profile:
+  description: BillBasket provides point-of-sale, billing, invoicing, collections, customer ledger, and reconciliation software.
+  links:
+    site: https://www.billbasket.app
+sources:
+  - source_id: src_2bd5cc2e0d393e0b582c7e7e3d17a1dae01b1f006dbb9f6e2115035005172be9
+    url: https://www.billbasket.app/social-support-programs/startup
+programs:
+  - program_id: prg_01m1mdrdx46jmpmvb5kqh4fx64
+    program_slug: social-support-program-for-startups
+    program_slug_aliases: []
+    title: BillBasket Social Support Program for Startups
+    summary: BillBasket's startup support program gives eligible young, DPIIT-recognized companies free access to its complete POS and app for one year.
+    source_ids:
+      - src_2bd5cc2e0d393e0b582c7e7e3d17a1dae01b1f006dbb9f6e2115035005172be9
+offers:
+  - offer_id: off_01m1mdrdx4dzyw9vvmaedpm6nr
+    program_id: prg_01m1mdrdx46jmpmvb5kqh4fx64
+    offer_slug: complete-pos-and-app-free-for-one-year
+    offer_slug_aliases: []
+    title: Complete BillBasket POS and App free for one year
+    summary: Eligible startups receive one year of free access to the complete BillBasket POS and App, including billing, collections, ledgers, and reconciliation.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-03T20:00:57.853Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: One year of free access to the complete BillBasket POS and App
+          duration:
+            kind: exact
+            value: P1Y
+          kind: free-service
+          service: Complete BillBasket POS and App
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: Company was incorporated less than two years ago.
+            value:
+              type: number
+              value: 24
+          - criterion_id: cri_02
+            kind: manual
+            reason: not-machine-evaluable
+            statement: Company is registered under India's Department for Promotion of Industry and Internal Trade (DPIIT).
+    roles:
+      terms_authority_entity_id: ent_01m1mdrdx305wnks5yegaa0tz3
+      access_operator_entity_id: ent_01m1mdrdx305wnks5yegaa0tz3
+    access:
+      availability: public
+      method: form
+      url: https://www.billbasket.app/social-support-programs/startup
+    source_ids:
+      - src_2bd5cc2e0d393e0b582c7e7e3d17a1dae01b1f006dbb9f6e2115035005172be9

--- a/entities/bi/billbasket.yaml
+++ b/entities/bi/billbasket.yaml
@@ -11,7 +11,7 @@ entity:
   category: finance-accounting
 profile:
   description: BillBasket provides point-of-sale, billing, invoicing, collections, customer ledger, and reconciliation software.
-  summary: BillBasket is offline-first POS and billing software for Indian businesses, covering billing, inventory, GST invoicing, and reports.
+  summary: BillBasket provides point-of-sale and billing software for businesses in India.
   links:
     site: https://www.billbasket.app
 sources:

--- a/entities/bi/billbasket.yaml
+++ b/entities/bi/billbasket.yaml
@@ -11,6 +11,7 @@ entity:
   category: finance-accounting
 profile:
   description: BillBasket provides point-of-sale, billing, invoicing, collections, customer ledger, and reconciliation software.
+  summary: BillBasket is offline-first POS and billing software for Indian businesses, covering billing, inventory, GST invoicing, and reports.
   links:
     site: https://www.billbasket.app
 sources:


### PR DESCRIPTION
## Summary

- add BillBasket as one new Entity with one startup-specific offer
- record one year of free access to the complete BillBasket POS and App
- model the published company-age and DPIIT registration requirements
- cite only BillBasket's first-party English-language program page

Closes #1266

## Validation

- `git diff --check` passes
- DCO sign-off is present
- the pinned verifier generated and received a signed identity context for the exact candidate; local final validation currently reports a signer-registry digest mismatch between the live identity service and the repository root set, so the canonical CI check is expected to rerun this network-dependent step

Signed-off-by: João Cláudio Carvalho <joaoclaudiocarvalho@gmail.com>