### PR TITLE
Add Hopohopo portfolio startup discount

### DIFF
--- a/entities/ho/hopohopo.yaml
+++ b/entities/ho/hopohopo.yaml
@@ -1,0 +1,72 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1vhy0gaag11grf7eam85cxr
+  slug: hopohopo
+  slug_aliases: []
+  name: Hopohopo
+  domains:
+    - value: hopohopo.io
+      role: primary
+      valid_from: 2026-09-06T00:00:00.000Z
+  category: crm-sales
+profile:
+  description: Hopohopo provides fundraising CRM software for startups and portfolio-management tools for investors and accelerators.
+  summary: Hopohopo helps startups find investors and manage fundraising pipelines, with collaboration tools for their investors and mentors.
+  links:
+    site: https://www.hopohopo.io/
+sources:
+  - source_id: src_315c827087bda84477da46d283e8fd3a535d7701c1ff2d82f39118a4fadc5ca9
+    url: https://www.hopohopo.io/partner-program-welcome
+  - source_id: src_072a98faccae997b9e862073987364a3f32ba06c5a28b69bc014caf291cc6033
+    url: https://www.hopohopo.io/
+  - source_id: src_46404659ab7939d6c748694626ca2a2afcb719f7a75665a103f8971071e166e6
+    url: https://www.hopohopo.io/terms-of-service
+programs:
+  - program_id: prg_01m1vhy0gbstayzr68bywd7j99
+    program_slug: hopohopo-partner-program
+    program_slug_aliases: []
+    title: Hopohopo Partner Program
+    summary: Investors and accelerators can provide a one-year CRM discount to startups in their portfolios.
+    source_ids:
+      - src_315c827087bda84477da46d283e8fd3a535d7701c1ff2d82f39118a4fadc5ca9
+offers:
+  - offer_id: off_01m1vhy0gb8a8ka7yrdkv945qa
+    program_id: prg_01m1vhy0gbstayzr68bywd7j99
+    offer_slug: portfolio-startup-pro-discount
+    offer_slug_aliases: []
+    title: Hopohopo portfolio startup discount
+    summary: Startups in participating portfolios receive 50% off the Hopohopo CRM Pro Plan for one year.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T00:00:00.000Z
+    economics:
+      consideration:
+        kind: none
+      benefits:
+        - benefit_id: ben_01m1vhy0gby2036gn1nk0wvyks
+          description: 50% discount on the Hopohopo CRM Pro Plan for one year.
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            basis_points: 5000
+            kind: exact
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_hopohopo_portfolio_membership
+        statement: Startup belongs to an investor or accelerator portfolio participating in the Hopohopo Partner Program; Hopohopo confirms eligibility.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m1vhy0gaag11grf7eam85cxr
+      access_operator_entity_id: ent_01m1vhy0gaag11grf7eam85cxr
+    access:
+      availability: membership
+      method: code
+      public_code: PORTFOLIO50
+      url: https://www.hopohopo.io/partner-program-welcome
+      instructions: Confirm portfolio eligibility with Hopohopo, then redeem through the participating partner's invitation using PORTFOLIO50.
+    source_ids:
+      - src_315c827087bda84477da46d283e8fd3a535d7701c1ff2d82f39118a4fadc5ca9
+      - src_46404659ab7939d6c748694626ca2a2afcb719f7a75665a103f8971071e166e6

--- a/entities/ho/hopohopo.yaml
+++ b/entities/ho/hopohopo.yaml
@@ -41,7 +41,8 @@ offers:
       effective_from: 2026-09-06T00:00:00.000Z
     economics:
       consideration:
-        kind: none
+        kind: unknown
+        description: The offer discounts the Pro Plan subscription; the cited partner page does not specify the remaining subscription amount.
       benefits:
         - benefit_id: ben_01m1vhy0gby2036gn1nk0wvyks
           description: 50% discount on the Hopohopo CRM Pro Plan for one year.


### PR DESCRIPTION
## What changed

Adds one Hopohopo Entity and one offer: 50% off the CRM Pro Plan for one year for startups in participating investor or accelerator portfolios. The record includes the named Partner Program, membership eligibility, the published redemption code, and the vendor's terms page. It does not present the code as an unrestricted discount.

Closes #1432. Prepared with Codex assistance; factual claims were checked against the first-party pages, including the rendered partner-program page.

## Sources

- https://www.hopohopo.io/partner-program-welcome — plan, percentage, duration, portfolio eligibility and redemption.
- https://www.hopohopo.io/ — fundraising CRM product description.
- https://www.hopohopo.io/terms-of-service — service terms.

## Validation

- The pinned `@sourcey/catalog-verifier` 1.0.0 passed for exactly one Entity, one Program and one Offer at commit `2c18118`.
- Identity context digest: `sha256:e08d0fb284ab7fff63d0d60a4845998df4bff13ba63f49de33c8aa182cefe4fd`.
- Live parent release: `sha256:7a8a661d5a009941c3e9a96f100622a1644737471d6bc6c1f0e9f0f25ea7ecf2`.
- Repository searches found no other Hopohopo issue or PR before reservation #1432, and no Hopohopo Entity in main. The public identity-context preflight passed.
- Only `entities/ho/hopohopo.yaml` changes. No executable code or generated evidence is included. Private admission and merge remain Sourcey's review decisions.

## Certification

- [x] I changed only allowed repository content and did not mix Entity YAML with other paths.
- [x] Public sources substantiate every submitted factual value; any Sourcey-written prose is a neutral summary, not a fabricated vendor quote.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commits include a `Signed-off-by` line.
