### PR TITLE
Add Cribl for Startups entity (fixes #1291)

### DIFF
--- a/entities/cr/cribl.yaml
+++ b/entities/cr/cribl.yaml
@@ -1,0 +1,76 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1syneb3a9q8ghht89wwdvkj
+  slug: cribl
+  slug_aliases: []
+  name: Cribl
+  domains:
+    - value: cribl.io
+      role: primary
+      valid_from: 2026-09-05T22:49:03.000Z
+  category: observability
+profile:
+  description: Cribl provides log analytics and observability tools for engineering and platform teams.
+  links:
+    site: https://cribl.io
+sources:
+  - source_id: src_982979930c62c94e6efe47473508d87e86e3811d8be28ef0e8fbb8d496616e0b
+    url: https://cribl.io/startup/
+programs:
+  - program_id: prg_01m1synebf6ck7zsaf1kpqzhca
+    program_slug: cribl-for-startups
+    program_slug_aliases: []
+    title: Cribl for Startups
+    summary: Cribl's startup program offers free Cribl.Cloud access, one-on-one technical advice, partner network access, and co-marketing opportunities for qualifying Seed through Series A companies.
+    source_ids:
+      - src_982979930c62c94e6efe47473508d87e86e3811d8be28ef0e8fbb8d496616e0b
+offers:
+  - offer_id: off_01m1synebgv7tqz7wzqws8p3gh
+    program_id: prg_01m1synebf6ck7zsaf1kpqzhca
+    offer_slug: cribl-for-startups
+    offer_slug_aliases: []
+    title: Cribl for Startups
+    summary: Free Cribl.Cloud access including Cribl Stream and Cribl Search, one-on-one technical advice, partner network access, and co-marketing opportunities for Seed through Series A startups.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-05T22:49:03.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Free access to all Cribl.Cloud products including Cribl Stream and Cribl Search for qualifying startups.
+          kind: other
+        - benefit_id: ben_02
+          description: One-on-one technical advice sessions with Cribl experts to help scale solutions and tackle technical challenges.
+          kind: other
+        - benefit_id: ben_03
+          description: Access to Cribl's partner network and community of startups, plus co-marketing opportunities through events and brand initiatives.
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.stage
+            kind: predicate
+            operator: in
+            statement: Seed through Series A stage
+            value:
+              type: string-set
+              values:
+                - Seed
+                - Series A
+          - criterion_id: cri_02
+            kind: manual
+            reason: vendor-discretion
+            statement: Building monitoring, observability, cybersecurity, or DevOps data solutions; selection is at Cribl's discretion.
+    roles:
+      terms_authority_entity_id: ent_01m1syneb3a9q8ghht89wwdvkj
+      access_operator_entity_id: ent_01m1syneb3a9q8ghht89wwdvkj
+    access:
+      availability: public
+      method: form
+      url: https://cribl.io/startup/
+    source_ids:
+      - src_982979930c62c94e6efe47473508d87e86e3811d8be28ef0e8fbb8d496616e0b


### PR DESCRIPTION
## Summary

Add entity for **Cribl** covering the Cribl for Startups program (issue #1291).

## Changes

- **Entity**: Cribl (cribl.io) — observability and log analytics platform
- **Program**: Cribl for Startups
- **Offer**: Free Cribl.Cloud access (Cribl Stream + Cribl Search), one-on-one technical advice, partner network access, and co-marketing opportunities
- **Eligibility**: Seed through Series A startups building monitoring, observability, cybersecurity, or DevOps data solutions; selection at Cribl's discretion
- **Access**: Public form at https://cribl.io/startup/

## Source

All facts sourced from Cribl's own startup page: https://cribl.io/startup/

## DCO

Signed-off-by: pilars-agent <pilars@agent.local>
