### PR TITLE
data: add Cyberport CCMF Hong Kong grant

### DIFF
--- a/entities/cy/cyberport.yaml
+++ b/entities/cy/cyberport.yaml
@@ -78,7 +78,7 @@ offers:
           - criterion_id: cri_06
             kind: manual
             reason: external-verification
-            statement: Applicants must be the project's original creators, respect third-party intellectual property, and disclose other funding applications, admissions, grants, and subsequent changes.
+            statement: Applicants must be the project's original creators and, to their knowledge, its product or service must not already be available or under development elsewhere. They must respect third-party intellectual property and disclose other funding applications, admissions, grants, and subsequent changes.
           - criterion_id: cri_07
             kind: manual
             reason: vendor-discretion

--- a/entities/cy/cyberport.yaml
+++ b/entities/cy/cyberport.yaml
@@ -1,0 +1,97 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1rpyrcnst97nkp53jvx0k86
+  slug: cyberport
+  slug_aliases: []
+  name: Cyberport
+  domains:
+    - value: cyberport.hk
+      role: primary
+      valid_from: 2026-09-05T11:58:40.020Z
+  category: other
+profile:
+  description: Cyberport is Hong Kong's digital technology hub and AI accelerator, supporting entrepreneurs with funding, incubation, business networks, and office space.
+  links:
+    site: https://www.cyberport.hk/en/about_us/vision_focus/
+sources:
+  - source_id: src_cb2cb0b24fb48352b22e0bf5da633594e96a23e21953e04705546291d89f9417
+    url: https://www.cyberport.hk/en/entrepreneurship/hong_kong_programme/
+  - source_id: src_e3f5921002ef193e9aabccda664012d1d38d5a1777fefd661d248f87abd381c7
+    url: https://www.cyberport.hk/wp-content/uploads/ENC.RF_.015a-GN_for_Applicants-CCMF-HK_Programme.pdf
+  - source_id: src_51a86e76cb6715a5a67080db63a43f6c8032a3659c6e6634812124c2aade861d
+    url: https://www.cyberport.hk/en/about_us/vision_focus/
+programs:
+  - program_id: prg_01m1rpyrcpvzznv19js6tkd8jf
+    program_slug: creative-micro-fund
+    program_slug_aliases: []
+    title: Cyberport Creative Micro Fund
+    summary: Cyberport's Creative Micro Fund supports digital technology projects and early-stage startups with seed funding and entrepreneurial support.
+    source_ids:
+      - src_cb2cb0b24fb48352b22e0bf5da633594e96a23e21953e04705546291d89f9417
+offers:
+  - offer_id: off_01m1rpyrcpffk79z3vkncwfx2s
+    program_id: prg_01m1rpyrcpvzznv19js6tkd8jf
+    offer_slug: ccmf-hong-kong-programme
+    offer_slug_aliases: []
+    title: CCMF Hong Kong Programme startup grant
+    summary: Selected digital technology projects at the idea or early development stage can receive up to HKD 100,000 in staged cash funding and entrepreneurial support during a six-month programme.
+    lifecycle:
+      status: active
+      effective_from: 2026-03-26T00:00:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          kind: other
+          description: Up to HKD 100,000 in cash funding over six months, paid as HKD 10,000 after signing the grant agreement, HKD 45,000 after interim-report approval, and HKD 45,000 after project completion and final-report approval.
+        - benefit_id: ben_02
+          kind: other
+          description: Training, mentorship, business advice, business and investment connections, publicity, and access to Cyberport's business and alumni networks.
+      consideration:
+        kind: unknown
+        description: The cited programme page and applicant guidance do not specify a participation price or equity consideration.
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: Projects must involve digital technology and be at the idea or early development stage before admission.
+          - kind: any
+            rules:
+              - criterion_id: cri_02
+                kind: manual
+                reason: external-verification
+                statement: Individual applications require a principal applicant aged at least 18 who holds a Hong Kong Identity Card.
+              - criterion_id: cri_03
+                kind: manual
+                reason: external-verification
+                statement: Company applications require a Hong Kong registered and incorporated limited company and founders, co-founders, and directors aged at least 18.
+          - criterion_id: cri_04
+            kind: manual
+            reason: external-verification
+            statement: The same or a similar project must not have previously entered a CCMF programme or the Cyberport Incubation Programme.
+          - criterion_id: cri_05
+            kind: manual
+            reason: external-verification
+            statement: Applicants and relevant founders or directors cannot have a same or similar project currently in, or graduated from, HKDC or HKSTP seed funding, pre-incubation, or incubation. Such funding or offers must not be accepted before or during application or the project period.
+          - criterion_id: cri_06
+            kind: manual
+            reason: external-verification
+            statement: Applicants must be the project's original creators, respect third-party intellectual property, and disclose other funding applications, admissions, grants, and subsequent changes.
+          - criterion_id: cri_07
+            kind: manual
+            reason: vendor-discretion
+            statement: Admission requires screening, vetting, and a presentation with questions for shortlisted applicants. Funding is subject to Cyberport's final selection.
+    roles:
+      terms_authority_entity_id: ent_01m1rpyrcnst97nkp53jvx0k86
+      access_operator_entity_id: ent_01m1rpyrcnst97nkp53jvx0k86
+    access:
+      availability: public
+      method: form
+      url: https://ems.cyberport.hk/form/
+      instructions: Apply through EMS using the principal applicant or a company founder, co-founder, or director. The next published deadline is 1 December 2026 for the February 2027 intake. Selected applicants must return the agreement within 30 days, complete the project within six months, and submit interim and final reports. Funds go to the individual or company recipient's Hong Kong bank account. Breach of programme conditions may require withdrawal and repayment.
+    terms_url: https://www.cyberport.hk/wp-content/uploads/ENC.RF_.015a-GN_for_Applicants-CCMF-HK_Programme.pdf
+    source_ids:
+      - src_cb2cb0b24fb48352b22e0bf5da633594e96a23e21953e04705546291d89f9417
+      - src_e3f5921002ef193e9aabccda664012d1d38d5a1777fefd661d248f87abd381c7


### PR DESCRIPTION
## What changed

Closes #1322. Adds one new Cyberport entity and one CCMF Hong Kong Programme offer for early-stage digital technology projects.

- Preserves the staged HKD 100,000 cash grant, six-month project period, eligibility routes, project originality, overlapping-programme exclusions, and reporting conditions.
- Records the next published deadline (1 December 2026 for February 2027 intake).
- Models cash funding as `kind: other`, since the pinned contract has no grant benefit kind; the amount, currency, and payment stages remain explicit.

## Sources

- Programme: https://www.cyberport.hk/en/entrepreneurship/hong_kong_programme/
- Applicant guidance, revision 8 effective 26 March 2026: https://www.cyberport.hk/wp-content/uploads/ENC.RF_.015a-GN_for_Applicants-CCMF-HK_Programme.pdf
- Entity: https://www.cyberport.hk/en/about_us/vision_focus/

## Validation

The lockfile-pinned `contributionEntityAuthoringSchema` accepts the final YAML; `git diff --check` passes. Both commits have DCO sign-off. Full signed identity-context and changed-closure validation is pending automatic `sourcey/validation`: the public context API was unavailable from the local environment. No full-verifier or factual-admission pass is claimed.

Prepared with AI assistance and checked against the first-party material.

## Certification

- [x] Only one Entity YAML file changes.
- [x] Submitted facts use first-party sources; prose is a neutral summary.
- [x] No verification, provenance, freshness, or signature claims were authored.
- [x] Commits include a `Signed-off-by` line.
