### PR TITLE
Add WE.VESTR Grow discount for Microsoft for Startups members

### DIFF
--- a/entities/we/wevestr.yaml
+++ b/entities/we/wevestr.yaml
@@ -1,0 +1,72 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1s03pxm26znwefpb8h1aewx
+  slug: wevestr
+  slug_aliases: []
+  name: WE.VESTR
+  domains:
+    - value: wevestr.com
+      role: primary
+      valid_from: 2026-09-05T14:35:00.000Z
+  category: finance-accounting
+profile:
+  description: WE.VESTR provides equity management software for cap tables, shareholder reporting, fundraising, and employee equity plans.
+  links:
+    site: https://wevestr.com/
+sources:
+  - source_id: src_20d5d2e5406b5de70c762837f1fc686a409782108a7a5cf4f56bf2bea9eeff85
+    url: https://wevestr.com/microsoft-for-startups
+  - source_id: src_d2e33b5e533d1c25998e0a5f6546dad82e87a6b876f89976d1f4bd18041deaf0
+    url: https://learn.microsoft.com/en-us/startups/benefits/technical-benefits/third-party-benefits/we-vestr
+programs: []
+offers:
+  - offer_id: off_01m1s03pxmsy9kg3ss4y9p8y96
+    offer_slug: microsoft-for-startups-paid-plan-discount
+    offer_slug_aliases: []
+    title: 70% off WE.VESTR paid plans for Microsoft for Startups members
+    summary: Eligible new WE.VESTR customers with 30 or more stakeholders receive 70% off paid plans for their first 12 months through Microsoft for Startups.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-05T14:35:00.000Z
+    economics:
+      consideration:
+        kind: variable
+        description: A paid WE.VESTR subscription is required; the discounted price depends on the selected plan and stakeholder count.
+      benefits:
+        - benefit_id: ben_paid_plan_discount
+          kind: discount
+          description: 70% off a paid WE.VESTR plan for the first year from activation.
+          percentage:
+            kind: exact
+            basis_points: 7000
+          duration:
+            kind: exact
+            value: P1Y
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - kind: manual
+            criterion_id: cri_microsoft_membership
+            statement: The startup is backed by a VC, accelerator, incubator, or university in the Microsoft Investor Network and has this benefit available in Microsoft for Startups.
+            reason: external-verification
+          - kind: manual
+            criterion_id: cri_new_customer
+            statement: The startup is a new WE.VESTR customer.
+            reason: external-verification
+          - kind: manual
+            criterion_id: cri_paid_plan_stakeholders
+            statement: The startup has 30 or more stakeholders and selects a paid plan. Stakeholders include founders, employees with equity, investors, advisors, or anyone holding shares or options.
+            reason: external-verification
+    roles:
+      terms_authority_entity_id: ent_01m1s03pxm26znwefpb8h1aewx
+      access_operator_entity_id: ent_01kyh8fpe3n3yye39kmzvy410z
+    access:
+      availability: membership
+      method: other
+      url: https://portal.startups.microsoft.com/login
+      instructions: Sign in to Microsoft for Startups, open Benefits, and redeem WE.VESTR. Follow the vendor landing-page prompts; membership verification is required for the discount.
+    terms_url: https://wevestr.com/terms-and-conditions
+    source_ids:
+      - src_20d5d2e5406b5de70c762837f1fc686a409782108a7a5cf4f56bf2bea9eeff85
+      - src_d2e33b5e533d1c25998e0a5f6546dad82e87a6b876f89976d1f4bd18041deaf0

--- a/entities/we/wevestr.yaml
+++ b/entities/we/wevestr.yaml
@@ -17,25 +17,27 @@ sources:
   - source_id: src_20d5d2e5406b5de70c762837f1fc686a409782108a7a5cf4f56bf2bea9eeff85
     url: https://wevestr.com/microsoft-for-startups
   - source_id: src_d2e33b5e533d1c25998e0a5f6546dad82e87a6b876f89976d1f4bd18041deaf0
-    url: https://learn.microsoft.com/en-us/startups/benefits/technical-benefits/third-party-benefits/we-vestr
+    url: https://wevestr.com/pricing
 programs: []
 offers:
   - offer_id: off_01m1s03pxmsy9kg3ss4y9p8y96
     offer_slug: microsoft-for-startups-paid-plan-discount
     offer_slug_aliases: []
-    title: 70% off WE.VESTR paid plans for Microsoft for Startups members
-    summary: Eligible new WE.VESTR customers with 30 or more stakeholders receive 70% off paid plans for their first 12 months through Microsoft for Startups.
+    title: WE.VESTR Grow first-year discount for Microsoft for Startups members
+    summary: Verified Microsoft for Startups Founders Hub members can start the Grow plan at EUR 45 per month, excluding VAT, for the first year instead of the standard EUR 150 monthly rate.
     lifecycle:
       status: active
       effective_from: 2026-09-05T14:35:00.000Z
     economics:
       consideration:
-        kind: variable
-        description: A paid WE.VESTR subscription is required; the discounted price depends on the selected plan and stakeholder count.
+        kind: fixed
+        amount:
+          currency: EUR
+          minor_units: 4500
       benefits:
         - benefit_id: ben_paid_plan_discount
           kind: discount
-          description: 70% off a paid WE.VESTR plan for the first year from activation.
+          description: Grow costs EUR 45 per month excluding VAT for the first year instead of the standard EUR 150 per month. The vendor shows the first month free on both plans.
           percentage:
             kind: exact
             basis_points: 7000
@@ -48,24 +50,24 @@ offers:
         rules:
           - kind: manual
             criterion_id: cri_microsoft_membership
-            statement: The startup is backed by a VC, accelerator, incubator, or university in the Microsoft Investor Network and has this benefit available in Microsoft for Startups.
+            statement: The applicant is a Microsoft for Startups Founders Hub member and completes WE.VESTR's membership verification for the discount.
             reason: external-verification
           - kind: manual
             criterion_id: cri_new_customer
-            statement: The startup is a new WE.VESTR customer.
+            statement: The applicant starts a new Grow subscription using WE.VESTR's dedicated Microsoft for Startups onboarding link.
             reason: external-verification
           - kind: manual
             criterion_id: cri_paid_plan_stakeholders
-            statement: The startup has 30 or more stakeholders and selects a paid plan. Stakeholders include founders, employees with equity, investors, advisors, or anyone holding shares or options.
+            statement: The applicant selects the Grow plan, which supports up to 50 stakeholders.
             reason: external-verification
     roles:
       terms_authority_entity_id: ent_01m1s03pxm26znwefpb8h1aewx
-      access_operator_entity_id: ent_01kyh8fpe3n3yye39kmzvy410z
+      access_operator_entity_id: ent_01m1s03pxm26znwefpb8h1aewx
     access:
       availability: membership
-      method: other
-      url: https://portal.startups.microsoft.com/login
-      instructions: Sign in to Microsoft for Startups, open Benefits, and redeem WE.VESTR. Follow the vendor landing-page prompts; membership verification is required for the discount.
+      method: form
+      url: https://wevestr.com/microsoft-for-startups
+      instructions: Use the Grow plan's Start for Free link on the vendor's Microsoft for Startups page and complete WE.VESTR's membership verification. Prices exclude VAT and use monthly invoicing; the discount applies for the first year.
     terms_url: https://wevestr.com/terms-and-conditions
     source_ids:
       - src_20d5d2e5406b5de70c762837f1fc686a409782108a7a5cf4f56bf2bea9eeff85


### PR DESCRIPTION
## What changed

Add WE.VESTR and one vendor-operated startup offer: the Grow plan's first-year price for verified Microsoft for Startups Founders Hub members. The vendor's dedicated page offers a direct signup flow and says membership must be verified for the discount.

- Exactly one new file, `entities/we/wevestr.yaml`, containing one offer.
- Grow is EUR 45 per month excluding VAT on the member page versus EUR 150 per month excluding VAT on the ordinary pricing page. Both use monthly invoicing and both show the first month free. The structured discount is the arithmetic difference: `(150 - 45) / 150 = 70%`.
- The offer records the first-year duration, Grow's limit of 50 stakeholders, paid-subscription consideration, and membership verification. The free Launch plan and separate Scale plan are outside this contribution.
- WE.VESTR is both the terms authority and the access operator for this direct vendor signup route. This is not a general free tier, ordinary trial, public coupon, or referral reward.

Closes #1328.

## Sources

- Vendor's member-offer page: https://wevestr.com/microsoft-for-startups
- Vendor's standard pricing: https://wevestr.com/pricing
- Vendor terms: https://wevestr.com/terms-and-conditions

Checked September 5, 2026 in a public browser without signing in. The member page states that the discount applies for the first year and on verification of Microsoft for Startups Founders Hub membership. It lists Grow at EUR 45/month and up to 50 stakeholders; the ordinary pricing page lists Grow at EUR 150/month with the same stakeholder limit.

Plain HTTP requests from my environment return 403, while the pages render publicly in a browser. That fetch limitation remains explicit. The 70% figure is calculated from the two displayed vendor prices, not presented as a verbatim vendor quote. No annual savings amount is claimed.

## Review evidence

- Raw YAML pinned to the submitted head: https://raw.githubusercontent.com/hide10/startup-credits/f1afe23090a117cf95ab3722fa2d9869fe78f477/entities/we/wevestr.yaml
- The submitted head passed the current lockfile-pinned Catalog Verifier with a signed live identity context: 1 entity, 0 programs, 1 offer. The GitHub checks below provide the public PR-head result.
- Public entity lookup for `wevestr` returned not_found, and open PR/issue searches found no existing submission before reservation #1328.
- Both commits carry DCO sign-offs. Only the Entity YAML is in the PR diff; no scripts, workflow changes, captures, or generated evidence are included.

Sourcey admission, publication, and any external bounty acceptance remain unconfirmed.

## Certification

- [x] I changed only allowed repository content and did not mix Entity YAML with other paths.
- [x] Public sources substantiate every submitted factual value; any Sourcey-written prose is a neutral summary, not a fabricated vendor quote.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commits include a `Signed-off-by` line.
