### PR TITLE
fix(qarnot): correct discount percentage schema and eligibility rule

### DIFF
--- a/entities/qa/qarnot.yaml
+++ b/entities/qa/qarnot.yaml
@@ -1,0 +1,72 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1hppx9gmpt0a397prcktycp
+  slug: qarnot
+  slug_aliases: []
+  name: Qarnot
+  domains:
+    - value: qarnot.com
+      role: primary
+      valid_from: 2026-09-02T00:00:00.000Z
+  category: hosting-infra
+profile:
+  description: Qarnot provides sustainable, waste-heat-recovering cloud HPC and rendering infrastructure for compute-intensive workloads.
+  links:
+    site: https://qarnot.com
+sources:
+  - source_id: src_a8c368caec29037df355f80e2c48a7e4e49f82a60ef45aa005cae8b46d22b285
+    url: https://qarnot.com/en/start-up
+programs:
+  - program_id: prg_01m1hppx9m6abzs6eb4m8c60ex
+    program_slug: qarnot-start-up-program
+    program_slug_aliases: []
+    title: Qarnot Start-up Program
+    summary: Qarnot provides €6,000 in free cloud HPC credits over six months, then a 50% discount on computing usage, plus Research Tax Credit (CIR) eligibility for French companies using Qarnot's HPC solution.
+    source_ids:
+      - src_a8c368caec29037df355f80e2c48a7e4e49f82a60ef45aa005cae8b46d22b285
+offers:
+  - offer_id: off_01m1hppx9mvyeztfm9w61s2zet
+    program_id: prg_01m1hppx9m6abzs6eb4m8c60ex
+    offer_slug: qarnot-start-up-program
+    offer_slug_aliases: []
+    title: Qarnot Start-up Program
+    summary: Eligible startups receive €6,000 in free Qarnot cloud credits for the first six months, then 50% off computing usage with pay-as-you-go billing, plus optional Research Tax Credit (CIR) eligibility for French companies.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-02T00:00:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: €6,000 in free Qarnot cloud HPC credits for the first six months
+          kind: credit
+          value:
+            kind: up-to
+            amount:
+              currency: EUR
+              minor_units: 600000
+        - benefit_id: ben_02
+          description: 50% discount on computing usage with pay-as-you-go billing after free credits are used
+          kind: discount
+          percentage:
+            kind: exact
+            basis_points: 5000
+        - benefit_id: ben_03
+          description: Research Tax Credit (CIR) eligibility for French companies using Qarnot's HPC solution for R&D projects
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Startups must apply through the Qarnot start-up program page and be approved by Qarnot; terms eligibility and start-up qualification are at the vendor's discretion.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m1hppx9gmpt0a397prcktycp
+      access_operator_entity_id: ent_01m1hppx9gmpt0a397prcktycp
+    access:
+      availability: public
+      method: form
+      url: https://qarnot.com/en/start-up
+    source_ids:
+      - src_a8c368caec29037df355f80e2c48a7e4e49f82a60ef45aa005cae8b46d22b285


### PR DESCRIPTION
## Summary
Corrects Sourcey catalog validation errors on #1261:
- `benefits[1]`: replace `value.percent: 50` with `percentage.kind: exact, basis_points: 5000`
- `eligibility.rule`: add `criterion_id: cri_requirement_01` and update `reason: not-machine-evaluable` (valid value per AWS/n8n examples)

The original CI failure showed:
```
Catalog data is invalid:
- offers[0].economics.benefits[1].percentage: Invalid input: expected object, received undefined
- offers[0].economics.benefits[1]: Unrecognized key: "value"
- offers[0].eligibility.rule: Invalid input
```

## Test plan
- [x] Verified against existing entities with `kind: discount` (n8n.yaml) and `kind: manual` eligibility (AWS, n8n)
- [x] Local YAML parses cleanly
- [ ] CI `validate-catalog-change` should pass on this branch

## References
- Sourcey catalog validation workflow
- n8n.yaml reference for `percentage: { kind: exact, basis_points: ... }`
- AWS Activate for `criterion_id` + `reason: not-machine-evaluable` in `kind: manual` rules
- Frantic bounty #120 (1 USD startup-credit)
- Frantic bounty #127 (20 USD Sourcey catalog credit)
