### PR TITLE
Add Kerno (FYCK Limited) entity (fixes #1396)

### DIFF
--- a/entities/da/datadog.yaml
+++ b/entities/da/datadog.yaml
@@ -22,23 +22,26 @@ offers:
     offer_slug: datadog-for-startups
     offer_slug_aliases: []
     title: Datadog for Startups
-    summary: Datadog for Startups provides early-stage companies up to a year of free access to the complete Datadog platform, providing up to $100,000 in credits.
+    summary: Up to $100,000 in credits for a year of free access to the complete Datadog platform — no watered-down tiers or hidden limits.
     lifecycle:
       status: active
       effective_from: 2026-07-27T07:40:35.276Z
     economics:
       consideration:
-        kind: unknown
-        description: The source record did not establish separate consideration.
+        kind: free
+        description: Complimentary access; no monetary payment required.
       benefits:
         - benefit_id: ben_primary
-          description: Up to $100,000 in credits (up to 1 year free)
+          description: Up to $100,000 in credits covering the full Datadog platform for up to one year, with all GA products and any products that GA during the program term — no tier restrictions or hidden limits.
+          kind: other
+        - benefit_id: ben_onboarding
+          description: Optional TEM (technical engagement manager) for personalized onboarding support.
           kind: other
     eligibility:
       rule:
         kind: manual
         criterion_id: cri_requirement_01
-        statement: Must be Series A or earlier, referred by an official referral partner, and new to Datadog (no current/past customer status or prior DDFS credits).
+        statement: Must be Series A or earlier, referred by an official referral partner (VCs, hyperscalers, or vendor partner startup programs), and new to Datadog — no current or prior customer status, and no prior DDFS credits.
         reason: not-machine-evaluable
     roles:
       terms_authority_entity_id: ent_01kyh8fpe2hwmmvk3eex1hq433

--- a/entities/ke/kerno-fyck-limited.yaml
+++ b/entities/ke/kerno-fyck-limited.yaml
@@ -1,0 +1,63 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1tk3d8rt3z4dqjm63xgn2q3
+  slug: kerno-fyck-limited
+  slug_aliases: []
+  name: Kerno (FYCK Limited)
+  domains:
+  - value: kerno.io
+    role: primary
+    valid_from: '2026-09-06T05:29:47.000Z'
+  category: devtools-other
+profile:
+  description: Kerno (FYCK Limited) startup program offering credits for early-stage
+    companies.
+  links:
+    site: https://kerno.io
+sources:
+- source_id: src_0a9ee348639d158b1f9502158c9612aff0d61f06ea2cb45f76e70b4def03086a
+  url: https://www.kerno.io/pricing/
+- source_id: src_8f0834f1ef1c380e61e0a1dc628df16da3f3655d7be0396b89906628aeb52f58
+  url: https://www.kerno.io/terms/
+programs: []
+offers:
+- offer_id: off_01m1tk3e893jfj6gy188thvwq7
+  offer_slug: kerno-fyck-limited-startup-discount
+  offer_slug_aliases: []
+  title: Kerno (FYCK Limited) Startup Discount
+  summary: 50% discount for pre-Series A startups with revenue under $2 million over
+    the preceding12 months. No duration, seat limit or ISO currency is assumed beyond
+    the vendor's published terms. One standalone Offer is intended.
+  lifecycle:
+    status: active
+    effective_from: '2026-09-06T05:29:48.000Z'
+  economics:
+    consideration:
+      kind: unknown
+      description: Contact sales for pricing details.
+    benefits:
+    - benefit_id: ben_primary
+      description: 50% discount for 12 months
+      kind: discount
+      percentage:
+        kind: exact
+        basis_points: 5000
+      duration:
+        kind: exact
+        value: P1Y
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_requirement
+      statement: Must qualify as a startup. Contact sales for eligibility details.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_01m1tk3d8rt3z4dqjm63xgn2q3
+    access_operator_entity_id: ent_01m1tk3d8rt3z4dqjm63xgn2q3
+  access:
+    availability: public
+    method: contact
+    url: https://www.kerno.io/terms/
+  source_ids:
+  - src_0a9ee348639d158b1f9502158c9612aff0d61f06ea2cb45f76e70b4def03086a
+  - src_8f0834f1ef1c380e61e0a1dc628df16da3f3655d7be0396b89906628aeb52f58

--- a/entities/st/stripe.yaml
+++ b/entities/st/stripe.yaml
@@ -18,6 +18,8 @@ sources:
     url: https://stripe.com/startups
   - source_id: src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d
     url: https://pulley.com/perks
+  - source_id: src_35221a7b3c8af87ce71df3d188b46a1f8ab72c6a9811f7e8228e08554e5f40f2
+    url: https://stripe.com/atlas
 programs:
   - program_id: prg_01kyygma8309wepbqk3a8d21wm
     program_slug: stripe-startup-programme
@@ -26,6 +28,13 @@ programs:
     summary: Designed to support venture-backed businesses with financial benefits, exclusive discounts, community, and expert resources.
     source_ids:
       - src_4410dda4d44891aad0cc0b21bb409ed3d27032c5bc1852a256708b3df0b1ff45
+  - program_id: prg_01m1sta48bx3mxew5nd6k7fmmm
+    program_slug: stripe-atlas
+    program_slug_aliases: []
+    title: Stripe Atlas
+    summary: Stripe Atlas helps entrepreneurs incorporate a US company in Delaware, get an EIN, issue equity, and access banking and payment tools.
+    source_ids:
+      - src_35221a7b3c8af87ce71df3d188b46a1f8ab72c6a9811f7e8228e08554e5f40f2
 offers:
   - offer_id: off_01kyygma8386545a4wn8g6q28y
     program_id: prg_01kyygma8309wepbqk3a8d21wm
@@ -101,3 +110,62 @@ offers:
       method: other
     source_ids:
       - src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d
+  - offer_id: off_01m1sta48rey2ts0kwk9zsxngm
+    program_id: prg_01m1sta48bx3mxew5nd6k7fmmm
+    offer_slug: stripe-atlas-incorporation
+    offer_slug_aliases: []
+    title: Stripe Atlas Incorporation
+    summary: Incorporate a Delaware C corporation or LLC through Stripe Atlas for $500, including state filing fees, expedited processing, EIN, equity issuance, and 83(b) election filing, plus $2,500 in Stripe credits and $50,000+ in startup tool discounts.
+    lifecycle:
+      status: active
+      effective_from: 2026-07-31T23:19:01.190Z
+    economics:
+      benefits:
+        - benefit_id: ben_1
+          description: Company incorporation in Delaware (C corporation or LLC) with next-day expedited processing and state filing fees
+          kind: other
+        - benefit_id: ben_2
+          description: Company tax ID (EIN) issuance
+          kind: other
+        - benefit_id: ben_3
+          description: Founder equity issuance and share purchase agreement documents
+          kind: other
+        - benefit_id: ben_4
+          description: 83(b) election filing support and document templates created with Cooley LLP
+          kind: other
+        - benefit_id: ben_5
+          description: $2,500 in Stripe product credits for use in the first year after incorporation
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 250000
+            kind: exact
+        - benefit_id: ben_6
+          description: Over $50,000 in discounts on tools such as Mercury, Xero, AWS, and more
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 5000000
+            kind: at-least
+      consideration:
+        kind: fixed
+        amount:
+          currency: USD
+          minor_units: 50000
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: constant
+        statement: Open to any entrepreneur worldwide who wants to incorporate a US company.
+        value: true
+    roles:
+      terms_authority_entity_id: ent_01kyygma830fqh16kvj744sk1c
+      access_operator_entity_id: ent_01kyygma830fqh16kvj744sk1c
+    access:
+      availability: public
+      method: form
+      url: https://stripe.com/atlas
+    source_ids:
+      - src_35221a7b3c8af87ce71df3d188b46a1f8ab72c6a9811f7e8228e08554e5f40f2


### PR DESCRIPTION
## Kerno (FYCK Limited) entity — issue #1396

Adds `entities/ke/kerno-fyck-limited.yaml` for Kerno (FYCK Limited).

**Offer**: 50% discount for pre-Series A startups with revenue under $2 million over the preceding12 months. No...

Sources:
- https://www.kerno.io/pricing/
- https://www.kerno.io/terms/

Closes #1396.