### PR TITLE
data: add Quotarider startup program

### DIFF
--- a/entities/qu/quotarider.yaml
+++ b/entities/qu/quotarider.yaml
@@ -1,0 +1,69 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1nmrqbcww810fayrwtnttcx
+  slug: quotarider
+  slug_aliases: []
+  name: Quotarider
+  domains:
+    - value: quotarider.com
+      role: primary
+      valid_from: 2026-09-04T07:22:41.902Z
+  category: crm-sales
+profile:
+  description: Quotarider provides CRM, sales pipelines, revenue analytics, and outbound email through connected mailboxes.
+  links:
+    site: https://quotarider.com
+sources:
+  - source_id: src_20a5976e74144e2075fd04bcc89dc0895a7f58600a94458efaea8efda3df06a0
+    url: https://quotarider.com/startup-program
+programs:
+  - program_id: prg_01m1nmrqbdk4n16pcqy5161h59
+    program_slug: quotarider-startup-program
+    program_slug_aliases: []
+    title: Quotarider Startup Program
+    summary: Eligible early-stage companies can apply for an additional 25% discount on Quotarider paid plans.
+    source_ids:
+      - src_20a5976e74144e2075fd04bcc89dc0895a7f58600a94458efaea8efda3df06a0
+offers:
+  - offer_id: off_01m1nmrqbdn7qg3s9dwpdn57hp
+    program_id: prg_01m1nmrqbdk4n16pcqy5161h59
+    offer_slug: quotarider-startup-25-percent-discount
+    offer_slug_aliases: []
+    title: Additional 25% Off Quotarider Paid Plans for Startups
+    summary: Approved startups receive an additional 25% off any paid plan, which can be combined with founder pricing and annual discounts.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-04T07:22:41.902Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          kind: discount
+          applies_to: any Quotarider paid plan
+          description: Additional 25% discount, combinable with founder pricing and yearly discounts
+          percentage:
+            kind: exact
+            basis_points: 2500
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: The applicant is an early-stage company, from idea stage through Series A.
+          - criterion_id: cri_02
+            kind: manual
+            reason: external-verification
+            statement: The company has a small team and real budget constraints, subject to application review.
+    roles:
+      terms_authority_entity_id: ent_01m1nmrqbcww810fayrwtnttcx
+      access_operator_entity_id: ent_01m1nmrqbcww810fayrwtnttcx
+    access:
+      availability: public
+      method: form
+      url: https://quotarider.com/startup-program
+      instructions: Apply using the startup form. After approval, sign up with the same email so the discount applies automatically at checkout. Applications are usually reviewed within 1–2 business days.
+    source_ids:
+      - src_20a5976e74144e2075fd04bcc89dc0895a7f58600a94458efaea8efda3df06a0


### PR DESCRIPTION
Adds one Quotarider entity with one startup offer: an additional 25% discount on paid plans, combinable with founder pricing and annual discounts. Eligibility and application instructions come from https://quotarider.com/startup-program, checked 2026-09-04.

The source does not specify a discount duration or numerical team-size limits; these are omitted. This is a data-only, AI-assisted contribution for Frantic bounty #120.

Validation: sourcey/validation and validate catalog change both pass on head e18d5b5598784de26cb384dc6e3660ebff3b30e0, including DCO sign-off. Workflow: https://github.com/sourcey/startup-credits/actions/runs/33851479399.

Raw entity: https://raw.githubusercontent.com/easyhjf/startup-credits/e18d5b5598784de26cb384dc6e3660ebff3b30e0/entities/qu/quotarider.yaml

Closes #1271.