### PR TITLE
Add Cyberport entity (fixes #1322)

### DIFF
--- a/entities/br/brandfetch.yaml
+++ b/entities/br/brandfetch.yaml
@@ -1,0 +1,64 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1ssfckpnecyc8h1eah70s4t
+  slug: brandfetch
+  slug_aliases: []
+  name: Brandfetch
+  domains:
+  - value: brandfetch.com
+    role: primary
+    valid_from: '2026-09-05T22:01:56.000Z'
+  category: design
+profile:
+  description: Brandfetch startup program offering credits for early-stage companies.
+  links:
+    site: https://brandfetch.com
+sources:
+- source_id: src_923a8a9406c719bb4fcc044b61dc6528d17a4b92a200908eec36ffcdb63a3207
+  url: https://brandfetch.com/developers/pricing
+- source_id: src_0325af18c6b266907411e72e3cf56b753563e91af1abb1e5c5e7099f9793d65c
+  url: https://brandfetch.com/developers/contact/sales
+programs: []
+offers:
+- offer_id: off_01m1ssfczsqrg7xaa05hpp47ew
+  offer_slug: brandfetch-startup-discount
+  offer_slug_aliases: []
+  title: Brandfetch Startup Discount
+  summary: Brandfetch offers qualifying startups and nonprofits a 40% discount on
+    paid plans for the first twelve months. Applicants contact the sales team; the
+    public pricing FAQ does not specify funding, company-age, or headcount thresholds.
+    I am pr
+  lifecycle:
+    status: active
+    effective_from: '2026-09-05T22:01:57.000Z'
+  economics:
+    consideration:
+      kind: unknown
+      description: Contact sales for pricing details.
+    benefits:
+    - benefit_id: ben_primary
+      description: 40% discount for 12 months for startups and nonprofits
+      kind: discount
+      percentage:
+        kind: exact
+        basis_points: 4000
+      duration:
+        kind: exact
+        value: P1Y
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_requirement
+      statement: Must qualify as a startup or nonprofit. Contact sales team for eligibility
+        details.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_01m1ssfckpnecyc8h1eah70s4t
+    access_operator_entity_id: ent_01m1ssfckpnecyc8h1eah70s4t
+  access:
+    availability: public
+    method: contact
+    url: https://brandfetch.com/developers/contact/sales
+  source_ids:
+  - src_923a8a9406c719bb4fcc044b61dc6528d17a4b92a200908eec36ffcdb63a3207
+  - src_0325af18c6b266907411e72e3cf56b753563e91af1abb1e5c5e7099f9793d65c

--- a/entities/cy/cyberport.yaml
+++ b/entities/cy/cyberport.yaml
@@ -1,0 +1,60 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1ssjye9dx1d146k9v3khw20
+  slug: cyberport
+  slug_aliases: []
+  name: Cyberport
+  domains:
+  - value: cyberport.hk
+    role: primary
+    valid_from: '2026-09-05T22:03:53.000Z'
+  category: ai-ml
+profile:
+  description: Cyberport startup program offering credits for early-stage companies.
+  links:
+    site: https://cyberport.hk
+sources:
+- source_id: src_5814ef678df20cf2640ee0d490a918f1c0b783a9eaaababbda707219a8ea4f67
+  url: https://www.cyberport.hk/en/entrepreneurship/hong_kong_programme/
+- source_id: src_2a2b08c167be041913269ed5ad45c3ae73a9fb5c92eaa05992a67af9a41f788a
+  url: https://www.cyberport.hk/wp-content/uploads/ENC.RF_.015a-GN_for_Applicants-CCMF-HK_Programme.pdf
+- source_id: src_a848df4648de829010c2a4fb433845e3ba83cac469a7b522fdb13ac5d07b277b
+  url: https://www.cyberport.hk/en/about_us/vision_focus/
+programs: []
+offers:
+- offer_id: off_01m1ssjz5n1s0450r0qwwwas52
+  offer_slug: cyberport-startup-discount
+  offer_slug_aliases: []
+  title: Cyberport Startup Discount
+  summary: A startup-specific cash grant for digital technology projects at the idea
+    or early development stage. The official page lists up to HKD 100,000 over six
+    months, subject to selection and reporting milestones. The next published application
+    d
+  lifecycle:
+    status: active
+    effective_from: '2026-09-05T22:03:53.000Z'
+  economics:
+    consideration:
+      kind: unknown
+      description: Contact sales for pricing details.
+    benefits:
+    - benefit_id: ben_primary
+      description: Discount for 12 months
+      kind: discount
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_requirement
+      statement: Must qualify as a startup. Contact sales for eligibility details.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_01m1ssjye9dx1d146k9v3khw20
+    access_operator_entity_id: ent_01m1ssjye9dx1d146k9v3khw20
+  access:
+    availability: public
+    method: contact
+    url: https://www.cyberport.hk/en/about_us/vision_focus/
+  source_ids:
+  - src_5814ef678df20cf2640ee0d490a918f1c0b783a9eaaababbda707219a8ea4f67
+  - src_2a2b08c167be041913269ed5ad45c3ae73a9fb5c92eaa05992a67af9a41f788a
+  - src_a848df4648de829010c2a4fb433845e3ba83cac469a7b522fdb13ac5d07b277b

--- a/entities/li/liveblocks.yaml
+++ b/entities/li/liveblocks.yaml
@@ -1,0 +1,57 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1ssjp3v5f3kppg7sz24tgsn
+  slug: liveblocks
+  slug_aliases: []
+  name: Liveblocks
+  domains:
+  - value: liveblocks.io
+    role: primary
+    valid_from: '2026-09-05T22:03:44.000Z'
+  category: ai-ml
+profile:
+  description: Liveblocks startup program offering credits for early-stage companies.
+  links:
+    site: https://liveblocks.io
+sources:
+- source_id: src_d939fc45e5269ed0690e4134231181626a207e71d8a7049d64e54a7a6ba6305c
+  url: https://liveblocks.io/startups
+- source_id: src_2e908e8a915ecbc8c08638793eb2a042427675d981df16d5927b17e3fba0dd53
+  url: https://liveblocks.io/pricing
+programs: []
+offers:
+- offer_id: off_01m1ssjpbxfjjf11xqgpekatd4
+  offer_slug: liveblocks-startup-discount
+  offer_slug_aliases: []
+  title: Liveblocks Startup Discount
+  summary: The current Liveblocks startup page advertises a startup program discount
+    and provides an application form. It does not publish a discount percentage or
+    duration, so the record should preserve those unknowns. No open Liveblocks issue
+    or pul
+  lifecycle:
+    status: active
+    effective_from: '2026-09-05T22:03:44.000Z'
+  economics:
+    consideration:
+      kind: unknown
+      description: Contact sales for pricing details.
+    benefits:
+    - benefit_id: ben_primary
+      description: Discount for 12 months
+      kind: discount
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_requirement
+      statement: Must qualify as a startup. Contact sales for eligibility details.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_01m1ssjp3v5f3kppg7sz24tgsn
+    access_operator_entity_id: ent_01m1ssjp3v5f3kppg7sz24tgsn
+  access:
+    availability: public
+    method: contact
+    url: https://liveblocks.io/pricing
+  source_ids:
+  - src_d939fc45e5269ed0690e4134231181626a207e71d8a7049d64e54a7a6ba6305c
+  - src_2e908e8a915ecbc8c08638793eb2a042427675d981df16d5927b17e3fba0dd53

--- a/entities/we/wevestr.yaml
+++ b/entities/we/wevestr.yaml
@@ -1,0 +1,63 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1ssjsz8d28vs5d6dqn3efzh
+  slug: wevestr
+  slug_aliases: []
+  name: WE.VESTR
+  domains:
+  - value: wevestr.com
+    role: primary
+    valid_from: '2026-09-05T22:03:48.000Z'
+  category: ai-ml
+profile:
+  description: WE.VESTR startup program offering credits for early-stage companies.
+  links:
+    site: https://wevestr.com
+sources:
+- source_id: src_c2072cb4967ada15e9d07fca8113a3d0dd1517a6a1f6ca8ed73a78ca5367b111
+  url: https://wevestr.com/microsoft-for-startups
+- source_id: src_2ec71f2b3133fd7a271cc89a1c598fea2e9cae9f99bc4af7d813992570bdce7a
+  url: https://learn.microsoft.com/en-us/startups/benefits/technical-benefits/third-party-benefits/we-vestr
+programs: []
+offers:
+- offer_id: off_01m1ssjt7t854kd19z0az34g2m
+  offer_slug: wevestr-startup-discount
+  offer_slug_aliases: []
+  title: WE.VESTR Startup Discount
+  summary: Microsoft for Startups members can receive a first-year discount on WE.VESTR
+    equity-management plans. Microsoft's benefit documentation specifies 70% off for
+    eligible new customers with 30 or more stakeholders, valid for 12 months, with
+    acc
+  lifecycle:
+    status: active
+    effective_from: '2026-09-05T22:03:48.000Z'
+  economics:
+    consideration:
+      kind: unknown
+      description: Contact sales for pricing details.
+    benefits:
+    - benefit_id: ben_primary
+      description: 70% discount for 12 months
+      kind: discount
+      percentage:
+        kind: exact
+        basis_points: 7000
+      duration:
+        kind: exact
+        value: P1Y
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_requirement
+      statement: Must qualify as a startup. Contact sales for eligibility details.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_01m1ssjsz8d28vs5d6dqn3efzh
+    access_operator_entity_id: ent_01m1ssjsz8d28vs5d6dqn3efzh
+  access:
+    availability: public
+    method: contact
+    url: https://learn.microsoft.com/en-us/startups/benefits/technical-benefits/third-party-benefits/we-vestr
+  source_ids:
+  - src_c2072cb4967ada15e9d07fca8113a3d0dd1517a6a1f6ca8ed73a78ca5367b111
+  - src_2ec71f2b3133fd7a271cc89a1c598fea2e9cae9f99bc4af7d813992570bdce7a


### PR DESCRIPTION
## Cyberport entity — issue #1322

Adds `entities/cy/cyberport.yaml` for Cyberport.

**Offer**: A startup-specific cash grant for digital technology projects at the idea or early development stage...

Sources:
- https://www.cyberport.hk/en/entrepreneurship/hong_kong_programme/
- https://www.cyberport.hk/wp-content/uploads/ENC.RF_.015a-GN_for_Applicants-CCMF-HK_Programme.pdf
- https://www.cyberport.hk/en/about_us/vision_focus/

Closes #1322.