### PR TITLE
data: add Lettermint startup account credit

### DIFF
--- a/entities/le/lettermint.yaml
+++ b/entities/le/lettermint.yaml
@@ -1,0 +1,86 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1rr3w4h8hbspth6ckmjdqqa
+  slug: lettermint
+  slug_aliases: []
+  name: Lettermint
+  domains:
+    - value: lettermint.co
+      role: primary
+      valid_from: 2026-09-05T00:00:00.000Z
+  category: communication
+profile:
+  description: Lettermint provides transactional email delivery.
+  links:
+    site: https://lettermint.co
+sources:
+  - source_id: src_9ab3f3ff9aae910fa06db6bbdde00123b6fa32a48c93d6c5f7c8232756dcb0b7
+    url: https://lettermint.co/promo-codes-and-discounts/startups
+programs: []
+offers:
+  - offer_id: off_01m1rr3w4j16e2n4sgwhey49y2
+    offer_slug: startup-account-credit
+    offer_slug_aliases: []
+    title: EUR 60 startup account credit
+    summary: Eligible unfunded startups can apply for EUR 60 in subscription credit, valid for 12 months after activation.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-05T00:00:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          kind: credit
+          description: Account credit usable across Lettermint subscriptions.
+          value:
+            kind: exact
+            amount:
+              currency: EUR
+              minor_units: 6000
+          duration:
+            kind: exact
+            value: P12M
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: predicate
+            fact: company.funding_raised_usd
+            operator: eq
+            value:
+              type: number
+              value: 0
+            statement: The startup has raised no funding.
+          - criterion_id: cri_02
+            kind: predicate
+            fact: company.age_months
+            operator: lte
+            value:
+              type: number
+              value: 36
+            statement: The startup is at most three years old.
+          - criterion_id: cri_03
+            kind: manual
+            reason: not-machine-evaluable
+            statement: Annual recurring revenue is at most EUR 100,000.
+          - criterion_id: cri_04
+            kind: manual
+            reason: not-machine-evaluable
+            statement: The startup is a registered company.
+          - criterion_id: cri_05
+            kind: manual
+            reason: not-machine-evaluable
+            statement: The startup has not previously applied for Lettermint's startup discount.
+    roles:
+      terms_authority_entity_id: ent_01m1rr3w4h8hbspth6ckmjdqqa
+      access_operator_entity_id: ent_01m1rr3w4h8hbspth6ckmjdqqa
+    access:
+      availability: public
+      method: form
+      url: https://lettermint.co/promo-codes-and-discounts/startups
+      instructions: Create and verify a free account, configure the domain and project, then request the startup discount through dashboard Support. Approval is confirmed by email.
+    terms_url: https://lettermint.co/promo-codes-and-discounts/startups
+    source_ids:
+      - src_9ab3f3ff9aae910fa06db6bbdde00123b6fa32a48c93d6c5f7c8232756dcb0b7


### PR DESCRIPTION
Adds one Lettermint entity with one startup-specific offer: EUR 60 in account credit, valid for 12 months after activation, for qualifying registered, unfunded startups.

Source: https://lettermint.co/promo-codes-and-discounts/startups

The page's introductory six-month Pro wording differs from its detailed FAQ. This record uses the FAQ's explicit EUR 60 account credit and 12-month validity, without asserting six months of any specific plan. Eligibility and the support-request application route are included.

Prepared with AI assistance for Frantic bounty #120. No claim of vendor affiliation or Sourcey verification.

Closes #1324

Validation: canonical local Sourcey verifier passed for one entity and one offer; public CI will validate this signed-off commit.
