### PR TITLE
Add Pylon annual-contract offer through Brex Day Zero Stack

### DIFF
--- a/entities/py/pylon.yaml
+++ b/entities/py/pylon.yaml
@@ -21,6 +21,8 @@ sources:
     url: https://www.brex.com/support/brex-partner-perks
   - source_id: src_e96fa7e2506e2ca564581c244eb8e510e6292362218d0de08a2c6610e08b3a6a
     url: https://www.brex.com/dayzerostack
+  - source_id: src_f98677a98aaaf58a2696c90c2c12392dc4d32493645bc1ad4474f204706e56ff
+    url: https://www.usepylon.com/legal/terms
 programs: []
 offers:
   - offer_id: off_01m1v6swhqpsm17qj1x82qv7pe
@@ -34,7 +36,7 @@ offers:
     economics:
       consideration:
         kind: variable
-        description: Purchase an annual Pylon contract at the discounted price.
+        description: Customers pay Pylon the fees specified in their Order Form.
       benefits:
         - benefit_id: ben_annual_contract_discount
           kind: discount
@@ -62,7 +64,7 @@ offers:
           - criterion_id: cri_account_availability
             kind: manual
             reason: external-verification
-            statement: The Pylon perk must be available in the account's Perks and discounts list; any additional requirements appear in its redemption instructions.
+            statement: The Pylon perk must still appear in the account's Rewards > Perks and discounts list.
     roles:
       terms_authority_entity_id: ent_01m1v6swhdrkffwgyep3qsxn2s
       access_operator_entity_id: ent_01kyyts97rczvy7tt3n9gd0y3n
@@ -70,7 +72,8 @@ offers:
       availability: membership
       method: other
       url: https://www.brex.com/support/brex-partner-perks
-      instructions: A Brex account or card admin, or another user with the required product capability, opens Rewards > Perks and discounts in the dashboard, selects Pylon, and follows the displayed redemption instructions.
+      instructions: A Brex account or card admin, or another user with the required product capability, opens Rewards > Perks and discounts in the dashboard, selects Pylon, reviews any qualification requirements, and follows the displayed redemption instructions.
     source_ids:
       - src_63e1ec20a913cbb10619743d0bb78ad21e4aaeb5e189f1ec5c38a78badedf45d
       - src_e96fa7e2506e2ca564581c244eb8e510e6292362218d0de08a2c6610e08b3a6a
+      - src_f98677a98aaaf58a2696c90c2c12392dc4d32493645bc1ad4474f204706e56ff

--- a/entities/py/pylon.yaml
+++ b/entities/py/pylon.yaml
@@ -1,0 +1,76 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1v6swhdrkffwgyep3qsxn2s
+  slug: pylon
+  slug_aliases: []
+  name: Pylon
+  domains:
+    - value: usepylon.com
+      role: primary
+      valid_from: 2026-09-06T11:14:06.519Z
+  category: support
+profile:
+  summary: Pylon provides B2B customer support software with AI agents, ticketing, knowledge bases, and support across multiple channels.
+  description: Pylon provides B2B customer support software with AI agents, ticketing, knowledge bases, and support across multiple channels.
+  links:
+    site: https://www.usepylon.com/
+sources:
+  - source_id: src_7a7475661d885cdb1aab73305ca564c52dd2d511136005761d955875c9b28837
+    url: https://www.usepylon.com/
+  - source_id: src_63e1ec20a913cbb10619743d0bb78ad21e4aaeb5e189f1ec5c38a78badedf45d
+    url: https://www.brex.com/support/brex-partner-perks
+  - source_id: src_e96fa7e2506e2ca564581c244eb8e510e6292362218d0de08a2c6610e08b3a6a
+    url: https://www.brex.com/dayzerostack
+programs: []
+offers:
+  - offer_id: off_01m1v6swhqpsm17qj1x82qv7pe
+    offer_slug: brex-day-zero-stack-annual-contract-discount
+    offer_slug_aliases: []
+    title: Brex Day Zero Stack annual-contract discount
+    summary: Eligible Brex cardholders who are new Pylon customers can receive 15% off Pylon annual contracts through the Day Zero Stack partner perk.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T11:14:06.519Z
+    economics:
+      consideration:
+        kind: variable
+        description: Purchase an annual Pylon contract at the discounted price.
+      benefits:
+        - benefit_id: ben_annual_contract_discount
+          kind: discount
+          description: 15% off Pylon annual contracts.
+          applies_to: Pylon annual contracts
+          percentage:
+            kind: exact
+            basis_points: 1500
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_new_customer
+            kind: predicate
+            fact: company.is_current_customer
+            operator: eq
+            value:
+              type: boolean
+              value: false
+            statement: New Pylon customers only.
+          - criterion_id: cri_brex_cardholder
+            kind: manual
+            reason: external-verification
+            statement: Must be a Brex cardholder with access to the Pylon partner perk.
+          - criterion_id: cri_account_availability
+            kind: manual
+            reason: external-verification
+            statement: The Pylon perk must be available in the account's Perks and discounts list; any additional requirements appear in its redemption instructions.
+    roles:
+      terms_authority_entity_id: ent_01m1v6swhdrkffwgyep3qsxn2s
+      access_operator_entity_id: ent_01kyyts97rczvy7tt3n9gd0y3n
+    access:
+      availability: membership
+      method: other
+      url: https://www.brex.com/support/brex-partner-perks
+      instructions: A Brex account or card admin, or another user with the required product capability, opens Rewards > Perks and discounts in the dashboard, selects Pylon, and follows the displayed redemption instructions.
+    source_ids:
+      - src_63e1ec20a913cbb10619743d0bb78ad21e4aaeb5e189f1ec5c38a78badedf45d
+      - src_e96fa7e2506e2ca564581c244eb8e510e6292362218d0de08a2c6610e08b3a6a


### PR DESCRIPTION
Adds Pylon and its Brex Day Zero Stack offer: 15% off annual contracts for new Pylon customers. The single new Entity YAML preserves Brex membership, account availability, and redemption conditions, and links the existing Brex entity as access operator.

Closes #1421.

Sources: [Pylon](https://www.usepylon.com/), [Brex partner perks](https://www.brex.com/support/brex-partner-perks), and [Day Zero Stack](https://www.brex.com/dayzerostack). No discount duration or renewal guarantee is inferred from the annual-contract wording.

Validation: YAML parsing, identifiers, source references, current taxonomy category, field lengths, and whitespace checks pass. Canonical local verifier was not run. This AI-assisted contribution is intended for Frantic bounty 120; acceptance and payment are pending.
