### PR TITLE
data: add WE.VESTR Microsoft for Startups discount

### DIFF
--- a/entities/we/we-vestr.yaml
+++ b/entities/we/we-vestr.yaml
@@ -1,0 +1,86 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1temg1fpgxjm9b5zn7eyhem
+  slug: we-vestr
+  slug_aliases: []
+  name: WE.VESTR
+  domains:
+    - value: wevestr.com
+      role: primary
+      valid_from: 2026-09-06T03:20:00.000Z
+  category: finance-accounting
+profile:
+  description: WE.VESTR provides equity management for startups, covering cap
+    tables, shareholder reporting, fundraising, and employee equity plans.
+  links:
+    site: https://wevestr.com
+sources:
+  - source_id: src_4763e176439b78b62fe9b12f3e96a332e12dcfc52d74b1b4ba63cf806220bc49
+    url: https://learn.microsoft.com/en-us/startups/benefits/technical-benefits/third-party-benefits/we-vestr
+programs:
+  - program_id: prg_01m1temg1mvw5zncv6cs8ph9wm
+    program_slug: we-vestr-microsoft-for-startups-benefit
+    program_slug_aliases: []
+    title: WE.VESTR Microsoft for Startups Benefit
+    summary: A WE.VESTR benefit offered to Microsoft for Startups members,
+      redeemed through the Microsoft for Startups benefits portal.
+    source_ids:
+      - src_4763e176439b78b62fe9b12f3e96a332e12dcfc52d74b1b4ba63cf806220bc49
+offers:
+  - offer_id: off_01m1temg1m793t8v568z37r8rx
+    program_id: prg_01m1temg1mvw5zncv6cs8ph9wm
+    offer_slug: microsoft-members-first-year-discount
+    offer_slug_aliases: []
+    title: 70% off WE.VESTR paid plans for the first year
+    summary: Microsoft for Startups members with 30 or more stakeholders get 70%
+      off their first year on WE.VESTR paid plans; teams with fewer than 30
+      stakeholders can use the platform for free.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T03:20:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_first_year_discount
+          kind: discount
+          description: 70% off the first year of a WE.VESTR paid plan for
+            eligible new customers with 30 or more stakeholders. Free access is
+            available for teams with fewer than 30 stakeholders.
+          percentage:
+            kind: exact
+            basis_points: 7000
+          duration:
+            kind: exact
+            value: P1Y
+          applies_to: WE.VESTR Grow and Scale plans for customers with 30 or more stakeholders
+      consideration:
+        kind: unknown
+        description: A paid WE.VESTR plan subscription at the discounted price
+          is required; after the first year regular pricing applies.
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_program_membership
+            kind: manual
+            reason: external-verification
+            statement: Must be a member of Microsoft for Startups, available to
+              startups backed by a VC, accelerator, incubator, or university in
+              the Microsoft Investor Network.
+          - criterion_id: cri_stakeholders
+            kind: manual
+            reason: external-verification
+            statement: 30 or more stakeholders for the paid-plan discount; fewer
+              than 30 stakeholders qualify for free access.
+    roles:
+      terms_authority_entity_id: ent_01m1temg1fpgxjm9b5zn7eyhem
+      access_operator_entity_id: ent_01m1temg1fpgxjm9b5zn7eyhem
+    access:
+      availability: public
+      method: form
+      url: https://learn.microsoft.com/en-us/startups/benefits/technical-benefits/third-party-benefits/we-vestr
+      instructions: Sign in to the Microsoft for Startups benefits portal, find
+        the WE.VESTR benefit, and click Redeem to reach a WE.VESTR landing page
+        that verifies membership.
+    terms_url: https://learn.microsoft.com/en-us/startups/benefits/technical-benefits/third-party-benefits/we-vestr
+    source_ids:
+      - src_4763e176439b78b62fe9b12f3e96a332e12dcfc52d74b1b4ba63cf806220bc49


### PR DESCRIPTION
Adds one new Entity YAML at `entities/we/we-vestr.yaml` with exactly one offer, sourced from the vendor-owned pages. Data-only change with DCO sign-off. Resolves #1328