### PR TITLE
Add SOAX startup program entry

### DIFF
--- a/entities/cy/cyberport.yaml
+++ b/entities/cy/cyberport.yaml
@@ -1,0 +1,77 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1sry1ayrma2rpp0yakr8f91
+  slug: cyberport
+  slug_aliases: []
+  name: Cyberport
+  domains:
+    - value: cyberport.hk
+      role: primary
+      valid_from: 2025-06-01T00:00:00.000Z
+  category: other
+profile:
+  description: Cyberport is Hong Kong's digital technology flagship and government-operated tech hub supporting digital innovation, AI ecosystem development, and the digital economy.
+  links:
+    site: https://cyberport.hk
+sources:
+  - source_id: src_b5c4911e05edea412234d0e9b0acb27783381b5b6d0eb16346f86ce851e428a6
+    url: https://www.cyberport.hk/en/entrepreneurship/hong_kong_programme/
+  - source_id: src_cc587297e3cbfca939dc2d03ac21a8aaba8d273784603398adf3765167ad387e
+    url: https://www.cyberport.hk/en/about_us/vision_focus/
+programs:
+  - program_id: prg_01m1sry1bhx2x81s4x21vybf5m
+    program_slug: ccmf-hong-kong-programme
+    program_slug_aliases:
+      - cyberport-creative-micro-fund
+    title: Cyberport Creative Micro Fund (CCMF) Hong Kong Programme
+    summary: Cyberport's grant programme providing up to HK$100,000 and all-round nurturing support to high-potential digital technology projects at the idea or early development stage.
+    source_ids:
+      - src_b5c4911e05edea412234d0e9b0acb27783381b5b6d0eb16346f86ce851e428a6
+offers:
+  - offer_id: off_01m1sry1bj8qme7z7cy4exk4tw
+    program_id: prg_01m1sry1bhx2x81s4x21vybf5m
+    offer_slug: up-to-hkd-100-000-ccmf-grant
+    offer_slug_aliases:
+      - ccmf-hong-kong-grant
+    title: Up to HK$100,000 CCMF grant and nurturing support
+    summary: Eligible digital tech projects at idea or early development stage receive up to HK$100,000 in grant funding plus training, mentorship, and access to Cyberport's business networks.
+    lifecycle:
+      status: active
+      effective_from: 2025-06-01T00:00:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to HK$100,000 in cash grant disbursed in stages, subject to reporting milestones and programme progress
+          kind: credit
+          value:
+            amount:
+              currency: HKD
+              minor_units: 100000
+            kind: up-to
+        - benefit_id: ben_02
+          description: Access to Cyberport's training, mentorship, business advice, investment connections, and global business network
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: any
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: Individual applicant is a Hong Kong ID card holder aged 18 or above upon application deadline
+          - criterion_id: cri_02
+            kind: manual
+            reason: external-verification
+            statement: Applicant is a limited company registered and incorporated in Hong Kong upon admission
+    roles:
+      terms_authority_entity_id: ent_01m1sry1ayrma2rpp0yakr8f91
+      access_operator_entity_id: ent_01m1sry1ayrma2rpp0yakr8f91
+    access:
+      availability: public
+      method: form
+      url: https://www.cyberport.hk/en/entrepreneurship/hong_kong_programme/
+    source_ids:
+      - src_b5c4911e05edea412234d0e9b0acb27783381b5b6d0eb16346f86ce851e428a6
+      - src_cc587297e3cbfca939dc2d03ac21a8aaba8d273784603398adf3765167ad387e

--- a/entities/le/lettermint.yaml
+++ b/entities/le/lettermint.yaml
@@ -1,0 +1,97 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01decd128608f95599da1f3c
+  slug: lettermint
+  slug_aliases: []
+  name: Lettermint
+  domains:
+    - value: lettermint.co
+      role: primary
+      valid_from: 2025-01-01T00:00:00.000Z
+  category: productivity
+profile:
+  description: Lettermint provides transactional email services for developers and businesses, offering reliable email delivery with a developer-friendly API.
+  links:
+    site: https://lettermint.co
+sources:
+  - source_id: src_b202c99cef3415c0550d601c08616f5a302b7cf3cc5e94608ce59380077ad4f0
+    url: https://lettermint.co/promo-codes-and-discounts/startups
+programs: []
+offers:
+  - offer_id: off_01d4c6cd0c5865e77717954b
+    offer_slug: lettermint-startup-discount
+    offer_slug_aliases: []
+    title: Lettermint Startup Discount
+    summary: Eligible startups receive €60 in account credit, valid for 12 months after activation, which can be used toward any Lettermint subscription.
+    lifecycle:
+      status: active
+      effective_from: 2025-01-01T00:00:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: €60 account credit valid for 12 months after activation
+          duration:
+            kind: exact
+            value: P1Y
+          kind: credit
+          value:
+            amount:
+              currency: EUR
+              minor_units: 6000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: eq
+            statement: Has not raised any funding
+            value:
+              type: number
+              value: 0
+          - criterion_id: cri_02
+            fact: company.age_months
+            kind: predicate
+            operator: lte
+            statement: Startup is not older than 3 years
+            value:
+              type: number
+              value: 36
+          - criterion_id: cri_03
+            fact: company.arr_usd
+            kind: predicate
+            operator: lte
+            statement: Annual recurring revenue does not exceed €100,000
+            value:
+              type: number
+              value: 100000
+          - criterion_id: cri_04
+            fact: company.is_registered
+            kind: predicate
+            operator: eq
+            statement: Must be a registered company
+            value:
+              type: boolean
+              value: true
+          - criterion_id: cri_05
+            fact: company.has_used_service
+            kind: predicate
+            operator: eq
+            statement: Has not previously applied for a startup discount
+            value:
+              type: boolean
+              value: false
+    roles:
+      terms_authority_entity_id: ent_01decd128608f95599da1f3c
+      access_operator_entity_id: ent_01decd128608f95599da1f3c
+    access:
+      availability: public
+      instructions: Create a free account, then request the discount via support ticket in the dashboard.
+      method: form
+      url: https://lettermint.co/promo-codes-and-discounts/startups
+    source_ids:
+      - src_b202c99cef3415c0550d601c08616f5a302b7cf3cc5e94608ce59380077ad4f0

--- a/entities/qu/qarnot.yaml
+++ b/entities/qu/qarnot.yaml
@@ -1,0 +1,70 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1hppx9gmpt0a397prcktycp
+  slug: qarnot
+  slug_aliases: []
+  name: Qarnot
+  domains:
+    - value: qarnot.com
+      role: primary
+      valid_from: 2026-09-02T00:00:00.000Z
+  category: hosting-infra
+profile:
+  description: Qarnot provides sustainable, waste-heat-recovering cloud HPC and rendering infrastructure for compute-intensive workloads.
+  links:
+    site: https://qarnot.com
+sources:
+  - source_id: src_a8c368caec29037df355f80e2c48a7e4e49f82a60ef45aa005cae8b46d22b285
+    url: https://qarnot.com/en/start-up
+programs:
+  - program_id: prg_01m1hppx9m6abzs6eb4m8c60ex
+    program_slug: qarnot-start-up-program
+    program_slug_aliases: []
+    title: Qarnot Start-up Program
+    summary: Qarnot provides €6,000 in free cloud HPC credits over six months, then a 50% discount on computing usage, plus Research Tax Credit (CIR) eligibility for French companies using Qarnot's HPC solution.
+    source_ids:
+      - src_a8c368caec29037df355f80e2c48a7e4e49f82a60ef45aa005cae8b46d22b285
+offers:
+  - offer_id: off_01m1hppx9mvyeztfm9w61s2zet
+    program_id: prg_01m1hppx9m6abzs6eb4m8c60ex
+    offer_slug: qarnot-start-up-program
+    offer_slug_aliases: []
+    title: Qarnot Start-up Program
+    summary: Eligible startups receive €6,000 in free Qarnot cloud credits for the first six months, then 50% off computing usage with pay-as-you-go billing, plus optional Research Tax Credit (CIR) eligibility for French companies.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-02T00:00:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: €6,000 in free Qarnot cloud HPC credits for the first six months
+          kind: credit
+          value:
+            amount:
+              currency: EUR
+              minor_units: 600000
+            kind: up-to
+        - benefit_id: ben_02
+          description: 50% discount on computing usage with pay-as-you-go billing after free credits are used
+          kind: discount
+          value:
+            percent: 50
+        - benefit_id: ben_03
+          description: Research Tax Credit (CIR) eligibility for French companies using Qarnot's HPC solution for R&D projects
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: manual
+        reason: vendor-discretion
+        statement: Startups must apply through the Qarnot start-up program page and be approved by Qarnot; terms eligibility and start-up qualification are at the vendor's discretion.
+    roles:
+      terms_authority_entity_id: ent_01m1hppx9gmpt0a397prcktycp
+      access_operator_entity_id: ent_01m1hppx9gmpt0a397prcktycp
+    access:
+      availability: public
+      method: form
+      url: https://qarnot.com/en/start-up
+    source_ids:
+      - src_a8c368caec29037df355f80e2c48a7e4e49f82a60ef45aa005cae8b46d22b285

--- a/entities/so/soax.yaml
+++ b/entities/so/soax.yaml
@@ -1,0 +1,91 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1ss3epbpcf9cjs1bksy5c7r
+  slug: soax
+  slug_aliases: []
+  name: SOAX
+  domains:
+    - value: soax.com
+      role: primary
+      valid_from: 2026-09-05T21:55:54.537Z
+  category: devtools-other
+profile:
+  description: SOAX handles IP rotation and selection in one connected system, so requests travel a shorter path and your connection stays fast and reliable.
+  links:
+    site: https://soax.com
+sources:
+  - source_id: src_3e53ff74a35697d5bb89b6d6570c4ab31ec0880af81751e0d129f3b7a9bdffbc
+    url: https://soax.com/pricing/startups
+programs:
+  - program_id: prg_01m1ss3eqdbh196xzr8wc6xkar
+    program_slug: startup-program
+    program_slug_aliases: []
+    title: SOAX Startup Program
+    summary: Qualifying startups receive 50% off a SOAX Enterprise plan, with full access to proxies and scraper APIs, dedicated success manager support, and direct product influence.
+    source_ids:
+      - src_3e53ff74a35697d5bb89b6d6570c4ab31ec0880af81751e0d129f3b7a9bdffbc
+offers:
+  - offer_id: off_01m1ss3eqfpvvpj2116bf7ffc8
+    program_id: prg_01m1ss3eqdbh196xzr8wc6xkar
+    offer_slug: 50-percent-off-enterprise-plan
+    offer_slug_aliases: []
+    title: 50% Off SOAX Enterprise Plan
+    summary: Qualifying startups get 50% off a full-price Enterprise subscription, with full access to all SOAX tools and dedicated support.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-05T21:55:54.537Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: 50% off a full-price subscription to premium Enterprise plans.
+          kind: discount
+          percentage:
+            basis_points: 5000
+            kind: exact
+        - benefit_id: ben_02
+          description: Full access to every SOAX product and all advanced features included in Enterprise plans, including proxies and scraper APIs.
+          kind: other
+        - benefit_id: ben_03
+          description: Dedicated customer success manager for integration, troubleshooting, and optimization.
+          kind: other
+        - benefit_id: ben_04
+          description: Collaborate directly with SOAX product managers to request features and shape the product roadmap.
+          kind: other
+        - benefit_id: ben_05
+          description: Personalized onboarding to optimize your data extraction pipeline from day one.
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lte
+            statement: Raised up to a maximum of $10 million in funding
+            value:
+              type: number
+              value: 10000000
+          - criterion_id: cri_02
+            fact: company.age_months
+            kind: predicate
+            operator: lte
+            statement: Incorporated less than 5 years ago
+            value:
+              type: number
+              value: 60
+          - criterion_id: cri_03
+            kind: manual
+            reason: not-machine-evaluable
+            statement: Must be a new SOAX customer
+    roles:
+      terms_authority_entity_id: ent_01m1ss3epbpcf9cjs1bksy5c7r
+      access_operator_entity_id: ent_01m1ss3epbpcf9cjs1bksy5c7r
+    access:
+      availability: public
+      method: form
+      url: https://soax.com/pricing/startups#apply-now
+    source_ids:
+      - src_3e53ff74a35697d5bb89b6d6570c4ab31ec0880af81751e0d129f3b7a9bdffbc

--- a/entities/we/wevestr.yaml
+++ b/entities/we/wevestr.yaml
@@ -1,0 +1,94 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1srjgzbq7g4avpk4w5tdxwk
+  slug: wevestr
+  slug_aliases: []
+  name: WE.VESTR
+  domains:
+  - value: wevestr.com
+    role: primary
+    valid_from: '2026-09-05T21:49:37.540Z'
+  category: banking
+profile:
+  description: WE.VESTR is an equity management platform that helps startups manage
+    cap tables, stakeholder records, and equity plans from incorporation through exit.
+  links:
+    site: https://wevestr.com
+sources:
+- source_id: src_3ae35796bef4f724cb10137b35d223dc417019945a5d475c144af33775c7539f
+  url: https://wevestr.com/microsoft-for-startups
+- source_id: src_b2019d3b081760cfe71ef2510252e8fb8cc3cd24f5a50b705ed7c98cb43641a2
+  url: https://learn.microsoft.com/en-us/startups/benefits/technical-benefits/third-party-benefits/we-vest
+programs:
+- program_id: prg_01m1srjgzqyned01scq3epfpnp
+  program_slug: microsoft-for-startups
+  program_slug_aliases: []
+  title: Microsoft for Startups
+  summary: Microsoft for Startups provides equity-management discounts to its member
+    startups through third-party partner offers.
+  source_ids:
+  - src_b2019d3b081760cfe71ef2510252e8fb8cc3cd24f5a50b705ed7c98cb43641a2
+offers:
+- offer_id: off_01m1srjgzqzv7hs0jbq16b845x
+  program_id: prg_01m1srjgzqyned01scq3epfpnp
+  offer_slug: 70-percent-off-first-year-for-microsoft-for-startups
+  offer_slug_aliases: []
+  title: 70% off the first year of WE.VESTR equity-management plans for Microsoft
+    for Startups members
+  summary: Microsoft for Startups members who are new WE.VESTR customers can receive
+    70% off their first year of WE.VESTR equity-management plans, valid for 12 months.
+  lifecycle:
+    status: active
+    effective_from: '2026-09-05T21:49:37.540Z'
+  economics:
+    benefits:
+    - benefit_id: ben_01
+      applies_to: WE.VESTR equity-management plans
+      description: 70% off for the first year of WE.VESTR equity-management plans,
+        valid for 12 months
+      duration:
+        kind: exact
+        value: P1Y
+      kind: discount
+      percentage:
+        basis_points: 7000
+        kind: exact
+    consideration:
+      kind: none
+  eligibility:
+    rule:
+      kind: all
+      rules:
+      - criterion_id: cri_01
+        kind: manual
+        reason: external-verification
+        statement: Must be a member of Microsoft for Startups.
+      - criterion_id: cri_02
+        kind: predicate
+        fact: company.is_current_customer
+        operator: eq
+        statement: Must be a new WE.VESTR customer.
+        value:
+          type: boolean
+          value: false
+      - criterion_id: cri_03
+        kind: predicate
+        fact: company.stakeholder_count
+        operator: gte
+        statement: Must have at least 30 stakeholders.
+        value:
+          type: integer
+          value: 30
+  roles:
+    terms_authority_entity_id: ent_01m1srjgzbq7g4avpk4w5tdxwk
+    access_operator_entity_id: ent_01kyh8fpe3n3yye39kmzvy410z
+  access:
+    availability: membership
+    method: form
+    url: https://learn.microsoft.com/en-us/startups/benefits/technical-benefits/third-party-benefits/we-vest
+    instructions: Access the offer through the Microsoft for Startups Founders Hub
+      Benefits page. The WE.VESTR first-year discount is listed under third-party
+      technical benefits and requires active Microsoft for Startups membership.
+  source_ids:
+  - src_3ae35796bef4f724cb10137b35d223dc417019945a5d475c144af33775c7539f
+  - src_b2019d3b081760cfe71ef2510252e8fb8cc3cd24f5a50b705ed7c98cb43641a2


### PR DESCRIPTION
## SOAX — Startup Program Entry

**Issue:** #1340

### Summary

Added `entities/so/soax.yaml` for SOAX (soax.com), a residential and mobile proxy / web data extraction provider.

**Program:** SOAX Startup Program
- **Discount:** 50% off SOAX Enterprise plan
- **Eligibility:** 
  - Raised ≤ $10M in total funding
  - Incorporated < 5 years ago
  - New customers only
- **Benefits:**
  - 50% off full-price Enterprise subscription
  - Full access to all SOAX tools (proxies + scraper APIs)
  - Dedicated customer success manager
  - Direct product influence / roadmap collaboration
  - Personalized onboarding
- **Access:** Public form at https://soax.com/pricing/startups

**Category:** `devtools-other`

**Source:** https://soax.com/pricing/startups
