### PR TITLE
docs: show profile.summary on every entity

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,9 +20,11 @@ For a new record, copy a nearby Entity file and preserve the shape:
 - Use only a category from the exact `taxonomy.json` bundled with the pinned Catalog Verifier.
   The local preflight downloads that file, and both local and CI failures print the complete
   current list; a nearby legacy record is not taxonomy authority.
+- Give every Entity a `profile.summary`: one or two plain sentences about what the company does.
+  Machine admission requires it; a submission without it is asked to add one.
 - Keep `profile.description` to 200 characters and describe the Entity itself, not its Offers.
-- Keep each `summary` to 240 characters: it is the compact public synopsis used in listings and
-  metadata. An Offer may use optional `description` for longer source-backed context. Economics,
+- Keep each `summary` (`profile.summary` and every Offer `summary`) to 240 characters: it is the
+  compact public synopsis used in listings and metadata. An Offer may use optional `description` for longer source-backed context. Economics,
   eligibility, and access still belong in their structured fields rather than repeated prose.
 
 Generate fresh IDs with Node's built-in crypto support. The first command prints one Entity,

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ entity:
       valid_from: 2026-01-01T00:00:00.000Z
   category: productivity
 profile:
+  summary: Collaboration and developer tools for software teams.
   description: Atlassian makes collaboration and developer tools for software teams.
   links:
     site: https://www.atlassian.com/


### PR DESCRIPTION
Machine admission requires `profile.summary` on every Entity, but the README example and CONTRIBUTING never showed it, so submissions failed with `entity_summary_required` without a visible reason. This adds the field to the example and names it in the contributing rules.