### PR TITLE
data: add Hippo Video startup offer

### DIFF
--- a/entities/hi/hippo-video.yaml
+++ b/entities/hi/hippo-video.yaml
@@ -1,0 +1,81 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1q13fr88dvpnbza4awtqes5
+  slug: hippo-video
+  slug_aliases: []
+  name: Hippo Video
+  domains:
+    - value: hippovideo.io
+      role: primary
+      valid_from: 2026-09-04T20:17:38.234Z
+  category: marketing
+profile:
+  description: Hippo Video is an AI-powered video platform for personalized sales outreach, product demonstrations, customer communication, and video analytics.
+  links:
+    site: https://www.hippovideo.io
+sources:
+  - source_id: src_55a5b2585448831e12d3cee29a9cd901a5e0708800255dfd5e7c3a15689019a0
+    url: https://www.hippovideo.io/startups
+programs: []
+offers:
+  - offer_id: off_01m1q13fr86be491w537ccdktv
+    offer_slug: hippo-video-for-startups
+    offer_slug_aliases: []
+    title: Hippo Video for Startups
+    summary: Eligible startups receive three months free, then up to 70% off for one year, plus free personalization and testimonial add-ons for that year.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-04T20:17:38.234Z
+    economics:
+      consideration:
+        kind: unknown
+        description: Paid subscription is required after the three-month free period to continue receiving the discount.
+      benefits:
+        - benefit_id: ben_01
+          description: Three months of free access to Hippo Video
+          duration:
+            kind: exact
+            value: P3M
+          kind: free-service
+          service: Hippo Video
+        - benefit_id: ben_02
+          description: Up to 70% off Hippo Video plans for one year after the free period
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            kind: up-to
+            basis_points: 7000
+        - benefit_id: ben_03
+          description: Free personalization and testimonial add-ons for one year
+          duration:
+            kind: exact
+            value: P1Y
+          kind: free-service
+          service: Hippo Video personalization and testimonial add-ons
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lte
+            statement: Startup funding must not exceed $2,000,000.
+            value:
+              type: number
+              value: 2000000
+          - criterion_id: cri_02
+            kind: manual
+            statement: Applicant must be a new Hippo Video customer and cannot combine this offer with another offer or discount.
+            reason: external-verification
+    roles:
+      terms_authority_entity_id: ent_01m1q13fr88dvpnbza4awtqes5
+      access_operator_entity_id: ent_01m1q13fr88dvpnbza4awtqes5
+    access:
+      availability: public
+      method: form
+      url: https://www.hippovideo.io/startups
+    source_ids:
+      - src_55a5b2585448831e12d3cee29a9cd901a5e0708800255dfd5e7c3a15689019a0

--- a/entities/hi/hippo-video.yaml
+++ b/entities/hi/hippo-video.yaml
@@ -30,7 +30,7 @@ offers:
     economics:
       consideration:
         kind: variable
-        description: From the fourth month, discounted pricing applies for one year at 70% off annual, 65% off quarterly, or 60% off monthly billing.
+        description: Discounted pricing applies for one year from the fourth month.
       benefits:
         - benefit_id: ben_01
           description: Hippo Video is free of cost for the first three months

--- a/entities/hi/hippo-video.yaml
+++ b/entities/hi/hippo-video.yaml
@@ -10,6 +10,7 @@ entity:
       valid_from: 2026-09-04T20:17:38.234Z
   category: marketing
 profile:
+  summary: AI-powered video platform for personalized sales outreach, product demos, customer communication, and video analytics.
   description: Hippo Video is an AI-powered video platform for personalized sales outreach, product demonstrations, customer communication, and video analytics.
   links:
     site: https://www.hippovideo.io
@@ -28,18 +29,18 @@ offers:
       effective_from: 2026-09-04T20:17:38.234Z
     economics:
       consideration:
-        kind: unknown
-        description: Paid subscription is required after the three-month free period to continue receiving the discount.
+        kind: variable
+        description: From the fourth month, the startup pays the applicable Hippo Video plan price at a 70% discount for one year.
       benefits:
         - benefit_id: ben_01
-          description: Three months of free access to Hippo Video
+          description: Hippo Video is free of cost for the first three months
           duration:
             kind: exact
             value: P3M
           kind: free-service
           service: Hippo Video
         - benefit_id: ben_02
-          description: Up to 70% off Hippo Video plans for one year after the free period
+          description: A 70% discount applies from the fourth month for one year
           duration:
             kind: exact
             value: P1Y
@@ -48,12 +49,12 @@ offers:
             kind: up-to
             basis_points: 7000
         - benefit_id: ben_03
-          description: Free personalization and testimonial add-ons for one year
+          description: Premium personalization and testimonial add-ons are free for one year
           duration:
             kind: exact
             value: P1Y
           kind: free-service
-          service: Hippo Video personalization and testimonial add-ons
+          service: Premium personalization and testimonial add-ons
     eligibility:
       rule:
         kind: all
@@ -76,6 +77,6 @@ offers:
     access:
       availability: public
       method: form
-      url: https://www.hippovideo.io/startups
+      url: https://www.hippovideo.io/users/sign_up
     source_ids:
       - src_55a5b2585448831e12d3cee29a9cd901a5e0708800255dfd5e7c3a15689019a0

--- a/entities/hi/hippo-video.yaml
+++ b/entities/hi/hippo-video.yaml
@@ -30,7 +30,7 @@ offers:
     economics:
       consideration:
         kind: variable
-        description: From the fourth month, the startup pays the applicable Hippo Video plan price at a 70% discount for one year.
+        description: From the fourth month, discounted pricing applies for one year at 70% off annual, 65% off quarterly, or 60% off monthly billing.
       benefits:
         - benefit_id: ben_01
           description: Hippo Video is free of cost for the first three months
@@ -60,13 +60,9 @@ offers:
         kind: all
         rules:
           - criterion_id: cri_01
-            fact: company.funding_raised_usd
-            kind: predicate
-            operator: lte
-            statement: Startup funding must not exceed $2,000,000.
-            value:
-              type: number
-              value: 2000000
+            kind: manual
+            statement: Total funding must not exceed US$2M.
+            reason: external-verification
           - criterion_id: cri_02
             kind: manual
             statement: Applicant must be a new Hippo Video customer and cannot combine this offer with another offer or discount.


### PR DESCRIPTION
## What changed

Adds one new Entity YAML for Hippo Video and its Hippo Video for Startups offer.

Closes #1292

## Sources

- https://www.hippovideo.io/startups

## Certification

- [x] I changed only allowed repository content and did not mix Entity YAML with other paths.
- [x] Public sources substantiate every submitted factual value; any Sourcey-written prose is a neutral summary, not a fabricated vendor quote.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commits include a Signed-off-by line.