### PR TITLE
data: add AgentMail for Startups (fixes #729)

### DIFF
--- a/entities/ag/agentmail.yaml
+++ b/entities/ag/agentmail.yaml
@@ -1,0 +1,103 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1t1qv3nkbheegg2zjmmcck7
+  slug: agentmail
+  slug_aliases: []
+  name: AgentMail
+  domains:
+    - value: agentmail.to
+      role: primary
+      valid_from: 2026-09-06T00:25:00.000Z
+  category: communication
+profile:
+  description: AgentMail provides an email inbox API for AI agents, with programmatic inboxes, custom domains, and agent-native SDKs.
+  links:
+    site: https://www.agentmail.to
+    pricing: https://www.agentmail.to/pricing
+sources:
+  - source_id: src_aabe8a185b080db3d1c64cb90fd9703d512a5190ae03215f439801d43026990d
+    url: https://www.agentmail.to/startups
+  - source_id: src_8933eaae80cce0943670d2ba204c601b65a4d72adc0b5b572663d173bcf80236
+    url: https://www.agentmail.to/pricing
+programs:
+  - program_id: prg_01m1t1qv3vdq0smmz6z7k19ph5
+    program_slug: agentmail-for-startups
+    program_slug_aliases: []
+    title: AgentMail for Startups
+    summary: AgentMail's startup program gives approved early-stage AI-agent companies three months of the Startup tier free, then standard Startup pricing.
+    source_ids:
+      - src_aabe8a185b080db3d1c64cb90fd9703d512a5190ae03215f439801d43026990d
+offers:
+  - offer_id: off_01m1t1qv3wn7wmw1tqkcfgwdbr
+    program_id: prg_01m1t1qv3vdq0smmz6z7k19ph5
+    offer_slug: three-months-free-startup-tier
+    offer_slug_aliases: []
+    title: Three months free on the AgentMail Startup tier
+    summary: Approved first-time customers building AI agents with $500K–$10M raised receive the $200/mo Startup tier free for three months, including 150 inboxes, 150 custom domains, 10 seats, and a SOC 2 report.
+    description: AgentMail publishes the offer on its startups page. After the three free months, the account moves to standard Startup pricing at $200 per month unless cancelled. No credit card is required to apply. Applications are reviewed individually within a few business days.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T00:25:00.000Z
+    economics:
+      consideration:
+        kind: none
+      benefits:
+        - benefit_id: ben_01
+          description: Full AgentMail Startup tier free for three months (normally $200 per month), including 150 inboxes, 150 custom domains, 10 organization seats, and SOC 2 report access
+          kind: free-service
+          service: AgentMail Startup tier
+          duration:
+            kind: exact
+            value: P3M
+          value:
+            amount:
+              currency: USD
+              minor_units: 60000
+            kind: exact
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: Applicant is building with AI agents.
+          - criterion_id: cri_02
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: gte
+            statement: Applicant has raised at least $500,000 in funding.
+            value:
+              type: number
+              value: 500000
+          - criterion_id: cri_03
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lte
+            statement: Applicant has raised at most $10,000,000 in funding.
+            value:
+              type: number
+              value: 10000000
+          - criterion_id: cri_04
+            fact: company.is_current_customer
+            kind: predicate
+            operator: eq
+            statement: Applicant is not currently, and has never previously been, a customer of AgentMail.
+            value:
+              type: boolean
+              value: false
+          - criterion_id: cri_05
+            kind: manual
+            reason: vendor-discretion
+            statement: AgentMail reviews each application for fit and emails the result within a few business days.
+    roles:
+      terms_authority_entity_id: ent_01m1t1qv3nkbheegg2zjmmcck7
+      access_operator_entity_id: ent_01m1t1qv3nkbheegg2zjmmcck7
+    access:
+      availability: public
+      method: form
+      instructions: Submit the application form on the AgentMail for Startups page. No credit card is required.
+      url: https://www.agentmail.to/startups
+    source_ids:
+      - src_aabe8a185b080db3d1c64cb90fd9703d512a5190ae03215f439801d43026990d
+      - src_8933eaae80cce0943670d2ba204c601b65a4d72adc0b5b572663d173bcf80236

--- a/entities/ag/agentmail.yaml
+++ b/entities/ag/agentmail.yaml
@@ -49,11 +49,6 @@ offers:
           duration:
             kind: exact
             value: P3M
-          value:
-            amount:
-              currency: USD
-              minor_units: 60000
-            kind: exact
     eligibility:
       rule:
         kind: all


### PR DESCRIPTION
## Summary
Adds one data-only Entity YAML for **AgentMail** (`agentmail.to`) covering the first-party **AgentMail for Startups** offer:

- Three months free on the Startup tier (normally **$200/mo**)
- Includes 150 inboxes, 150 custom domains, 10 organization seats, SOC 2 report
- Eligibility: building with AI agents; raised $500K–$10M; never previously an AgentMail customer
- Apply via public form (no credit card)

Sources:
- https://www.agentmail.to/startups
- https://www.agentmail.to/pricing

Closes / fixes #729 (reauthor after prior format cutover; no open replacement PR).

## Checklist
- [x] Exactly one new Entity file at `entities/ag/agentmail.yaml`
- [x] Data-only (no docs/workflow/code)
- [x] Fresh `ent_` / `prg_` / `off_` / `src_` IDs
- [x] DCO Signed-off-by on commit
- [x] Facts limited to first-party pages

AI-assisted contribution by veriton-dev / agent-064c1e.