### PR TITLE
data: add E2E Networks Startup Program offer

### DIFF
--- a/entities/e2/e2e-networks.yaml
+++ b/entities/e2/e2e-networks.yaml
@@ -1,0 +1,66 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1tpsk8hse4ty07p836bsjqq
+  slug: e2e-networks
+  slug_aliases: []
+  name: E2E Networks
+  domains:
+    - value: e2enetworks.com
+      role: primary
+      valid_from: 2026-09-06T06:34:19.000Z
+  category: hosting-infra
+profile:
+  description: E2E Networks provides cloud infrastructure, including GPU compute and other services for AI and general-purpose workloads.
+  links:
+    site: https://www.e2enetworks.com
+sources:
+  - source_id: src_f56a4e33855afad6fa5d16101b07eb9286e941ac1478e37e8e2a37d4af8364c1
+    url: https://www.e2enetworks.com/meity-startup
+programs:
+  - program_id: prg_01m1tpsk8mv6398km3sjxjcd7d
+    program_slug: e2e-cloud-for-meity-startups
+    program_slug_aliases: []
+    title: E2E Cloud for MeitY Startups
+    summary: E2E Networks supports incubators, accelerators, and their portfolio startups with cloud credits, discounts, technical guidance, training, and ecosystem access.
+    source_ids:
+      - src_f56a4e33855afad6fa5d16101b07eb9286e941ac1478e37e8e2a37d4af8364c1
+offers:
+  - offer_id: off_01m1tpsk8m2v8q4jjbw3xhsqrm
+    program_id: prg_01m1tpsk8mv6398km3sjxjcd7d
+    offer_slug: inr-20000-initial-cloud-credit
+    offer_slug_aliases: []
+    title: INR 20,000 Initial Cloud Credit
+    summary: Portfolio startups receive INR 20,000 in free initial credits to test E2E Networks cloud services, plus technical support, training, and ecosystem benefits.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T06:34:19.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: INR 20,000 in initial cloud credits for free to test E2E Networks services.
+          kind: credit
+          value:
+            amount:
+              currency: INR
+              minor_units: 2000000
+            kind: exact
+        - benefit_id: ben_02
+          description: Technical guidance, training, support, events, and access to investor and mentor networks.
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: external-verification
+        statement: Must be a portfolio startup participating through an incubator or accelerator accepted into the E2E Cloud for MeitY Startups program.
+    roles:
+      terms_authority_entity_id: ent_01m1tpsk8hse4ty07p836bsjqq
+      access_operator_entity_id: ent_01m1tpsk8hse4ty07p836bsjqq
+    access:
+      availability: membership
+      method: form
+      url: https://www.e2enetworks.com/meity-startup
+    source_ids:
+      - src_f56a4e33855afad6fa5d16101b07eb9286e941ac1478e37e8e2a37d4af8364c1

--- a/entities/e2/e2e-networks.yaml
+++ b/entities/e2/e2e-networks.yaml
@@ -10,57 +10,77 @@ entity:
       valid_from: 2026-09-06T06:34:19.000Z
   category: hosting-infra
 profile:
+  summary: Cloud infrastructure and GPU computing services for AI and machine-learning workloads.
   description: E2E Networks provides cloud infrastructure, including GPU compute and other services for AI and general-purpose workloads.
   links:
     site: https://www.e2enetworks.com
 sources:
   - source_id: src_f56a4e33855afad6fa5d16101b07eb9286e941ac1478e37e8e2a37d4af8364c1
-    url: https://www.e2enetworks.com/meity-startup
+    url: https://www.e2enetworks.com/startup-program
 programs:
   - program_id: prg_01m1tpsk8mv6398km3sjxjcd7d
-    program_slug: e2e-cloud-for-meity-startups
+    program_slug: startup-program
     program_slug_aliases: []
-    title: E2E Cloud for MeitY Startups
-    summary: E2E Networks supports incubators, accelerators, and their portfolio startups with cloud credits, discounts, technical guidance, training, and ecosystem access.
+    title: E2E Networks Startup Program
+    summary: E2E Networks provides eligible AI startups worldwide with cloud credits or usage-based discounts and engineering support through three program tiers.
     source_ids:
       - src_f56a4e33855afad6fa5d16101b07eb9286e941ac1478e37e8e2a37d4af8364c1
 offers:
   - offer_id: off_01m1tpsk8m2v8q4jjbw3xhsqrm
     program_id: prg_01m1tpsk8mv6398km3sjxjcd7d
-    offer_slug: inr-20000-initial-cloud-credit
+    offer_slug: ai-explorer
     offer_slug_aliases: []
-    title: INR 20,000 Initial Cloud Credit
-    summary: Portfolio startups receive INR 20,000 in free initial credits to test E2E Networks cloud services, plus technical support, training, and ecosystem benefits.
+    title: AI Explorer
+    summary: Eligible bootstrapped or early-stage AI startups receive $5,000 in free-to-use E2E Networks AI Cloud credits.
     lifecycle:
       status: active
       effective_from: 2026-09-06T06:34:19.000Z
     economics:
       benefits:
         - benefit_id: ben_01
-          description: INR 20,000 in initial cloud credits for free to test E2E Networks services.
+          description: $5,000 in free-to-use AI Cloud credits.
           kind: credit
           value:
             amount:
-              currency: INR
-              minor_units: 2000000
+              currency: USD
+              minor_units: 500000
             kind: exact
-        - benefit_id: ben_02
-          description: Technical guidance, training, support, events, and access to investor and mentor networks.
-          kind: other
       consideration:
         kind: none
     eligibility:
       rule:
-        criterion_id: cri_01
-        kind: manual
-        reason: external-verification
-        statement: Must be a portfolio startup participating through an incubator or accelerator accepted into the E2E Cloud for MeitY Startups program.
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: The company is a bootstrapped or early-stage startup with an AI-first product.
+          - criterion_id: cri_02
+            fact: company.employee_count
+            kind: predicate
+            operator: lte
+            statement: The company has 10 or fewer employees.
+            value:
+              type: number
+              value: 10
+          - criterion_id: cri_03
+            fact: company.age_months
+            kind: predicate
+            operator: lte
+            statement: The company was founded within the last five years.
+            value:
+              type: number
+              value: 60
+          - criterion_id: cri_04
+            kind: manual
+            reason: external-verification
+            statement: The company is legally incorporated in any country.
     roles:
       terms_authority_entity_id: ent_01m1tpsk8hse4ty07p836bsjqq
       access_operator_entity_id: ent_01m1tpsk8hse4ty07p836bsjqq
     access:
-      availability: membership
+      availability: public
       method: form
-      url: https://www.e2enetworks.com/meity-startup
+      url: https://www.e2enetworks.com/startup-program
     source_ids:
       - src_f56a4e33855afad6fa5d16101b07eb9286e941ac1478e37e8e2a37d4af8364c1


### PR DESCRIPTION
## Summary

Adds E2E Networks as one new entity with the AI Explorer startup offer.

The current first-party program page documents:

- $5,000 in free-to-use AI Cloud credits
- eligibility for bootstrapped or early-stage AI startups worldwide
- 10 or fewer employees and incorporation within the last five years

The vendor retired the earlier MeitY URL after this PR opened, so this revision uses its current Startup Program page.

## Source

- https://www.e2enetworks.com/startup-program

## Verification

- Pinned Sourcey verifier passed: 1 entity, 1 program, 1 offer
- git diff --check passed
- DCO sign-off included
- sourcey/validation passed on commit 3c8c8fe

Closes #1409