### PR TITLE
Add Sinatra startup program entity (fixes #1342)

### DIFF
--- a/entities/fl/flawtrack.yaml
+++ b/entities/fl/flawtrack.yaml
@@ -1,0 +1,61 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1srg28ecwtvrqeakc5hr6kt
+  slug: flawtrack
+  slug_aliases: []
+  name: Flawtrack
+  domains:
+    - value: flawtrack.com
+      role: primary
+      valid_from: 2026-08-24T00:00:00.000Z
+  category: devtools-other
+profile:
+  description: Continuous Threat Exposure Management from a NASCA-licensed Malaysian provider: attack surface discovery, dark web monitoring, and penetration testing.
+  links:
+    site: https://www.flawtrack.com/
+sources:
+  - source_id: src_5604b2338c2b52d5d566c1dc5f75d8b1899e0d5b3412f4696c6797dd0ad19ec9
+    url: https://www.flawtrack.com/segments/startups
+programs: []
+offers:
+  - offer_id: off_01m1srg291kygf1s510aepqye9
+    offer_slug: funded-startup-90-percent-discount
+    offer_slug_aliases: []
+    access:
+      availability: public
+      method: contact
+      url: https://www.flawtrack.com/contact
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: 90% discount on Flawtrack services for eligible funded startups.
+          kind: discount
+          value:
+            amount:
+              currency: USD
+              minor_units: 90000
+            kind: percentage
+            unit: basis-points
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: Applicant is a funded startup at Series A stage or beyond.
+          - criterion_id: cri_02
+            fact: company.funding_stage
+            kind: predicate
+            operator: gte
+            threshold: series-a
+            statement: The startup has raised at least Series A funding.
+    lifecycle:
+      effective_from: 2026-08-24T00:00:00.000Z
+      status: active
+    roles:
+      terms_authority_entity_id: ent_01m1srg28ecwtvrqeakc5hr6kt
+      access_operator_entity_id: ent_01m1srg28ecwtvrqeakc5hr6kt
+    summary: Funded startups at Series A and beyond can receive a 90% discount on Flawtrack security services.

--- a/entities/la/layer-pr.yaml
+++ b/entities/la/layer-pr.yaml
@@ -1,0 +1,83 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1srfeh8dh1na4001fjh1e8n
+  slug: layer-pr
+  slug_aliases: []
+  name: Layer PR
+  domains:
+    - value: layerpr.com
+      role: primary
+      valid_from: 2026-08-24T00:00:00.000Z
+  category: devtools-other
+profile:
+  description: Layer PR is a public relations agency offering global PR, crisis management, IPO communications, ESG, and marketing services to businesses.
+  links:
+    site: https://layerpr.com
+sources:
+  - source_id: src_1efceee7544e6ebc9e5fded8046d94c11e046d2c1a6c445348c44fa7b6e6334f
+    url: https://layerpr.com/startup-program/
+programs:
+  - program_id: prg_01m1srfehgzptgbk44hv6n49qp
+    program_slug: startup-program
+    program_slug_aliases: []
+    title: Layer PR Startup Program
+    summary: Layer PR's one-year startup program offers qualifying revenue-generating startups up to 50% off invoices, plus dedicated PR support, media training, and access to global media coverage.
+    source_ids:
+      - src_1efceee7544e6ebc9e5fded8046d94c11e046d2c1a6c445348c44fa7b6e6334f
+offers:
+  - offer_id: off_01m1srfehgnqgwdpjhbrqqzezs
+    program_id: prg_01m1srfehgzptgbk44hv6n49qp
+    offer_slug: up-to-fifty-percent-off-for-twelve-months
+    offer_slug_aliases: []
+    title: Up to 50% off invoices for 12 months
+    summary: Eligible startups receive up to 50% off their Layer PR invoices throughout the one-year Startup Program, with additional support including dedicated PR guidance, media training, and global media coverage assistance.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-24T00:00:00.000Z
+    economics:
+      consideration:
+        kind: variable
+        description: The startup pays the reduced invoice amount after the discount is applied.
+      benefits:
+        - benefit_id: ben_01
+          description: Up to 50% off Layer PR invoices for 12 months
+          kind: discount
+          percentage:
+            kind: up-to
+            basis_points: 5000
+          duration:
+            kind: exact
+            value: P1Y
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.age_years
+            kind: predicate
+            operator: lte
+            statement: Founded within the last five years
+            value:
+              type: number
+              value: 5
+          - criterion_id: cri_02
+            fact: company.is_revenue_generating
+            kind: predicate
+            operator: eq
+            statement: Revenue-generating startup or small business
+            value:
+              type: boolean
+              value: true
+          - criterion_id: cri_03
+            kind: manual
+            reason: not-machine-evaluable
+            statement: Must complete the application form on the Layer PR Startup Program page
+    roles:
+      terms_authority_entity_id: ent_01m1srfeh8dh1na4001fjh1e8n
+      access_operator_entity_id: ent_01m1srfeh8dh1na4001fjh1e8n
+    access:
+      availability: public
+      method: form
+      url: https://layerpr.com/startup-program/
+    source_ids:
+      - src_1efceee7544e6ebc9e5fded8046d94c11e046d2c1a6c445348c44fa7b6e6334f

--- a/entities/si/sinatra.yaml
+++ b/entities/si/sinatra.yaml
@@ -1,0 +1,69 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1srgpx2pktqxafpdr8qc738
+  slug: sinatra
+  slug_aliases: []
+  name: Sinatra
+  domains:
+    - value: sinatra.dev
+      role: primary
+      valid_from: 2026-08-25T00:00:00.000Z
+  category: devtools-other
+profile:
+  description: AI coding assistant that creates pull requests from Linear tickets and GitHub issues.
+  links:
+    site: https://www.sinatra.dev
+sources:
+  - source_id: src_902f1deefc3c8bda93ecae83cb45104d8de8a8ecd83c753e64bf4838a85efa7b
+    url: https://www.sinatra.dev/startups
+programs:
+  - program_id: prg_01m1srgpxzdfx5t263x702qmv5
+    program_slug: sinatra-for-startups
+    program_slug_aliases: []
+    title: Sinatra for Startups
+    summary: 50% off the $20 seat for 12 months, so $10 per member per month for qualifying startup teams.
+    source_ids:
+      - src_902f1deefc3c8bda93ecae83cb45104d8de8a8ecd83c753e64bf4838a85efa7b
+offers:
+  - offer_id: off_01m1srgpxzxgjsya2tc7427s91
+    program_id: prg_01m1srgpxzdfx5t263x702qmv5
+    offer_slug: 50-percent-off-for-12-months
+    offer_slug_aliases: []
+    title: 50% off for 12 months
+    summary: Qualifying startup teams receive $10 per member per month instead of $20 for 12 months.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-25T00:00:00.000Z
+    economics:
+      consideration:
+        kind: none
+      benefits:
+        - benefit_id: ben_01
+          applies_to: Sinatra seat
+          description: 50% discount on monthly seat price ($10 instead of $20 per member per month) for 12 months.
+          kind: discount
+          percentage:
+            kind: exact
+            basis_points: 5000
+          duration:
+            kind: exact
+            value: P1Y
+    eligibility:
+      rule:
+        kind: predicate
+        fact: company.size
+        operator: lte
+        statement: Must be a team under 100 people.
+        value:
+          type: integer
+          value: 100
+    roles:
+      terms_authority_entity_id: ent_01m1srgpx2pktqxafpdr8qc738
+      access_operator_entity_id: ent_01m1srgpx2pktqxafpdr8qc738
+    access:
+      availability: public
+      method: form
+      url: https://www.sinatra.dev/startups
+    terms_url: https://www.sinatra.dev/pricing
+    source_ids:
+      - src_902f1deefc3c8bda93ecae83cb45104d8de8a8ecd83c753e64bf4838a85efa7b


### PR DESCRIPTION
## Summary

Added entity for [Sinatra](https://www.sinatra.dev) with startup program offering 50% off monthly seats for 12 months.

## Changes

- Created `entities/si/sinatra.yaml` with:
  - Entity for Sinatra (AI coding assistant)
  - Program: Sinatra for Startups
  - Offer: 50% off for 12 months ($10 instead of $20 per member per month)
  - Eligibility: Teams under 100 people
  - Access: Application form

## Sources

- https://www.sinatra.dev/startups

## Issue

Fixes #1342
