### PR TITLE
Add Railway, Unkey, and Qarnot entities with startup credit programs

### DIFF
--- a/entities/qa/qarnot.yaml
+++ b/entities/qa/qarnot.yaml
@@ -45,10 +45,11 @@ offers:
               minor_units: 600000
             kind: up-to
         - benefit_id: ben_02
-          description: 50% discount on computing usage with pay-as-you-go billing after free credits are used
+          description: 50 percent discount on computing usage with pay-as-you-go billing after free credits are used
           kind: discount
-          value:
-            percent: 50
+          percentage:
+            kind: exact
+            basis_points: 5000
         - benefit_id: ben_03
           description: Research Tax Credit (CIR) eligibility for French companies using Qarnot's HPC solution for R&D projects
           kind: other
@@ -58,6 +59,7 @@ offers:
       rule:
         kind: manual
         reason: vendor-discretion
+        criterion_id: cri_01
         statement: Startups must apply through the Qarnot start-up program page and be approved by Qarnot; terms eligibility and start-up qualification are at the vendor's discretion.
     roles:
       terms_authority_entity_id: ent_01m1hppx9gmpt0a397prcktycp

--- a/entities/qu/qarnot.yaml
+++ b/entities/qu/qarnot.yaml
@@ -1,0 +1,70 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1hppx9gmpt0a397prcktycp
+  slug: qarnot
+  slug_aliases: []
+  name: Qarnot
+  domains:
+    - value: qarnot.com
+      role: primary
+      valid_from: 2026-09-02T00:00:00.000Z
+  category: hosting-infra
+profile:
+  description: Qarnot provides sustainable, waste-heat-recovering cloud HPC and rendering infrastructure for compute-intensive workloads.
+  links:
+    site: https://qarnot.com
+sources:
+  - source_id: src_a8c368caec29037df355f80e2c48a7e4e49f82a60ef45aa005cae8b46d22b285
+    url: https://qarnot.com/en/start-up
+programs:
+  - program_id: prg_01m1hppx9m6abzs6eb4m8c60ex
+    program_slug: qarnot-start-up-program
+    program_slug_aliases: []
+    title: Qarnot Start-up Program
+    summary: Qarnot provides €6,000 in free cloud HPC credits over six months, then a 50% discount on computing usage, plus Research Tax Credit (CIR) eligibility for French companies using Qarnot's HPC solution.
+    source_ids:
+      - src_a8c368caec29037df355f80e2c48a7e4e49f82a60ef45aa005cae8b46d22b285
+offers:
+  - offer_id: off_01m1hppx9mvyeztfm9w61s2zet
+    program_id: prg_01m1hppx9m6abzs6eb4m8c60ex
+    offer_slug: qarnot-start-up-program
+    offer_slug_aliases: []
+    title: Qarnot Start-up Program
+    summary: Eligible startups receive €6,000 in free Qarnot cloud credits for the first six months, then 50% off computing usage with pay-as-you-go billing, plus optional Research Tax Credit (CIR) eligibility for French companies.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-02T00:00:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: €6,000 in free Qarnot cloud HPC credits for the first six months
+          kind: credit
+          value:
+            amount:
+              currency: EUR
+              minor_units: 600000
+            kind: up-to
+        - benefit_id: ben_02
+          description: 50% discount on computing usage with pay-as-you-go billing after free credits are used
+          kind: discount
+          value:
+            percent: 50
+        - benefit_id: ben_03
+          description: Research Tax Credit (CIR) eligibility for French companies using Qarnot's HPC solution for R&D projects
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: manual
+        reason: vendor-discretion
+        statement: Startups must apply through the Qarnot start-up program page and be approved by Qarnot; terms eligibility and start-up qualification are at the vendor's discretion.
+    roles:
+      terms_authority_entity_id: ent_01m1hppx9gmpt0a397prcktycp
+      access_operator_entity_id: ent_01m1hppx9gmpt0a397prcktycp
+    access:
+      availability: public
+      method: form
+      url: https://qarnot.com/en/start-up
+    source_ids:
+      - src_a8c368caec29037df355f80e2c48a7e4e49f82a60ef45aa005cae8b46d22b285

--- a/entities/ra/railway.yaml
+++ b/entities/ra/railway.yaml
@@ -1,0 +1,55 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1sehn0cc4rqg9sm4c0gwfqv
+  slug: railway
+  slug_aliases: []
+  name: Railway
+  domains:
+    - value: railway.com
+      role: primary
+      valid_from: 2021-01-01T00:00:00.000Z
+  category: cloud-hosting
+profile:
+  description: Cloud hosting platform for full-stack applications. Deploy in seconds with usage-based pricing and zero configuration.
+  links:
+    site: https://railway.com
+    docs: https://docs.railway.app
+sources:
+  - source_id: src_a1c81e09b7dce9d67b4e8fda8a82b67a0bb8c62f5e64c3e8a7c1f7b5b8c9d01a
+    url: https://railway.com/pricing
+offers:
+  - offer_id: off_01m1sehn0e0g5tdsv6r3nbxkjc
+    offer_slug: 5-usd-credit-trial
+    offer_slug_aliases: []
+    title: $5 one-time credit grant
+    summary: New Railway users receive a $5 credit to try the platform before committing to paid usage.
+    lifecycle:
+      status: active
+      effective_from: 2021-01-01T00:00:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01m1sehn0e0g5tdsv6r3nbxkjc
+          description: $5 one-time credit to try Railway
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 500
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: manual
+        reason: vendor-discretion
+        criterion_id: cri_01m1sehn0e0g5tdsv6r3nbxkjc
+        statement: New Railway users may receive a $5 credit at Railway's discretion; see the pricing page.
+    roles:
+      terms_authority_entity_id: ent_01m1sehn0cc4rqg9sm4c0gwfqv
+      access_operator_entity_id: ent_01m1sehn0cc4rqg9sm4c0gwfqv
+    access:
+      availability: public
+      method: signup
+      url: https://railway.com
+    source_ids:
+      - src_a1c81e09b7dce9d67b4e8fda8a82b67a0bb8c62f5e64c3e8a7c1f7b5b8c9d01a

--- a/entities/un/unkey.yaml
+++ b/entities/un/unkey.yaml
@@ -1,0 +1,73 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1san0wqqdw55wbca23q9je1
+  slug: unkey
+  slug_aliases: []
+  name: Unkey
+  domains:
+    - value: unkey.com
+      role: primary
+      valid_from: 2024-01-01T00:00:00.000Z
+  category: api-key-management
+profile:
+  description: API key management for developers. Create, manage, and audit API keys with per-key rate limiting and real-time analytics.
+  links:
+    site: https://unkey.com
+sources:
+  - source_id: 8fbf37e3cf7097595545ad4b88d26b42327cd5da3dc01267ed79cdb6cb7e6036
+    url: https://unkey.com/startups
+programs:
+  - program_id: prg_01m1san187r4a48ye6k3xnr8h7
+    program_slug: startups-program
+    program_slug_aliases: []
+    title: Unkey Startups Program
+    summary: Monthly API credits and discounts for early-stage startups that have not raised more than $5 million.
+    source_ids:
+      - 8fbf37e3cf7097595545ad4b88d26b42327cd5da3dc01267ed79cdb6cb7e6036
+offers:
+  - offer_id: off_01m1san0zprfy7wx7ftp5te6dk
+    program_id: prg_01m1san187r4a48ye6k3xnr8h7
+    program_slug: startups-program
+    offer_slug: 1000-usd-monthly-startup-credits
+    offer_slug_aliases: []
+    title: $1,000 monthly credits for startups
+    summary: Eligible startups receive $1,000 in API credits every month, plus a 50 percent discount after the $5 million funding threshold.
+    lifecycle:
+      status: active
+      effective_from: 2024-01-01T00:00:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01m1san12kca1dg6gr8djtrz33
+          description: $1,000 in monthly API credits
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 100000
+            kind: up-to
+          duration:
+            kind: up-to
+            value: P1M
+        - benefit_id: ben_01m1san13s80pfy3z10px6ebkd
+          description: 50 percent discount after the $5M funding threshold
+          kind: discount
+          percentage:
+            kind: exact
+            basis_points: 5000
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: manual
+        reason: vendor-discretion
+        criterion_id: cri_01
+        statement: Available to startups that have not raised more than $5 million in total funding. Approval and grant are at Unkey's discretion.
+    roles:
+      terms_authority_entity_id: ent_01m1san0wqqdw55wbca23q9je1
+      access_operator_entity_id: ent_01m1san0wqqdw55wbca23q9je1
+    access:
+      availability: public
+      method: form
+      url: https://unkey.com/startups
+    source_ids:
+      - 8fbf37e3cf7097595545ad4b88d26b42327cd5da3dc01267ed79cdb6cb7e6036


### PR DESCRIPTION
Adds entities/un/unkey.yaml with one Unkey entity and one active startup offer.