### PR TITLE
Add StrongKeep 500 Global portfolio discount

### DIFF
--- a/entities/st/strongkeep.yaml
+++ b/entities/st/strongkeep.yaml
@@ -23,7 +23,7 @@ offers:
     offer_slug_aliases: []
     title: 500 Global portfolio annual-plan discount
     summary: 500 Global portfolio startups receive 25% off StrongKeep Protection and Compliance annual base plans; additional devices remain full price. Offer valid until 30 June 2027.
-    description: The source gives an expiry date without a timezone or exact cutoff time. StrongKeep may modify or withdraw the offer without notice.
+    description: StrongKeep may modify or withdraw this portfolio offer without notice. Use of the service is subject to StrongKeep's terms of service.
     lifecycle:
       status: active
       effective_from: 2026-09-06T06:08:35.021Z

--- a/entities/st/strongkeep.yaml
+++ b/entities/st/strongkeep.yaml
@@ -1,0 +1,57 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1tnaepd10yyn2w51mxnma3m
+  slug: strongkeep
+  slug_aliases: []
+  name: StrongKeep
+  domains:
+    - value: strongkeep.com
+      role: primary
+      valid_from: 2026-09-06T06:08:35.021Z
+  category: auth-security
+profile:
+  description: StrongKeep bundles device protection, a web firewall, password management, staff training, and compliance guidance for businesses.
+  links:
+    site: https://www.strongkeep.com/
+sources:
+  - source_id: src_60657552df05ee67292e1eaaea21f5236fae77e98d64238be54ed0fb8fae5118
+    url: https://www.strongkeep.com/partners/500/
+programs: []
+offers:
+  - offer_id: off_01m1tnaepe0tbpvgss8qjcgdrk
+    offer_slug: 500-global-portfolio-discount
+    offer_slug_aliases: []
+    title: 500 Global portfolio annual-plan discount
+    summary: 500 Global portfolio startups receive 25% off StrongKeep Protection and Compliance annual base plans; additional devices remain full price. Offer valid until 30 June 2027.
+    description: The source gives an expiry date without a timezone or exact cutoff time. StrongKeep may modify or withdraw the offer without notice.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T06:08:35.021Z
+    economics:
+      consideration:
+        kind: variable
+        description: A paid annual Protection or Compliance base plan is required. Extra device coverage beyond the five included devices is charged at normal rates.
+      benefits:
+        - benefit_id: ben_01m1tnaepef8ph8vm66x58etmd
+          kind: discount
+          applies_to: Protection and Compliance annual base plans
+          percentage:
+            kind: exact
+            basis_points: 2500
+          description: 25% off annual base plans; the discount is applied at checkout after registration through the vendor partner-page links.
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_500_global_portfolio
+        reason: external-verification
+        statement: Exclusive to 500 Global portfolio companies. One account per company; non-transferable and not combinable with other promotions or discounts. Valid until 30 June 2027.
+    roles:
+      terms_authority_entity_id: ent_01m1tnaepd10yyn2w51mxnma3m
+      access_operator_entity_id: ent_01m1tnaepd10yyn2w51mxnma3m
+    access:
+      availability: public
+      method: automatic
+      url: https://www.strongkeep.com/partners/500/
+    terms_url: https://www.strongkeep.com/partners/500/
+    source_ids:
+      - src_60657552df05ee67292e1eaaea21f5236fae77e98d64238be54ed0fb8fae5118


### PR DESCRIPTION
Adds StrongKeep and one 500 Global portfolio offer in `entities/st/strongkeep.yaml`. Closes #1405.

## Offer and evidence

The vendor's [500 Global partner page](https://www.strongkeep.com/partners/500/), including “Offer Terms & Conditions”, supports these terms:

- The 25% discount covers Protection and Compliance annual base plans for 500 Global portfolio companies. It is a portfolio-restricted partner offer. The vendor implements access with an automatically applied promo code through its registration links; that mechanism is disclosed, not presented as a general-public coupon.
- A paid annual plan is required. Five devices are included; additional devices are charged at normal rates and excluded from the discount.
- Only one account per company is allowed. The offer is non-transferable and cannot be combined with other promotions or discounts. StrongKeep may modify or withdraw it without notice.
- The published expiry is 30 June 2027, preserved in the summary and eligibility. The source supplies no exact cutoff/timezone, so no UTC instant is invented. Annual billing is not assumed to establish a 12-month promotional duration or discounted renewal entitlement.

## Validation and scope

Canonical local validation with the signed live identity context passed for this YAML. [Current-head GitHub validation](https://github.com/sourcey/startup-credits/actions/runs/34017328704) passed, including DCO. These structural checks do not replace Sourcey's private evidence admission.

- [Commit-pinned YAML](https://raw.githubusercontent.com/aipebble46fe1c33-jpg/startup-credits/5d14c708e56402c58b8a47506e2c54ea85e73007/entities/st/strongkeep.yaml)
- [PR diff](https://github.com/sourcey/startup-credits/pull/1406.diff)

Rechecked on 2026-09-06: main has no StrongKeep record; public issue/PR searches return only this reservation and PR. No matching public bounty event was found. Exactly one Entity YAML and one offer; IDs remain stable. Authoring timestamps are not claims of a vendor launch or domain registration date.

- [x] Data-only change; no code, generated evidence or unrelated paths.
- [x] First-party source supports factual values; prose is a neutral summary.
- [x] No contributor-authored verification, provenance or signature claims in YAML.
- [x] Commits include Signed-off-by.

AI-assisted contribution for [Frantic bounty 120](https://gofrantic.com/bounties/120), through this human-managed account.
