### PR TITLE
data: add GetBlock Solana Grant Program (fixes #593)

### DIFF
--- a/entities/ge/getblock.yaml
+++ b/entities/ge/getblock.yaml
@@ -1,0 +1,103 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1trnz9n2nz8jgzcr09d491p
+  slug: getblock
+  slug_aliases: []
+  name: GetBlock
+  domains:
+    - value: getblock.io
+      role: primary
+      valid_from: 2026-09-06T07:05:00.000Z
+  category: hosting-infra
+profile:
+  description: GetBlock provides blockchain RPC APIs, shared and dedicated nodes, and related Web3 infrastructure for developers and teams.
+  links:
+    site: https://getblock.io
+    pricing: https://getblock.io/pricing/
+sources:
+  - source_id: src_b14552ca60ceedce66c6d92d54fcb367549dee7d3afb44f2a066b3ecc5c0c46e
+    url: https://getblock.io/grant-program-solana/
+  - source_id: src_3a45c2df6a72436dc95c5a8fb7ba710cff0ac76b3caedfebca6e856840b43aeb
+    url: https://getblock.io/terms-of-service/grant-program-solana/
+  - source_id: src_e7679f96d5cda95dbf97dee77980a852b4b0e84307f4367b043e4761590750f3
+    url: https://getblock.io/blog/getblock-opens-solana-startup-program/
+programs:
+  - program_id: prg_01m1trnz9vyccz2smctysvvp85
+    program_slug: solana-grant-program
+    program_slug_aliases: []
+    title: GetBlock Solana Grant Program
+    summary: GetBlock's Solana Grant Program awards approved Solana builders non-cash compute credits and RPC access for up to 90 days.
+    source_ids:
+      - src_b14552ca60ceedce66c6d92d54fcb367549dee7d3afb44f2a066b3ecc5c0c46e
+      - src_3a45c2df6a72436dc95c5a8fb7ba710cff0ac76b3caedfebca6e856840b43aeb
+offers:
+  - offer_id: off_01m1trnz9w4d1y8vyrty90zp3j
+    program_id: prg_01m1trnz9vyccz2smctysvvp85
+    offer_slug: solana-startup-program-credits
+    offer_slug_aliases:
+      - solana-grant-compute-credits
+    title: Solana Startup Program compute credits
+    summary: Approved Solana teams can receive up to USD 10,000 in non-cash compute credits on a GetBlock account, valid for a 90-day grant period after activation.
+    description: >-
+      GetBlock publishes the Solana Grant Program for developers and teams building production-grade applications on Solana.
+      Credits are non-monetary promotional value applied to a GetBlock account for GetBlock Services during the Grant Period.
+      The actual award may be less than the USD 10,000 maximum and is set at GetBlock's discretion.
+      Participation and credit awards are not guaranteed.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T07:05:00.000Z
+    economics:
+      consideration:
+        kind: none
+      benefits:
+        - benefit_id: ben_01
+          description: Up to USD 10,000 in non-cash compute credits per team or organization, applied to the participant's GetBlock account for GetBlock Services.
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 1000000
+            kind: upper_bound
+          duration:
+            kind: exact
+            value: P90D
+        - benefit_id: ben_02
+          description: Solana RPC access and related GetBlock infrastructure resources usable during the grant period for the approved project.
+          kind: free-service
+          service: GetBlock Solana RPC and infrastructure access
+          duration:
+            kind: exact
+            value: P90D
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: Applicant is an individual, startup, or established entity willing to register a GetBlock account.
+          - criterion_id: cri_02
+            kind: manual
+            reason: external-verification
+            statement: Applicant is building or intends to build a project on the Solana network.
+          - criterion_id: cri_03
+            kind: manual
+            reason: external-verification
+            statement: Applicant is not subject to sanctions or export restrictions that would prohibit participation.
+          - criterion_id: cri_04
+            kind: manual
+            reason: vendor-discretion
+            statement: GetBlock reviews each Credit Application and may approve, decline, or award less than the maximum without providing a reason.
+    roles:
+      terms_authority_entity_id: ent_01m1trnz9n2nz8jgzcr09d491p
+      access_operator_entity_id: ent_01m1trnz9n2nz8jgzcr09d491p
+    access:
+      availability: public
+      method: form
+      url: https://getblock.io/grant-program-solana/
+      instructions: Submit the Credit Application form on the GetBlock Solana Grant Program page with project details; approved teams receive credits on their GetBlock account after written confirmation.
+    terms_url: https://getblock.io/terms-of-service/grant-program-solana/
+    source_ids:
+      - src_b14552ca60ceedce66c6d92d54fcb367549dee7d3afb44f2a066b3ecc5c0c46e
+      - src_3a45c2df6a72436dc95c5a8fb7ba710cff0ac76b3caedfebca6e856840b43aeb
+      - src_e7679f96d5cda95dbf97dee77980a852b4b0e84307f4367b043e4761590750f3

--- a/entities/ge/getblock.yaml
+++ b/entities/ge/getblock.yaml
@@ -10,6 +10,7 @@ entity:
       valid_from: 2026-09-06T07:05:00.000Z
   category: hosting-infra
 profile:
+  summary: GetBlock is a blockchain infrastructure provider offering RPC APIs, shared and dedicated nodes, and Web3 developer tooling across multiple chains.
   description: GetBlock provides blockchain RPC APIs, shared and dedicated nodes, and related Web3 infrastructure for developers and teams.
   links:
     site: https://getblock.io

--- a/entities/ge/getblock.yaml
+++ b/entities/ge/getblock.yaml
@@ -57,7 +57,7 @@ offers:
             amount:
               currency: USD
               minor_units: 1000000
-            kind: upper_bound
+            kind: up-to
           duration:
             kind: exact
             value: P90D


### PR DESCRIPTION
## Summary
Adds one data-only Entity YAML for **GetBlock** (`getblock.io`) covering the first-party **Solana Grant Program** / Solana Startup Program:

- Up to **USD 10,000** in non-cash compute credits per team/organization
- Credits applied to a GetBlock account for GetBlock Services
- **90-day** grant period after activation
- Public application form; award amount and approval at GetBlock discretion

Reauthor after closed (unmerged) PR #855 with **fresh** `ent_` / `prg_` / `off_` / `src_` IDs and category `hosting-infra`.

Sources (vendor first-party only):
- https://getblock.io/grant-program-solana/
- https://getblock.io/terms-of-service/grant-program-solana/
- https://getblock.io/blog/getblock-opens-solana-startup-program/

Closes / fixes #593.

## Checklist
- [x] Exactly one new Entity file at `entities/ge/getblock.yaml`
- [x] Data-only (no docs/workflow/code)
- [x] Fresh `ent_` / `prg_` / `off_` / `src_` IDs
- [x] DCO Signed-off-by on commit
- [x] Facts limited to first-party pages
- [x] No open twin PR for GetBlock at open time (searched; #855 closed unmerged)

AI-assisted contribution by veriton-dev / agent-064c1e.