### PR TITLE
data: add SimpleLocalize startup Developer Plan offer

### DIFF
--- a/entities/si/simplelocalize.yaml
+++ b/entities/si/simplelocalize.yaml
@@ -1,0 +1,69 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1qb7dnxnxdfygk0ak64t4xz
+  slug: simplelocalize
+  slug_aliases: []
+  name: SimpleLocalize
+  domains:
+    - value: simplelocalize.io
+      role: primary
+      valid_from: 2026-09-04T23:24:19.000Z
+  category: devtools-other
+profile:
+  description: SimpleLocalize provides translation management with a web-based editor, translation hosting, APIs, and developer integrations.
+  links:
+    site: https://simplelocalize.io
+sources:
+  - source_id: src_9fe40e5b6a3d89e410625aea0710b6c5b6f9374a561b138b3f5227dfb4057e76
+    url: https://simplelocalize.io/for/startups/
+programs:
+  - program_id: prg_01m1qb7dnze7tj435pjc1ajv8s
+    program_slug: simplelocalize-startup-plan
+    program_slug_aliases: []
+    title: SimpleLocalize Startup Plan
+    summary: SimpleLocalize offers early-stage products free or discounted annual plans following application review.
+    source_ids:
+      - src_9fe40e5b6a3d89e410625aea0710b6c5b6f9374a561b138b3f5227dfb4057e76
+offers:
+  - offer_id: off_01m1qb7dnzf47pa2as46vtmreg
+    program_id: prg_01m1qb7dnze7tj435pjc1ajv8s
+    offer_slug: simplelocalize-startup-developer-plan-free-first-year
+    offer_slug_aliases: []
+    title: SimpleLocalize Developer Plan Free First Year for Startups
+    summary: Approved startups contributing to the community receive the Developer Plan free for their first year; auto-translation characters are excluded.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-04T23:24:19.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          kind: free-service
+          service: SimpleLocalize Developer Plan
+          description: Developer Plan free for the first year, excluding auto-translation characters.
+          duration:
+            kind: exact
+            value: P1Y
+      consideration:
+        kind: variable
+        description: A community contribution, such as sharing the product experience through a blog post or social-media mention, is required for the free plan.
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: vendor-discretion
+            statement: SimpleLocalize must approve the application for a genuine early-stage product; established companies seeking lower costs are excluded.
+          - criterion_id: cri_02
+            kind: manual
+            reason: external-verification
+            statement: The applicant contributes to the community to qualify for the free Developer Plan.
+    roles:
+      terms_authority_entity_id: ent_01m1qb7dnxnxdfygk0ak64t4xz
+      access_operator_entity_id: ent_01m1qb7dnxnxdfygk0ak64t4xz
+    access:
+      availability: public
+      method: form
+      url: https://simplelocalize.io/startup-form/
+    source_ids:
+      - src_9fe40e5b6a3d89e410625aea0710b6c5b6f9374a561b138b3f5227dfb4057e76

--- a/entities/si/simplelocalize.yaml
+++ b/entities/si/simplelocalize.yaml
@@ -10,6 +10,7 @@ entity:
       valid_from: 2026-09-04T23:24:19.000Z
   category: devtools-other
 profile:
+  summary: SimpleLocalize is a translation management platform with a web-based editor, translation hosting, APIs, and developer integrations.
   description: SimpleLocalize provides translation management with a web-based editor, translation hosting, APIs, and developer integrations.
   links:
     site: https://simplelocalize.io


### PR DESCRIPTION
## What changed

Closes #1302.

Adds SimpleLocalize and one startup-specific offer: the Developer Plan free for the first year, conditional on application approval and a community contribution. Auto-translation characters are excluded. The contribution is represented in consideration and eligibility; no monetary value or numerical startup threshold is invented. The Entity includes the required neutral `profile.summary`.

Only `entities/si/simplelocalize.yaml` changes. The separate Team Plan and discounted alternatives are outside this single-offer contribution.

## Sources

- https://simplelocalize.io/for/startups/

## Validation

The repository-pinned `@sourcey/catalog-verifier` 1.0.0 passed locally with a fresh signed Sourcey identity context: one Entity, one Program, one Offer. The published Git tree and YAML blob match the validated local candidate exactly. Public validation and DCO passed on current head `2c46c3e856a6c21f1d0d894976684af486107aac`: [CI run](https://github.com/sourcey/startup-credits/actions/runs/34129886363). Private admission for this head is pending.

Reviewable artifacts:

- [Current raw YAML](https://raw.githubusercontent.com/koksny/startup-credits/2c46c3e856a6c21f1d0d894976684af486107aac/entities/si/simplelocalize.yaml)
- [Signed-off correction commit](https://github.com/koksny/startup-credits/commit/2c46c3e856a6c21f1d0d894976684af486107aac)

## Admission follow-up

The [September 6 report for the previous head](https://artifacts.sourcey.com/catalog/admission-results/sha256-7037d75d2e37d0a4bb3a57904ebde1cce13470958f808260a65c4cc58fb50292/report.json) rejected it for `claim_unresolved`, `claim_unsupported`, `entity_summary_required`, and `exact_conflict`. The correction adds the missing Entity summary. The existing source still describes the selected offer's benefits and conditions under “What are the limits?”, “Want to contribute?”, and “How to start?”; those terms and IDs are unchanged.

The report's conflict references are #1369 and #1370, opened September 5 at 22:04 UTC. This PR was opened September 4 at 23:35 UTC, after the [reservation comment](https://github.com/sourcey/startup-credits/issues/1302#issuecomment-5547631175) at 23:30 UTC. The duplicate conflict and evidence judgments remain for Sourcey to resolve.

## Certification

- [x] I changed only allowed repository content and did not mix Entity YAML with other paths.
- [x] Public sources substantiate every submitted factual value; Sourcey-written prose is a neutral summary.
- [x] I did not author verification, provenance, freshness, or signature claims in the data.
- [x] My commits include a `Signed-off-by` line.

This contribution is intended for [Frantic bounty #120](https://gofrantic.com/bounties/120). Submission does not imply acceptance, payment, or Sourcey publication.
