### PR TITLE
Add Mobot YC startup QA discount

### DIFF
--- a/entities/mo/mobot.yaml
+++ b/entities/mo/mobot.yaml
@@ -1,0 +1,62 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1tmqs7ng9cgb1827bk1ghpn
+  slug: mobot
+  slug_aliases: []
+  name: Mobot
+  domains:
+    - value: mobot.io
+      role: primary
+      valid_from: 2026-09-06T05:58:23.221Z
+  category: devtools-other
+profile:
+  description: Mobot provides robot-powered mobile app regression testing on physical iOS and Android devices.
+  links:
+    site: https://www.mobot.io/
+sources:
+  - source_id: src_b4eeba98837be73b8f1b01f756bda8a3e571ab57f60993af21255a28c85a760e
+    url: https://www.mobot.io/yc-startup-support
+programs: []
+offers:
+  - offer_id: off_01m1tmqs7pbaxzd0w13c4rr59s
+    offer_slug: yc-startup-support
+    offer_slug_aliases: []
+    title: YC Startup Support mobile QA discount
+    summary: New YC startups receive 50% off a one-month Mobot base-tier mobile QA pilot, with 2,500 Mobot Credits included.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T05:58:23.221Z
+    economics:
+      consideration:
+        kind: variable
+        description: A paid one-month base-tier pilot is required; the published saving is USD 1,250.
+      benefits:
+        - benefit_id: ben_01m1tmqs7pf29t6nn53170a1fs
+          kind: discount
+          applies_to: Mobot base-tier one-month mobile QA pilot
+          percentage:
+            kind: exact
+            basis_points: 5000
+          duration:
+            kind: exact
+            value: P1M
+          description: 50% discount on the base-tier pilot.
+        - benefit_id: ben_01m1tmqs7p31eqjjqdfsvqvjs8
+          kind: other
+          description: 2,500 Mobot Credits included at no extra charge when starting the pilot; test-case setup is limited to 500 unique actions per month.
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_yc_new_customer
+        reason: external-verification
+        statement: Y Combinator startups with a native iOS/Android app or mobile web app; existing and prior customers are excluded. The team must provide access to a staging/test build.
+    roles:
+      terms_authority_entity_id: ent_01m1tmqs7ng9cgb1827bk1ghpn
+      access_operator_entity_id: ent_01m1tmqs7ng9cgb1827bk1ghpn
+    access:
+      availability: public
+      method: form
+      url: https://www.mobot.io/yc-startup-support
+    terms_url: https://www.mobot.io/yc-startup-support
+    source_ids:
+      - src_b4eeba98837be73b8f1b01f756bda8a3e571ab57f60993af21255a28c85a760e

--- a/entities/mo/mobot.yaml
+++ b/entities/mo/mobot.yaml
@@ -22,14 +22,14 @@ offers:
     offer_slug: yc-startup-support
     offer_slug_aliases: []
     title: YC Startup Support mobile QA discount
-    summary: New YC startups receive 50% off a one-month Mobot base-tier mobile QA pilot, with 2,500 Mobot Credits included.
+    summary: YC startups that have never been Mobot customers receive 50% off a one-month Mobot base-tier mobile QA pilot, with 2,500 Mobot Credits included.
     lifecycle:
       status: active
       effective_from: 2026-09-06T05:58:23.221Z
     economics:
       consideration:
         kind: variable
-        description: A paid one-month base-tier pilot is required; the published saving is USD 1,250.
+        description: A paid one-month base-tier pilot is required; the offer discounts the base package by 50%.
       benefits:
         - benefit_id: ben_01m1tmqs7pf29t6nn53170a1fs
           kind: discount
@@ -43,7 +43,7 @@ offers:
           description: 50% discount on the base-tier pilot.
         - benefit_id: ben_01m1tmqs7p31eqjjqdfsvqvjs8
           kind: other
-          description: 2,500 Mobot Credits included at no extra charge when starting the pilot; test-case setup is limited to 500 unique actions per month.
+          description: 2,500 Mobot Credits (service usage units) included at no extra charge when starting the pilot; test-case setup is limited to 500 unique actions per month.
     eligibility:
       rule:
         kind: manual


### PR DESCRIPTION
Adds Mobot and one YC Startup Support mobile QA offer in `entities/mo/mobot.yaml`. Closes #1403.

## Offer and evidence

The first-party [YC Startup Support page](https://www.mobot.io/yc-startup-support), particularly “How this works” and “Program Requirements & Terms”, supports these terms:

- A 50% discount applies to the base-tier one-month paid pilot. This is an explicitly YC-specific pilot discount; it is not represented as free testing or an unrestricted trial.
- The bundle includes 2,500 Mobot Credits. These are service usage units, modeled as an `other` benefit within the same offer, not cash credit or a second offer. No dollar-to-credit conversion or unspecified currency is inferred.
- Eligible teams are YC startups with native iOS/Android or mobile web apps that have never been Mobot customers. Both existing and prior customers are excluded.
- Teams provide a staging/test build; test-case setup is capped at 500 unique actions per month. The vendor's form is the access route. No continuing discount after the one-month pilot is promised.

## Validation and scope

Canonical local validation with the signed live identity context passed for this YAML. [Current-head GitHub validation](https://github.com/sourcey/startup-credits/actions/runs/34017197593) passed, including DCO. These structural checks do not replace Sourcey's private evidence admission.

- [Commit-pinned YAML](https://raw.githubusercontent.com/aipebble46fe1c33-jpg/startup-credits/b13e213a75d689fa4261030d8f2510dca90989a9/entities/mo/mobot.yaml)
- [PR diff](https://github.com/sourcey/startup-credits/pull/1404.diff)

Rechecked on 2026-09-06: main has no Mobot record; public issue/PR searches return only this reservation and PR. No matching public bounty event was found. Exactly one Entity YAML and one offer; IDs remain stable. Authoring timestamps are not claims of a vendor launch or domain registration date.

- [x] Data-only change; no code, generated evidence or unrelated paths.
- [x] First-party source supports factual values; prose is a neutral summary.
- [x] No contributor-authored verification, provenance or signature claims in YAML.
- [x] Commits include Signed-off-by.

AI-assisted contribution for [Frantic bounty 120](https://gofrantic.com/bounties/120), through this human-managed account.
