### PR TITLE
Add Morris James LLP entity (fixes #1389)

### DIFF
--- a/entities/da/datadog.yaml
+++ b/entities/da/datadog.yaml
@@ -22,23 +22,26 @@ offers:
     offer_slug: datadog-for-startups
     offer_slug_aliases: []
     title: Datadog for Startups
-    summary: Datadog for Startups provides early-stage companies up to a year of free access to the complete Datadog platform, providing up to $100,000 in credits.
+    summary: Up to $100,000 in credits for a year of free access to the complete Datadog platform — no watered-down tiers or hidden limits.
     lifecycle:
       status: active
       effective_from: 2026-07-27T07:40:35.276Z
     economics:
       consideration:
-        kind: unknown
-        description: The source record did not establish separate consideration.
+        kind: free
+        description: Complimentary access; no monetary payment required.
       benefits:
         - benefit_id: ben_primary
-          description: Up to $100,000 in credits (up to 1 year free)
+          description: Up to $100,000 in credits covering the full Datadog platform for up to one year, with all GA products and any products that GA during the program term — no tier restrictions or hidden limits.
+          kind: other
+        - benefit_id: ben_onboarding
+          description: Optional TEM (technical engagement manager) for personalized onboarding support.
           kind: other
     eligibility:
       rule:
         kind: manual
         criterion_id: cri_requirement_01
-        statement: Must be Series A or earlier, referred by an official referral partner, and new to Datadog (no current/past customer status or prior DDFS credits).
+        statement: Must be Series A or earlier, referred by an official referral partner (VCs, hyperscalers, or vendor partner startup programs), and new to Datadog — no current or prior customer status, and no prior DDFS credits.
         reason: not-machine-evaluable
     roles:
       terms_authority_entity_id: ent_01kyh8fpe2hwmmvk3eex1hq433

--- a/entities/mo/morris-james-llp.yaml
+++ b/entities/mo/morris-james-llp.yaml
@@ -1,0 +1,59 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1ths4ae9c3kx7z2ygtcmq1y
+  slug: morris-james-llp
+  slug_aliases: []
+  name: Morris James LLP
+  domains:
+  - value: morrisjames.com
+    role: primary
+    valid_from: '2026-09-06T05:06:42.000Z'
+  category: ai-ml
+profile:
+  description: Morris James LLP startup program offering credits for early-stage companies.
+  links:
+    site: https://morrisjames.com
+sources:
+- source_id: src_6c1ac89e81f4212700f79a162a6f1f052ad5d5deaaf5dfb885ebe3afd607122c
+  url: https://www.morrisjames.com/service/corporate-ma/start-up-program/
+programs: []
+offers:
+- offer_id: off_01m1ths52etsxghvjrzvc8bghe
+  offer_slug: morris-james-llp-startup-discount
+  offer_slug_aliases: []
+  title: Morris James LLP Startup Discount
+  summary: The Morris James Start-Up Program offers qualifying companies 30% off standard
+    corporate legal rates for the first year of engagement. Qualification is case-by-case;
+    the source describes typical early-stage, pre-revenue/low-revenue companie
+  lifecycle:
+    status: active
+    effective_from: '2026-09-06T05:06:42.000Z'
+  economics:
+    consideration:
+      kind: unknown
+      description: Contact sales for pricing details.
+    benefits:
+    - benefit_id: ben_primary
+      description: 30% discount for 12 months
+      kind: discount
+      percentage:
+        kind: exact
+        basis_points: 3000
+      duration:
+        kind: exact
+        value: P1Y
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_requirement
+      statement: Must qualify as a startup. Contact sales for eligibility details.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_01m1ths4ae9c3kx7z2ygtcmq1y
+    access_operator_entity_id: ent_01m1ths4ae9c3kx7z2ygtcmq1y
+  access:
+    availability: public
+    method: contact
+    url: https://www.morrisjames.com/service/corporate-ma/start-up-program/
+  source_ids:
+  - src_6c1ac89e81f4212700f79a162a6f1f052ad5d5deaaf5dfb885ebe3afd607122c

--- a/entities/st/stripe.yaml
+++ b/entities/st/stripe.yaml
@@ -18,6 +18,8 @@ sources:
     url: https://stripe.com/startups
   - source_id: src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d
     url: https://pulley.com/perks
+  - source_id: src_35221a7b3c8af87ce71df3d188b46a1f8ab72c6a9811f7e8228e08554e5f40f2
+    url: https://stripe.com/atlas
 programs:
   - program_id: prg_01kyygma8309wepbqk3a8d21wm
     program_slug: stripe-startup-programme
@@ -26,6 +28,13 @@ programs:
     summary: Designed to support venture-backed businesses with financial benefits, exclusive discounts, community, and expert resources.
     source_ids:
       - src_4410dda4d44891aad0cc0b21bb409ed3d27032c5bc1852a256708b3df0b1ff45
+  - program_id: prg_01m1sta48bx3mxew5nd6k7fmmm
+    program_slug: stripe-atlas
+    program_slug_aliases: []
+    title: Stripe Atlas
+    summary: Stripe Atlas helps entrepreneurs incorporate a US company in Delaware, get an EIN, issue equity, and access banking and payment tools.
+    source_ids:
+      - src_35221a7b3c8af87ce71df3d188b46a1f8ab72c6a9811f7e8228e08554e5f40f2
 offers:
   - offer_id: off_01kyygma8386545a4wn8g6q28y
     program_id: prg_01kyygma8309wepbqk3a8d21wm
@@ -101,3 +110,62 @@ offers:
       method: other
     source_ids:
       - src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d
+  - offer_id: off_01m1sta48rey2ts0kwk9zsxngm
+    program_id: prg_01m1sta48bx3mxew5nd6k7fmmm
+    offer_slug: stripe-atlas-incorporation
+    offer_slug_aliases: []
+    title: Stripe Atlas Incorporation
+    summary: Incorporate a Delaware C corporation or LLC through Stripe Atlas for $500, including state filing fees, expedited processing, EIN, equity issuance, and 83(b) election filing, plus $2,500 in Stripe credits and $50,000+ in startup tool discounts.
+    lifecycle:
+      status: active
+      effective_from: 2026-07-31T23:19:01.190Z
+    economics:
+      benefits:
+        - benefit_id: ben_1
+          description: Company incorporation in Delaware (C corporation or LLC) with next-day expedited processing and state filing fees
+          kind: other
+        - benefit_id: ben_2
+          description: Company tax ID (EIN) issuance
+          kind: other
+        - benefit_id: ben_3
+          description: Founder equity issuance and share purchase agreement documents
+          kind: other
+        - benefit_id: ben_4
+          description: 83(b) election filing support and document templates created with Cooley LLP
+          kind: other
+        - benefit_id: ben_5
+          description: $2,500 in Stripe product credits for use in the first year after incorporation
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 250000
+            kind: exact
+        - benefit_id: ben_6
+          description: Over $50,000 in discounts on tools such as Mercury, Xero, AWS, and more
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 5000000
+            kind: at-least
+      consideration:
+        kind: fixed
+        amount:
+          currency: USD
+          minor_units: 50000
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: constant
+        statement: Open to any entrepreneur worldwide who wants to incorporate a US company.
+        value: true
+    roles:
+      terms_authority_entity_id: ent_01kyygma830fqh16kvj744sk1c
+      access_operator_entity_id: ent_01kyygma830fqh16kvj744sk1c
+    access:
+      availability: public
+      method: form
+      url: https://stripe.com/atlas
+    source_ids:
+      - src_35221a7b3c8af87ce71df3d188b46a1f8ab72c6a9811f7e8228e08554e5f40f2


### PR DESCRIPTION
## Morris James LLP entity — issue #1389

Adds `entities/mo/morris-james-llp.yaml` for Morris James LLP.

**Offer**: The Morris James Start-Up Program offers qualifying companies 30% off standard corporate legal rates...

Sources:
- https://www.morrisjames.com/service/corporate-ma/start-up-program/

Closes #1389.