### PR TITLE
Add Zimt startup annual-plan discount

### DIFF
--- a/entities/zi/zimt.yaml
+++ b/entities/zi/zimt.yaml
@@ -1,0 +1,125 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1ve9w1hb5jejsk0qp47f76k
+  slug: zimt
+  slug_aliases: []
+  name: Zimt
+  domains:
+    - value: zimt.ai
+      role: primary
+      valid_from: 2026-09-06T13:25:10.326Z
+  category: crm-sales
+profile:
+  summary: Zimt monitors competitors and target accounts, alerting go-to-market teams to changes in pricing, products, and messaging.
+  description: Zimt provides company-signal intelligence for go-to-market teams through competitor and account monitoring.
+  links:
+    site: https://www.zimt.ai/
+sources:
+  - source_id: src_80810f6b17aa2f14ca55e2d0ccbe3b762b2d9822964db247bae036817f528185
+    url: https://www.zimt.ai/startup-program
+  - source_id: src_9fbcea1f95fa62c4dcb10867da7eb5c08e3d8727289c92f50f401b60595e45f2
+    url: https://www.zimt.ai/
+programs:
+  - program_id: prg_01m1ve9w1pzk37751xe50esx9p
+    program_slug: zimt-startup-program
+    program_slug_aliases: []
+    title: Zimt Startup Program
+    summary: Zimt offers eligible startups discounted annual plans over three years.
+    source_ids:
+      - src_80810f6b17aa2f14ca55e2d0ccbe3b762b2d9822964db247bae036817f528185
+offers:
+  - offer_id: off_01m1ve9w1pymg9yaz3sytnm65y
+    program_id: prg_01m1ve9w1pzk37751xe50esx9p
+    offer_slug: signals-plus-three-year-startup-discount
+    offer_slug_aliases: []
+    title: Three-year startup discount on Zimt Signals+ Annual
+    summary: Eligible startups can apply for 60% off Signals+ Annual in year one, 40% off in year two, and 30% off in year three.
+    description: Discounts start at activation and step down annually; standard annual pricing follows year three. Payments are nonrefundable and offers cannot be combined. Use is limited to employees and competitor monitoring; reports cannot be shared or resold. Eligibility is assessed at contract signing.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T13:25:10.326Z
+    economics:
+      benefits:
+        - benefit_id: ben_year_1
+          description: 60% discount in the first year.
+          applies_to: Signals+ Annual plans, first year
+          kind: discount
+          percentage:
+            kind: exact
+            basis_points: 6000
+          duration:
+            kind: exact
+            value: P1Y
+        - benefit_id: ben_year_2
+          description: 40% discount in the second year.
+          applies_to: Signals+ Annual plans, second year
+          kind: discount
+          percentage:
+            kind: exact
+            basis_points: 4000
+          duration:
+            kind: exact
+            value: P1Y
+        - benefit_id: ben_year_3
+          description: 30% discount in the third year.
+          applies_to: Signals+ Annual plans, third year
+          kind: discount
+          percentage:
+            kind: exact
+            basis_points: 3000
+          duration:
+            kind: exact
+            value: P1Y
+      consideration:
+        kind: variable
+        description: The startup pays the discounted Signals+ Annual subscription price.
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_funding
+            kind: manual
+            reason: external-verification
+            statement: The startup has raised no more than $2 million in funding.
+          - criterion_id: cri_age
+            kind: predicate
+            fact: company.age_months
+            operator: lt
+            value:
+              type: number
+              value: 60
+            statement: The startup is under five years old.
+          - criterion_id: cri_team
+            kind: predicate
+            fact: company.employee_count
+            operator: lt
+            value:
+              type: number
+              value: 50
+            statement: The startup has fewer than 50 employees.
+          - criterion_id: cri_customer
+            kind: manual
+            reason: external-verification
+            statement: The applicant is a new customer and not currently a Zimt customer.
+          - criterion_id: cri_signup_window
+            kind: manual
+            reason: external-verification
+            statement: The startup must apply within 90 days of sign-up.
+          - criterion_id: cri_business
+            kind: manual
+            reason: external-verification
+            statement: A corporate email and verifiable business registration are required.
+          - criterion_id: cri_exclusions
+            kind: manual
+            reason: external-verification
+            statement: Competitive intelligence, account-based marketing services, market research, business intelligence software, and competitor affiliates or representatives are excluded.
+    roles:
+      terms_authority_entity_id: ent_01m1ve9w1hb5jejsk0qp47f76k
+      access_operator_entity_id: ent_01m1ve9w1hb5jejsk0qp47f76k
+    access:
+      availability: public
+      method: form
+      url: https://www.zimt.ai/startup-program
+    terms_url: https://www.zimt.ai/startup-program
+    source_ids:
+      - src_80810f6b17aa2f14ca55e2d0ccbe3b762b2d9822964db247bae036817f528185


### PR DESCRIPTION
Adds Zimt's startup discount on Signals+ Annual: 60% in the first year, 40% in the second and 30% in the third. The record includes the published funding, company-age, headcount, signup-window and business requirements, plus sector exclusions and usage terms.

Source: https://www.zimt.ai/startup-program and the vendor homepage. The startup page's terms accordion supplies the additional exclusions. The earlier contribution in #897 was withdrawn; this is a fresh record with new IDs. Relates to #892.

Validation: the repository's pinned Sourcey catalog verifier passed locally for exactly one entity, one program and one offer. GitHub CI and Sourcey's independent admission review remain separate checks.

AI-assisted research and preparation operated by TheSgarman, independently checked against the vendor's published material. Prepared for Frantic bounty #120; no acceptance or payment is claimed.
