### PR TITLE
data: add Hanko startup program

### DIFF
--- a/entities/ha/hanko.yaml
+++ b/entities/ha/hanko.yaml
@@ -1,0 +1,56 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1nybq8qvtar05tbggk70yye
+  slug: hanko
+  slug_aliases: []
+  name: Hanko
+  domains:
+    - value: hanko.io
+      role: primary
+      valid_from: 2026-09-04T10:19:29.478Z
+  category: auth-security
+profile:
+  description: Hanko provides passkey-first authentication infrastructure with hosted login flows, user management, and an identity API for web and mobile applications.
+  links:
+    site: https://www.hanko.io
+sources:
+  - source_id: src_cc26ce4582876cab63a36fd6e38a0435fc7d85f16a459af1f85ccac2d0c9497e
+    url: https://www.hanko.io/startup-plan
+programs: []
+offers:
+  - offer_id: off_01m1nybq8q5c6ygc8m7tc6pgm0
+    offer_slug: hanko-startup-plan
+    offer_slug_aliases: []
+    title: Hanko Startup Plan
+    summary: One million free monthly active users on a Hanko Cloud organization, held for life or until the startup passes $500k ARR or raises more than $1M in VC funding.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-04T10:19:29.478Z
+    economics:
+      consideration:
+        kind: unknown
+        description: The source record did not establish separate consideration.
+      benefits:
+        - benefit_id: ben_primary
+          description: One million free monthly active users for a Hanko Cloud organization on the Free plan or a Pro subscription
+          kind: free-service
+          service: Hanko Cloud monthly active users
+        - benefit_id: ben_support
+          description: Free consulting and setup support, plus a backlink from Hanko's case study page
+          kind: other
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Applies for life or until the startup generates more than $500k in ARR or receives more than $1M in VC funding.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m1nybq8qvtar05tbggk70yye
+      access_operator_entity_id: ent_01m1nybq8qvtar05tbggk70yye
+    access:
+      availability: public
+      method: form
+      url: https://www.hanko.io/startup-plan
+      instructions: Submit the startup plan form with name, email, company website, message, and the Hanko Cloud organization ID when one already exists.
+    source_ids:
+      - src_cc26ce4582876cab63a36fd6e38a0435fc7d85f16a459af1f85ccac2d0c9497e


### PR DESCRIPTION
Fixes #1279

Adds `entities/ha/hanko.yaml`: one new entity and exactly one offer, no other files.

- Source: https://www.hanko.io/startup-plan (the vendor's own page, the only source cited)
- Offer: One million free monthly active users for a Hanko Cloud organization, plus free consulting and setup support.
- Eligibility: For life or until the startup passes $500k ARR or raises more than $1M in VC funding.
- Fresh `ent_`/`off_` ULIDs and one file-local `source_id`; no program record, since the entity does not publish an umbrella program name beyond this offer.
- Local preflight passes: `sourcey-catalog-verify validate startup-credits` reports `Sourcey verification passed (entities: 1, programs: 0, offers: 1)` against the pinned root set and the live parent release.
- Commit carries the DCO sign-off.