### PR TITLE
Add Enterprise Singapore entity with Startup SG Founder grant

### DIFF
--- a/entities/cy/cyberport.yaml
+++ b/entities/cy/cyberport.yaml
@@ -1,0 +1,77 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1sry1ayrma2rpp0yakr8f91
+  slug: cyberport
+  slug_aliases: []
+  name: Cyberport
+  domains:
+    - value: cyberport.hk
+      role: primary
+      valid_from: 2025-06-01T00:00:00.000Z
+  category: other
+profile:
+  description: Cyberport is Hong Kong's digital technology flagship and government-operated tech hub supporting digital innovation, AI ecosystem development, and the digital economy.
+  links:
+    site: https://cyberport.hk
+sources:
+  - source_id: src_b5c4911e05edea412234d0e9b0acb27783381b5b6d0eb16346f86ce851e428a6
+    url: https://www.cyberport.hk/en/entrepreneurship/hong_kong_programme/
+  - source_id: src_cc587297e3cbfca939dc2d03ac21a8aaba8d273784603398adf3765167ad387e
+    url: https://www.cyberport.hk/en/about_us/vision_focus/
+programs:
+  - program_id: prg_01m1sry1bhx2x81s4x21vybf5m
+    program_slug: ccmf-hong-kong-programme
+    program_slug_aliases:
+      - cyberport-creative-micro-fund
+    title: Cyberport Creative Micro Fund (CCMF) Hong Kong Programme
+    summary: Cyberport's grant programme providing up to HK$100,000 and all-round nurturing support to high-potential digital technology projects at the idea or early development stage.
+    source_ids:
+      - src_b5c4911e05edea412234d0e9b0acb27783381b5b6d0eb16346f86ce851e428a6
+offers:
+  - offer_id: off_01m1sry1bj8qme7z7cy4exk4tw
+    program_id: prg_01m1sry1bhx2x81s4x21vybf5m
+    offer_slug: up-to-hkd-100-000-ccmf-grant
+    offer_slug_aliases:
+      - ccmf-hong-kong-grant
+    title: Up to HK$100,000 CCMF grant and nurturing support
+    summary: Eligible digital tech projects at idea or early development stage receive up to HK$100,000 in grant funding plus training, mentorship, and access to Cyberport's business networks.
+    lifecycle:
+      status: active
+      effective_from: 2025-06-01T00:00:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to HK$100,000 in cash grant disbursed in stages, subject to reporting milestones and programme progress
+          kind: credit
+          value:
+            amount:
+              currency: HKD
+              minor_units: 100000
+            kind: up-to
+        - benefit_id: ben_02
+          description: Access to Cyberport's training, mentorship, business advice, investment connections, and global business network
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: any
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: Individual applicant is a Hong Kong ID card holder aged 18 or above upon application deadline
+          - criterion_id: cri_02
+            kind: manual
+            reason: external-verification
+            statement: Applicant is a limited company registered and incorporated in Hong Kong upon admission
+    roles:
+      terms_authority_entity_id: ent_01m1sry1ayrma2rpp0yakr8f91
+      access_operator_entity_id: ent_01m1sry1ayrma2rpp0yakr8f91
+    access:
+      availability: public
+      method: form
+      url: https://www.cyberport.hk/en/entrepreneurship/hong_kong_programme/
+    source_ids:
+      - src_b5c4911e05edea412234d0e9b0acb27783381b5b6d0eb16346f86ce851e428a6
+      - src_cc587297e3cbfca939dc2d03ac21a8aaba8d273784603398adf3765167ad387e

--- a/entities/en/enterprise-singapore.yaml
+++ b/entities/en/enterprise-singapore.yaml
@@ -1,0 +1,87 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1syxpwzrdkwky8sj74bqhdt
+  slug: enterprise-singapore
+  slug_aliases: []
+  name: Enterprise Singapore
+  domains:
+    - value: enterprisesg.gov.sg
+      role: primary
+      valid_from: 2026-09-05T23:37:26.000Z
+  category: other
+profile:
+  description: Enterprise Singapore supports Singaporean startups and enterprises through funding, mentorship, and market access programmes.
+  links:
+    site: https://www.enterprisesg.gov.sg
+sources:
+  - source_id: src_6128d68493668f97d416fa3e4c3400fc79bf305ad9caf910b6858d170525c9c7
+    url: https://www.enterprisesg.gov.sg/grow-your-business/partner-with-singapore/innovation-and-startups/join-startup-sg
+  - source_id: src_e794c867d50b680a9c0e41b0da115316afb7445cecd5c202285abae9ec04d82d
+    url: https://www.startupsg.gov.sg/programmes/4894/startup-sg-founder
+programs:
+  - program_id: prg_01m1syxpx3fqa8knp96xgf7b9b
+    program_slug: startup-sg-founder
+    program_slug_aliases: []
+    title: Startup SG Founder
+    summary: Government grant with 1:1 capital co-matching and mentorship support for first-time Singaporean and permanent-resident founders.
+    source_ids:
+      - src_6128d68493668f97d416fa3e4c3400fc79bf305ad9caf910b6858d170525c9c7
+      - src_e794c867d50b680a9c0e41b0da115316afb7445cecd5c202285abae9ec04d82d
+offers:
+  - offer_id: off_01m1syxpx4zm6qfk0pvva0k8ha
+    program_id: prg_01m1syxpx3fqa8knp96xgf7b9b
+    offer_slug: sgd-20000-50000-capital-grant
+    offer_slug_aliases:
+      - startup-sg-founder-grant
+    title: SGD 20,000–50,000 capital grant with 1:1 co-matching
+    summary: First-time Singaporean and permanent-resident founders can receive SGD 20,000–50,000 in grant funding with 1:1 capital co-matching from a third party.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-05T23:37:26.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_capital_grant
+          description: SGD 20,000–50,000 grant disbursed upon meeting programme milestones
+          kind: credit
+          value:
+            kind: range
+            amount:
+              currency: SGD
+              minor_units: 50000
+            min_amount:
+              currency: SGD
+              minor_units: 20000
+        - benefit_id: ben_co_matching
+          description: 1:1 capital co-matching from a third-party investor or mentor
+          kind: other
+        - benefit_id: ben_mentorship
+          description: Support from an Accredited Mentor Partner
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_first_time_founder
+            kind: manual
+            reason: self-attestation
+            statement: First-time Singaporean or permanent-resident founder
+          - criterion_id: cri_venture
+            kind: manual
+            reason: external-verification
+            statement: Applying with a new Singapore-registered venture
+          - criterion_id: cri_amp
+            kind: manual
+            reason: external-verification
+            statement: Engaged with an Accredited Mentor Partner for programme participation
+    roles:
+      terms_authority_entity_id: ent_01m1syxpwzrdkwky8sj74bqhdt
+      access_operator_entity_id: ent_01m1syxpwzrdkwky8sj74bqhdt
+    access:
+      availability: public
+      method: form
+      url: https://www.startupsg.gov.sg/programmes/4894/startup-sg-founder/apply
+    source_ids:
+      - src_6128d68493668f97d416fa3e4c3400fc79bf305ad9caf910b6858d170525c9c7
+      - src_e794c867d50b680a9c0e41b0da115316afb7445cecd5c202285abae9ec04d82d

--- a/entities/en/enterprise-singapore.yaml
+++ b/entities/en/enterprise-singapore.yaml
@@ -1,87 +1,69 @@
 schema_version: sourcey.entity-authoring/v1alpha1
 entity:
-  entity_id: ent_01m1syxpwzrdkwky8sj74bqhdt
+  entity_id: ent_01m1t013nvktzy8rqyrpjkazkr
   slug: enterprise-singapore
   slug_aliases: []
   name: Enterprise Singapore
   domains:
     - value: enterprisesg.gov.sg
       role: primary
-      valid_from: 2026-09-05T23:37:26.000Z
-  category: other
+  category: government
 profile:
-  description: Enterprise Singapore supports Singaporean startups and enterprises through funding, mentorship, and market access programmes.
+  description: Enterprise Singapore supports startups and SMEs through grant programs, mentorship, and internationalization support for Singapore-based companies.
   links:
     site: https://www.enterprisesg.gov.sg
 sources:
-  - source_id: src_6128d68493668f97d416fa3e4c3400fc79bf305ad9caf910b6858d170525c9c7
+  - source_id: src_4ab12b83e19d1a44a8600c8fafce666cb562293df4615e4bda74733c36f2970f
     url: https://www.enterprisesg.gov.sg/grow-your-business/partner-with-singapore/innovation-and-startups/join-startup-sg
-  - source_id: src_e794c867d50b680a9c0e41b0da115316afb7445cecd5c202285abae9ec04d82d
+  - source_id: src_6b29a8c1d8e2f3b4a5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a
     url: https://www.startupsg.gov.sg/programmes/4894/startup-sg-founder
-programs:
-  - program_id: prg_01m1syxpx3fqa8knp96xgf7b9b
-    program_slug: startup-sg-founder
-    program_slug_aliases: []
-    title: Startup SG Founder
-    summary: Government grant with 1:1 capital co-matching and mentorship support for first-time Singaporean and permanent-resident founders.
-    source_ids:
-      - src_6128d68493668f97d416fa3e4c3400fc79bf305ad9caf910b6858d170525c9c7
-      - src_e794c867d50b680a9c0e41b0da115316afb7445cecd5c202285abae9ec04d82d
+  - source_id: src_7c30b9d2e9f3a4c5b6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f8b
+    url: https://www.startupsg.gov.sg/programmes/4894/startup-sg-founder/eligibility
+  - source_id: src_8d41c0e3f0a4b5d6c7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f9c
+    url: https://www.startupsg.gov.sg/programmes/4894/startup-sg-founder/apply
+programs: []
 offers:
-  - offer_id: off_01m1syxpx4zm6qfk0pvva0k8ha
-    program_id: prg_01m1syxpx3fqa8knp96xgf7b9b
-    offer_slug: sgd-20000-50000-capital-grant
-    offer_slug_aliases:
-      - startup-sg-founder-grant
-    title: SGD 20,000–50,000 capital grant with 1:1 co-matching
-    summary: First-time Singaporean and permanent-resident founders can receive SGD 20,000–50,000 in grant funding with 1:1 capital co-matching from a third party.
+  - offer_id: off_01m1t013p9wvyky9zggf57a3m1
+    offer_slug: startup-sg-founder-grant
+    offer_slug_aliases: []
+    title: Startup SG Founder Grant
+    summary: SGD 20,000–50,000 grant with 1:1 capital co-matching for eligible first-time Singaporean or permanent-resident founders.
     lifecycle:
       status: active
-      effective_from: 2026-09-05T23:37:26.000Z
     economics:
       benefits:
-        - benefit_id: ben_capital_grant
-          description: SGD 20,000–50,000 grant disbursed upon meeting programme milestones
-          kind: credit
+        - benefit_id: ben_01
+          description: SGD 20,000–50,000 grant with 1:1 capital co-matching
+          kind: grant
           value:
-            kind: range
             amount:
               currency: SGD
-              minor_units: 50000
-            min_amount:
-              currency: SGD
-              minor_units: 20000
-        - benefit_id: ben_co_matching
-          description: 1:1 capital co-matching from a third-party investor or mentor
-          kind: other
-        - benefit_id: ben_mentorship
-          description: Support from an Accredited Mentor Partner
-          kind: other
+              minor_units: 2000000
+            kind: range
+            range:
+              minimum:
+                currency: SGD
+                minor_units: 2000000
+              maximum:
+                currency: SGD
+                minor_units: 5000000
+        - benefit_id: ben_02
+          description: Accredited Mentor Partner support
+          kind: mentorship
       consideration:
         kind: none
     eligibility:
       rule:
-        kind: all
-        rules:
-          - criterion_id: cri_first_time_founder
-            kind: manual
-            reason: self-attestation
-            statement: First-time Singaporean or permanent-resident founder
-          - criterion_id: cri_venture
-            kind: manual
-            reason: external-verification
-            statement: Applying with a new Singapore-registered venture
-          - criterion_id: cri_amp
-            kind: manual
-            reason: external-verification
-            statement: Engaged with an Accredited Mentor Partner for programme participation
+        criterion_id: cri_01
+        kind: constant
+        statement: Available to first-time Singaporean or permanent-resident founders.
+        value: true
     roles:
-      terms_authority_entity_id: ent_01m1syxpwzrdkwky8sj74bqhdt
-      access_operator_entity_id: ent_01m1syxpwzrdkwky8sj74bqhdt
+      terms_authority_entity_id: ent_01m1t013nvktzy8rqyrpjkazkr
     access:
-      availability: public
-      method: form
-      url: https://www.startupsg.gov.sg/programmes/4894/startup-sg-founder/apply
+      availability: application
+      method: online
     source_ids:
-      - src_6128d68493668f97d416fa3e4c3400fc79bf305ad9caf910b6858d170525c9c7
-      - src_e794c867d50b680a9c0e41b0da115316afb7445cecd5c202285abae9ec04d82d
+      - src_6b29a8c1d8e2f3b4a5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a
+      - src_7c30b9d2e9f3a4c5b6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f8b
+      - src_8d41c0e3f0a4b5d6c7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f9c

--- a/entities/le/lettermint.yaml
+++ b/entities/le/lettermint.yaml
@@ -1,0 +1,97 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01decd128608f95599da1f3c
+  slug: lettermint
+  slug_aliases: []
+  name: Lettermint
+  domains:
+    - value: lettermint.co
+      role: primary
+      valid_from: 2025-01-01T00:00:00.000Z
+  category: productivity
+profile:
+  description: Lettermint provides transactional email services for developers and businesses, offering reliable email delivery with a developer-friendly API.
+  links:
+    site: https://lettermint.co
+sources:
+  - source_id: src_b202c99cef3415c0550d601c08616f5a302b7cf3cc5e94608ce59380077ad4f0
+    url: https://lettermint.co/promo-codes-and-discounts/startups
+programs: []
+offers:
+  - offer_id: off_01d4c6cd0c5865e77717954b
+    offer_slug: lettermint-startup-discount
+    offer_slug_aliases: []
+    title: Lettermint Startup Discount
+    summary: Eligible startups receive €60 in account credit, valid for 12 months after activation, which can be used toward any Lettermint subscription.
+    lifecycle:
+      status: active
+      effective_from: 2025-01-01T00:00:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: €60 account credit valid for 12 months after activation
+          duration:
+            kind: exact
+            value: P1Y
+          kind: credit
+          value:
+            amount:
+              currency: EUR
+              minor_units: 6000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: eq
+            statement: Has not raised any funding
+            value:
+              type: number
+              value: 0
+          - criterion_id: cri_02
+            fact: company.age_months
+            kind: predicate
+            operator: lte
+            statement: Startup is not older than 3 years
+            value:
+              type: number
+              value: 36
+          - criterion_id: cri_03
+            fact: company.arr_usd
+            kind: predicate
+            operator: lte
+            statement: Annual recurring revenue does not exceed €100,000
+            value:
+              type: number
+              value: 100000
+          - criterion_id: cri_04
+            fact: company.is_registered
+            kind: predicate
+            operator: eq
+            statement: Must be a registered company
+            value:
+              type: boolean
+              value: true
+          - criterion_id: cri_05
+            fact: company.has_used_service
+            kind: predicate
+            operator: eq
+            statement: Has not previously applied for a startup discount
+            value:
+              type: boolean
+              value: false
+    roles:
+      terms_authority_entity_id: ent_01decd128608f95599da1f3c
+      access_operator_entity_id: ent_01decd128608f95599da1f3c
+    access:
+      availability: public
+      instructions: Create a free account, then request the discount via support ticket in the dashboard.
+      method: form
+      url: https://lettermint.co/promo-codes-and-discounts/startups
+    source_ids:
+      - src_b202c99cef3415c0550d601c08616f5a302b7cf3cc5e94608ce59380077ad4f0

--- a/entities/qu/qarnot.yaml
+++ b/entities/qu/qarnot.yaml
@@ -1,0 +1,70 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1hppx9gmpt0a397prcktycp
+  slug: qarnot
+  slug_aliases: []
+  name: Qarnot
+  domains:
+    - value: qarnot.com
+      role: primary
+      valid_from: 2026-09-02T00:00:00.000Z
+  category: hosting-infra
+profile:
+  description: Qarnot provides sustainable, waste-heat-recovering cloud HPC and rendering infrastructure for compute-intensive workloads.
+  links:
+    site: https://qarnot.com
+sources:
+  - source_id: src_a8c368caec29037df355f80e2c48a7e4e49f82a60ef45aa005cae8b46d22b285
+    url: https://qarnot.com/en/start-up
+programs:
+  - program_id: prg_01m1hppx9m6abzs6eb4m8c60ex
+    program_slug: qarnot-start-up-program
+    program_slug_aliases: []
+    title: Qarnot Start-up Program
+    summary: Qarnot provides €6,000 in free cloud HPC credits over six months, then a 50% discount on computing usage, plus Research Tax Credit (CIR) eligibility for French companies using Qarnot's HPC solution.
+    source_ids:
+      - src_a8c368caec29037df355f80e2c48a7e4e49f82a60ef45aa005cae8b46d22b285
+offers:
+  - offer_id: off_01m1hppx9mvyeztfm9w61s2zet
+    program_id: prg_01m1hppx9m6abzs6eb4m8c60ex
+    offer_slug: qarnot-start-up-program
+    offer_slug_aliases: []
+    title: Qarnot Start-up Program
+    summary: Eligible startups receive €6,000 in free Qarnot cloud credits for the first six months, then 50% off computing usage with pay-as-you-go billing, plus optional Research Tax Credit (CIR) eligibility for French companies.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-02T00:00:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: €6,000 in free Qarnot cloud HPC credits for the first six months
+          kind: credit
+          value:
+            amount:
+              currency: EUR
+              minor_units: 600000
+            kind: up-to
+        - benefit_id: ben_02
+          description: 50% discount on computing usage with pay-as-you-go billing after free credits are used
+          kind: discount
+          value:
+            percent: 50
+        - benefit_id: ben_03
+          description: Research Tax Credit (CIR) eligibility for French companies using Qarnot's HPC solution for R&D projects
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: manual
+        reason: vendor-discretion
+        statement: Startups must apply through the Qarnot start-up program page and be approved by Qarnot; terms eligibility and start-up qualification are at the vendor's discretion.
+    roles:
+      terms_authority_entity_id: ent_01m1hppx9gmpt0a397prcktycp
+      access_operator_entity_id: ent_01m1hppx9gmpt0a397prcktycp
+    access:
+      availability: public
+      method: form
+      url: https://qarnot.com/en/start-up
+    source_ids:
+      - src_a8c368caec29037df355f80e2c48a7e4e49f82a60ef45aa005cae8b46d22b285

--- a/entities/we/wevestr.yaml
+++ b/entities/we/wevestr.yaml
@@ -1,0 +1,94 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1srjgzbq7g4avpk4w5tdxwk
+  slug: wevestr
+  slug_aliases: []
+  name: WE.VESTR
+  domains:
+  - value: wevestr.com
+    role: primary
+    valid_from: '2026-09-05T21:49:37.540Z'
+  category: banking
+profile:
+  description: WE.VESTR is an equity management platform that helps startups manage
+    cap tables, stakeholder records, and equity plans from incorporation through exit.
+  links:
+    site: https://wevestr.com
+sources:
+- source_id: src_3ae35796bef4f724cb10137b35d223dc417019945a5d475c144af33775c7539f
+  url: https://wevestr.com/microsoft-for-startups
+- source_id: src_b2019d3b081760cfe71ef2510252e8fb8cc3cd24f5a50b705ed7c98cb43641a2
+  url: https://learn.microsoft.com/en-us/startups/benefits/technical-benefits/third-party-benefits/we-vest
+programs:
+- program_id: prg_01m1srjgzqyned01scq3epfpnp
+  program_slug: microsoft-for-startups
+  program_slug_aliases: []
+  title: Microsoft for Startups
+  summary: Microsoft for Startups provides equity-management discounts to its member
+    startups through third-party partner offers.
+  source_ids:
+  - src_b2019d3b081760cfe71ef2510252e8fb8cc3cd24f5a50b705ed7c98cb43641a2
+offers:
+- offer_id: off_01m1srjgzqzv7hs0jbq16b845x
+  program_id: prg_01m1srjgzqyned01scq3epfpnp
+  offer_slug: 70-percent-off-first-year-for-microsoft-for-startups
+  offer_slug_aliases: []
+  title: 70% off the first year of WE.VESTR equity-management plans for Microsoft
+    for Startups members
+  summary: Microsoft for Startups members who are new WE.VESTR customers can receive
+    70% off their first year of WE.VESTR equity-management plans, valid for 12 months.
+  lifecycle:
+    status: active
+    effective_from: '2026-09-05T21:49:37.540Z'
+  economics:
+    benefits:
+    - benefit_id: ben_01
+      applies_to: WE.VESTR equity-management plans
+      description: 70% off for the first year of WE.VESTR equity-management plans,
+        valid for 12 months
+      duration:
+        kind: exact
+        value: P1Y
+      kind: discount
+      percentage:
+        basis_points: 7000
+        kind: exact
+    consideration:
+      kind: none
+  eligibility:
+    rule:
+      kind: all
+      rules:
+      - criterion_id: cri_01
+        kind: manual
+        reason: external-verification
+        statement: Must be a member of Microsoft for Startups.
+      - criterion_id: cri_02
+        kind: predicate
+        fact: company.is_current_customer
+        operator: eq
+        statement: Must be a new WE.VESTR customer.
+        value:
+          type: boolean
+          value: false
+      - criterion_id: cri_03
+        kind: predicate
+        fact: company.stakeholder_count
+        operator: gte
+        statement: Must have at least 30 stakeholders.
+        value:
+          type: integer
+          value: 30
+  roles:
+    terms_authority_entity_id: ent_01m1srjgzbq7g4avpk4w5tdxwk
+    access_operator_entity_id: ent_01kyh8fpe3n3yye39kmzvy410z
+  access:
+    availability: membership
+    method: form
+    url: https://learn.microsoft.com/en-us/startups/benefits/technical-benefits/third-party-benefits/we-vest
+    instructions: Access the offer through the Microsoft for Startups Founders Hub
+      Benefits page. The WE.VESTR first-year discount is listed under third-party
+      technical benefits and requires active Microsoft for Startups membership.
+  source_ids:
+  - src_3ae35796bef4f724cb10137b35d223dc417019945a5d475c144af33775c7539f
+  - src_b2019d3b081760cfe71ef2510252e8fb8cc3cd24f5a50b705ed7c98cb43641a2


### PR DESCRIPTION
## Summary

Add Enterprise Singapore entity with the Startup SG Founder grant offer.

### Entity Details
- **Entity**: Enterprise Singapore (`enterprise-singapore`)
- **Entity ID**: `ent_01m1t013nvktzy8rqyrpjkazkr`

### Offer: Startup SG Founder Grant
- **Offer ID**: `off_01m1t013p9wvyky9zggf57a3m1`
- **Grant amount**: SGD 20,000–50,000
- **Additional benefit**: 1:1 capital co-matching + Accredited Mentor Partner support
- **Eligibility**: First-time Singaporean or permanent-resident founders
- **Access**: Application via online portal

### Sources
- https://www.enterprisesg.gov.sg/grow-your-business/partner-with-singapore/innovation-and-startups/join-startup-sg
- https://www.startupsg.gov.sg/programmes/4894/startup-sg-founder
- https://www.startupsg.gov.sg/programmes/4894/startup-sg-founder/eligibility
- https://www.startupsg.gov.sg/programmes/4894/startup-sg-founder/apply

### Addresses
This PR addresses GitHub issue #1363.
