### PR TITLE
data: add Deepinfo Startup Program

### DIFF
--- a/entities/de/deepinfo.yaml
+++ b/entities/de/deepinfo.yaml
@@ -1,0 +1,76 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1q4j3mcpk6wqff4r9deywaq
+  slug: deepinfo
+  slug_aliases: []
+  name: Deepinfo
+  domains:
+    - value: deepinfo.com
+      role: primary
+      valid_from: 2026-09-04T00:00:00.000Z
+  category: auth-security
+profile:
+  description: Deepinfo provides external attack surface management, threat intelligence, brand risk protection, third-party risk management, and digital shadow intelligence.
+  links:
+    site: https://www.deepinfo.com
+sources:
+  - source_id: src_2817a1fcf11e2a579f8ae5500afd2b085436a270acc9c5a0bd439d29b70c65b6
+    url: https://www.deepinfo.com/programs/startup/
+programs:
+  - program_id: prg_01m1q4j3mh4xcbrj3h3rw5h095
+    program_slug: deepinfo-startup-program
+    program_slug_aliases: []
+    title: Deepinfo Startup Program
+    summary: Deepinfo offers discounted platform access, hands-on onboarding, a roadmap feedback channel, and a defined graduation path to qualifying early-stage companies.
+    source_ids:
+      - src_2817a1fcf11e2a579f8ae5500afd2b085436a270acc9c5a0bd439d29b70c65b6
+offers:
+  - offer_id: off_01m1q4j3mhes4ymnynmcqrkxtn
+    program_id: prg_01m1q4j3mh4xcbrj3h3rw5h095
+    offer_slug: discounted-platform-access-and-onboarding
+    offer_slug_aliases: []
+    title: Discounted Deepinfo access and onboarding
+    summary: Qualifying early-stage startups receive discounted Deepinfo platform access scaled to their stage, hands-on onboarding, a roadmap feedback channel, and a defined graduation path.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-04T00:00:00.000Z
+    economics:
+      consideration:
+        kind: variable
+        description: The startup completes a standard contract at program pricing; the public page does not publish a fixed price or discount amount.
+      benefits:
+        - benefit_id: ben_01
+          description: A significant discount on standard Deepinfo platform pricing, scaled to the startup's stage and relevant product scope.
+          kind: other
+        - benefit_id: ben_02
+          description: A working session with a Deepinfo solutions engineer for monitoring scope, alert configuration, and relevant platform capabilities.
+          kind: other
+        - benefit_id: ben_03
+          description: Access to an early-feedback channel for product roadmap input and a defined graduation path as the startup grows.
+          kind: other
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: not-machine-evaluable
+            statement: Applicant is a venture-backed or bootstrapped startup operating in technology, software, or a technology-adjacent sector.
+          - criterion_id: cri_02
+            kind: manual
+            reason: vendor-discretion
+            statement: Applicant meets Deepinfo's indicative early-stage criteria, including being founded within the last 5 years, having fewer than 50 employees, and being under the current funding ceiling.
+          - criterion_id: cri_03
+            kind: manual
+            reason: not-machine-evaluable
+            statement: Applicant is not a subsidiary of a larger organization that does not qualify for the program.
+    roles:
+      terms_authority_entity_id: ent_01m1q4j3mcpk6wqff4r9deywaq
+      access_operator_entity_id: ent_01m1q4j3mcpk6wqff4r9deywaq
+    access:
+      availability: public
+      method: form
+      url: https://www.deepinfo.com/programs/startup/
+    terms_url: https://www.deepinfo.com/programs/startup/
+    source_ids:
+      - src_2817a1fcf11e2a579f8ae5500afd2b085436a270acc9c5a0bd439d29b70c65b6


### PR DESCRIPTION
Adds Deepinfo's current startup discount and eligibility from a first-party source.

Closes #1288

## What changed

- Added a new Deepinfo entity and its named Startup Program.
- Modeled the published discounted access, onboarding session, roadmap feedback channel, graduation path, and indicative eligibility.

## Sources

- https://www.deepinfo.com/programs/startup/

## Certification

- [x] I changed only allowed repository content and did not mix Entity YAML with other paths.
- [x] Public sources substantiate every submitted factual value; any Sourcey-written prose is a neutral summary, not a fabricated vendor quote.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commits include a `Signed-off-by` line.
