### PR TITLE
data: add Royall for Startups offer

### DIFF
--- a/entities/ro/royall.yaml
+++ b/entities/ro/royall.yaml
@@ -1,0 +1,92 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1rgkfy3fw0pd11qcj7dnebr
+  slug: royall
+  slug_aliases: []
+  name: Royall
+  domains:
+    - value: royall.ai
+      role: primary
+      valid_from: 2026-09-05T10:05:00.000Z
+  category: auth-security
+profile:
+  description: Royall provides an API for identity resolution, real-time consent checks, license routing, and webhooks for AI products that use real people likenesses.
+  links:
+    site: https://royall.ai
+sources:
+  - source_id: src_fd005a045fc7621c25a5eb484c0f668cea2ef2ddf7b5a0a20adaa60c79dc0009
+    url: https://royall.ai/startups
+programs:
+  - program_id: prg_01m1rgkfy6e5k2dtfpmej6pq3v
+    program_slug: royall-for-startups
+    program_slug_aliases: []
+    title: Royall for Startups
+    summary: Royall for Startups gives eligible early-stage AI startups twelve months of full production Royall API access at no cost, plus onboarding support.
+    source_ids:
+      - src_fd005a045fc7621c25a5eb484c0f668cea2ef2ddf7b5a0a20adaa60c79dc0009
+offers:
+  - offer_id: off_01m1rgkfy6a40xrfen7fh3b8ze
+    program_id: prg_01m1rgkfy6e5k2dtfpmej6pq3v
+    offer_slug: twelve-months-free-full-production-api-access
+    offer_slug_aliases: []
+    title: 12 months free full production Royall API access
+    summary: Eligible early-stage AI startups receive twelve months of full production Royall API access for consent checks, identity resolution, licensing, and webhooks at no cost.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-05T10:05:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Twelve months of full production Royall API access including consent checks, identity resolution, licensing, and webhooks
+          duration:
+            kind: exact
+            value: P1Y
+          kind: other
+        - benefit_id: ben_02
+          description: White-glove onboarding with a shared Slack channel, integration reviews, and help shipping the first verified consent check
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: The company has raised under $3M or is at pre-seed or seed stage.
+          - criterion_id: cri_02
+            fact: company.employee_count
+            kind: predicate
+            operator: lt
+            statement: The company has under 15 employees.
+            value:
+              type: number
+              value: 15
+          - criterion_id: cri_03
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: The company was founded within the last 3 years.
+            value:
+              type: number
+              value: 36
+          - criterion_id: cri_04
+            kind: manual
+            reason: external-verification
+            statement: The company is building a product that generates, hosts, or authenticates media featuring real people.
+          - criterion_id: cri_05
+            kind: manual
+            reason: external-verification
+            statement: The company is not currently a paying Royall customer.
+    roles:
+      terms_authority_entity_id: ent_01m1rgkfy3fw0pd11qcj7dnebr
+      access_operator_entity_id: ent_01m1rgkfy3fw0pd11qcj7dnebr
+    access:
+      availability: public
+      method: form
+      url: https://royall.ai/startups
+      instructions: Complete the application on the Royall for Startups page. Applications are reviewed within about 3 business days.
+    terms_url: https://royall.ai/startups
+    source_ids:
+      - src_fd005a045fc7621c25a5eb484c0f668cea2ef2ddf7b5a0a20adaa60c79dc0009

--- a/entities/ro/royall.yaml
+++ b/entities/ro/royall.yaml
@@ -38,9 +38,6 @@ offers:
       benefits:
         - benefit_id: ben_01
           description: Twelve months of full production Royall API access including consent checks, identity resolution, licensing, and webhooks
-          duration:
-            kind: exact
-            value: P1Y
           kind: other
         - benefit_id: ben_02
           description: White-glove onboarding with a shared Slack channel, integration reviews, and help shipping the first verified consent check


### PR DESCRIPTION
## Summary
Adds Royall (royall.ai) startup program as a data-only entity: 12 months free full production API access for eligible early-stage AI startups.

## Source
- First-party page: https://royall.ai/startups
- Missing-record issue: #904

## Test plan
- [ ] `sourcey/validation` green
- [ ] `sourcey/admission` covers cited facts against royall.ai/startups

Signed-off-by in commit.

Made with [Cursor](https://cursor.com)