### PR TITLE
feat: add Stripe Atlas program and enrich Datadog offer

### DIFF
--- a/entities/ae/aerospike.yaml
+++ b/entities/ae/aerospike.yaml
@@ -1,0 +1,56 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rt22rp90myqr0axndg1w
+  slug: aerospike
+  slug_aliases: []
+  name: Aerospike
+  domains:
+    - value: aerospike.com
+      role: primary
+      valid_from: 2026-09-06T19:48:40Z
+  category: databases
+profile:
+  description: Aerospike provides a real-time NoSQL database and data platform optimized for high-performance, high-scale applications.
+  links:
+    site: https://aerospike.com
+sources:
+  - source_id: src_0c3c1b7b8195196273f2bf8544a0a89dd4dbdb33d8a567fad28f5f4b0460d32b
+    url: https://aerospike.com/get/cloud-for-startups/
+offers:
+  - offer_id: off_01m1w3rt3chhkfnr1h3ttkywp7
+    offer_slug: aerospike-cloud-for-startups
+    offer_slug_aliases: []
+    title: Aerospike Cloud for Startups
+    summary: Aerospike Cloud for Startups offers early-stage companies USD 300 in credits, 10% off public pricing, one day of Solution Architect support, and zero commitment to start.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T19:48:40Z
+    economics:
+      consideration:
+        kind: credits
+        description: USD 300 in credits plus 10% off public pricing.
+    benefits:
+      - benefit_id: ben_primary
+        description: USD 300 in Aerospike Cloud credits
+        kind: credits
+      - benefit_id: ben_02
+        description: 10% off public pricing
+        kind: discount
+      - benefit_id: ben_03
+        description: One day of Solution Architect support
+        kind: other
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Must be an early-stage company; zero commitment required to start.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m1w3rt22rp90myqr0axndg1w
+      access_operator_entity_id: ent_01m1w3rt22rp90myqr0axndg1w
+    access:
+      availability: public
+      method: form
+      url: https://aerospike.com/get/cloud-for-startups/
+    source_ids:
+      - src_0c3c1b7b8195196273f2bf8544a0a89dd4dbdb33d8a567fad28f5f4b0460d32b

--- a/entities/ai/air.yaml
+++ b/entities/ai/air.yaml
@@ -1,0 +1,50 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rtqmjhnkz6cnnd6n7wwe
+  slug: air
+  slug_aliases: []
+  name: Air
+  domains:
+    - value: air.inc
+      role: primary
+      valid_from: 2026-09-06T19:48:40Z
+  category: productivity
+profile:
+  description: Air is a creative operations platform for managing visual content, collaboration, and creative workflows for teams.
+  links:
+    site: https://air.inc
+sources:
+  - source_id: src_a73f5186325c366d8cf08b17259664741390b18fcc8cfa151ba416f8b9d4e620
+    url: https://air.inc/startups
+offers:
+  - offer_id: off_01m1w3rtrr81pm3k1969d1ayc1
+    offer_slug: air-startup-program
+    offer_slug_aliases: []
+    title: Air Startup Program
+    summary: Eligible partner-network startups receive up to six months free on Air's Business plan, worth up to USD 5,800.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T19:48:40Z
+    economics:
+      consideration:
+        kind: free-period
+        description: Up to six months free on the Business plan, worth up to USD 5,800.
+    benefits:
+      - benefit_id: ben_primary
+        description: Up to six months free on the Business plan, worth up to USD 5,800
+        kind: free-period
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Must be part of the partner network; specific partner-network criteria are published on the vendor startup page.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m1w3rtqmjhnkz6cnnd6n7wwe
+      access_operator_entity_id: ent_01m1w3rtqmjhnkz6cnnd6n7wwe
+    access:
+      availability: public
+      method: form
+      url: https://air.inc/startups
+    source_ids:
+      - src_a73f5186325c366d8cf08b17259664741390b18fcc8cfa151ba416f8b9d4e620

--- a/entities/ap/appsmith.yaml
+++ b/entities/ap/appsmith.yaml
@@ -1,0 +1,58 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w5647g1v1635b14h47fkz4
+  slug: appsmith
+  slug_aliases: []
+  name: Appsmith
+  domains:
+    - value: appsmith.com
+      role: primary
+      valid_from: 2026-09-06T20:04:00Z
+  category: no-code
+profile:
+  description: Appsmith is an open-source low-code platform for building internal tools, management dashboards, and business applications.
+  links:
+    site: https://www.appsmith.com
+sources:
+  - source_id: src_87c35e1c74bb8730ca73c99ecec27ebf21eba3fd5519650ce3548b8749bc36e5
+    url: https://www.appsmith.com/startup-program
+offers:
+  - offer_id: off_01m1w56480z63pnwwz30g5qfav
+    offer_slug: appsmith-startup-program
+    offer_slug_aliases: []
+    title: Appsmith Startup Program
+    summary: Early-stage startups incorporated less than 2 years ago and with less than USD 10 million in funding can receive USD 30,000 in credits valid for 12 months, full Business plan access, and dedicated developer advocate support.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T20:04:00Z
+    economics:
+      consideration:
+        kind: credits
+        description: USD 30,000 in platform credits, valid for 12 months from acceptance.
+    benefits:
+      - benefit_id: ben_primary
+        description: USD 30,000 in platform credits, valid for 12 months from acceptance
+        kind: credits
+        value:
+          amount:
+            currency: USD
+            minor_units: 3000000
+          kind: at-least
+      - benefit_id: ben_02
+        description: Full access to all Appsmith Business plan features
+        kind: other
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Must be incorporated less than 2 years ago and have raised less than USD 10 million in funding.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m1w5647g1v1635b14h47fkz4
+      access_operator_entity_id: ent_01m1w5647g1v1635b14h47fkz4
+    access:
+      availability: public
+      method: form
+      url: https://www.appsmith.com/startup-program
+    source_ids:
+      - src_87c35e1c74bb8730ca73c99ecec27ebf21eba3fd5519650ce3548b8749bc36e5

--- a/entities/ca/callmissed.yaml
+++ b/entities/ca/callmissed.yaml
@@ -1,0 +1,50 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rs3tqcmt132qbfa3m6zh
+  slug: callmissed
+  slug_aliases: []
+  name: CallMissed
+  domains:
+    - value: callmissed.com
+      role: primary
+      valid_from: 2026-09-06T19:47:36Z
+  category: communication
+profile:
+  description: CallMissed provides communication APIs and tools for B2C and developer products.
+  links:
+    site: https://www.callmissed.com
+sources:
+  - source_id: src_ecedb3b26b36f07662a99743ad54ee7d4cd5d5d3c274c6c6ffcecb734e50d39b
+    url: https://www.callmissed.com/solutions/startups
+offers:
+  - offer_id: off_01m1w3rs4hdckdds8sssj2hczm
+    offer_slug: callmissed-startup-credits
+    offer_slug_aliases: []
+    title: CallMissed Startup Credits
+    summary: Qualifying early-stage startups building B2C or developer products in India can apply for USD 1,000 in additional CallMissed API credits, equal to 100,000 credits at USD 0.01 each.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T19:47:36Z
+    economics:
+      consideration:
+        kind: credits
+        description: USD 1,000 in API credits (100,000 credits at USD 0.01 each).
+    benefits:
+      - benefit_id: ben_primary
+        description: USD 1,000 in additional API credits (100,000 credits at USD 0.01 each)
+        kind: credits
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Must be an early-stage startup building B2C or developer products in India.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m1w3rs3tqcmt132qbfa3m6zh
+      access_operator_entity_id: ent_01m1w3rs3tqcmt132qbfa3m6zh
+    access:
+      availability: public
+      method: form
+      url: https://www.callmissed.com/solutions/startups
+    source_ids:
+      - src_ecedb3b26b36f07662a99743ad54ee7d4cd5d5d3c274c6c6ffcecb734e50d39b

--- a/entities/ca/cardboard.yaml
+++ b/entities/ca/cardboard.yaml
@@ -1,0 +1,50 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rwykxphtyxrtjmbz13mn
+  slug: cardboard
+  slug_aliases: []
+  name: Cardboard
+  domains:
+    - value: cardboard.inc
+      role: primary
+      valid_from: 2026-09-06T19:49:38Z
+  category: other
+profile:
+  description: Cardboard provides software subscription management and procurement tools for businesses.
+  links:
+    site: https://cardboard.inc
+sources:
+  - source_id: src_2ccaeb4a55b7e947192dded88a95cf6d7679a60eb8a92d7ce32bdbf632ef4758
+    url: https://cardboard.inc/pricing/
+offers:
+  - offer_id: off_01m1w3rwzj759yhxgew42thh3b
+    offer_slug: cardboard-for-startups-paid-plan-discount
+    offer_slug_aliases: []
+    title: Cardboard for Startups
+    summary: Cardboard publishes an automatic 80% discount on its paid plans for companies incorporated less than two years ago. The discount runs for one year from signup.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T19:49:38Z
+    economics:
+      consideration:
+        kind: discount
+        description: Automatic 80% discount on paid plans for one year from signup.
+    benefits:
+      - benefit_id: ben_primary
+        description: 80% off paid plans for one year from signup
+        kind: discount
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Must be a company incorporated less than two years ago; discount applies automatically upon signup verification.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m1w3rwykxphtyxrtjmbz13mn
+      access_operator_entity_id: ent_01m1w3rwykxphtyxrtjmbz13mn
+    access:
+      availability: public
+      method: form
+      url: https://cardboard.inc/campaigns/software-subscriptions/
+    source_ids:
+      - src_2ccaeb4a55b7e947192dded88a95cf6d7679a60eb8a92d7ce32bdbf632ef4758

--- a/entities/cl/cloudsetu.yaml
+++ b/entities/cl/cloudsetu.yaml
@@ -1,0 +1,50 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rnyt9q2zk0yym0b80kx3
+  slug: cloudsetu
+  slug_aliases: []
+  name: CloudSetu
+  domains:
+    - value: cloudsetu.com
+      role: primary
+      valid_from: 2026-09-06T19:46:00Z
+  category: hosting-infra
+profile:
+  description: CloudSetu provides cloud services and infrastructure for businesses and startups in India.
+  links:
+    site: https://cloudsetu.com
+sources:
+  - source_id: src_972ec5c7dfd8e22081d8623b990a1687c2589e6c1b9c3dbef7c28c4aab56df89
+    url: https://cloudsetu.com/for-startups
+offers:
+  - offer_id: off_01m1w3rnzq9840r73ts9evntbe
+    offer_slug: cloudsetu-startup-credits
+    offer_slug_aliases: []
+    title: CloudSetu Startup Credits
+    summary: CloudSetu advertises INR 21,000 in cloud credits for qualifying Indian startups.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T19:46:00Z
+    economics:
+      consideration:
+        kind: credits
+        description: INR 21,000 in cloud credits for qualifying Indian startups.
+    benefits:
+      - benefit_id: ben_primary
+        description: INR 21,000 in cloud credits
+        kind: credits
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Must be a qualifying Indian startup; specific criteria are published on the vendor startup page.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m1w3rnyt9q2zk0yym0b80kx3
+      access_operator_entity_id: ent_01m1w3rnyt9q2zk0yym0b80kx3
+    access:
+      availability: public
+      method: form
+      url: https://cloudsetu.com/for-startups
+    source_ids:
+      - src_972ec5c7dfd8e22081d8623b990a1687c2589e6c1b9c3dbef7c28c4aab56df89

--- a/entities/cm/cms-austria.yaml
+++ b/entities/cm/cms-austria.yaml
@@ -1,0 +1,50 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rgf4php658j5fpkdn73f
+  slug: cms-austria
+  slug_aliases: []
+  name: CMS Reich-Rohrwig Hainz Rechtsanwälte GmbH
+  domains:
+    - value: cms.law
+      role: primary
+      valid_from: 2026-09-06T19:43:48Z
+  category: legal-compliance
+profile:
+  description: CMS Reich-Rohrwig Hainz is a full-service commercial law firm in Austria offering legal services to businesses and startups.
+  links:
+    site: https://cms.law/en/aut
+sources:
+  - source_id: src_76ded3be8a8db7e5e2b8adba038b1118cc025820da427e4d6a12c7e87353613c
+    url: https://cms.law/en/aut/insight/start-ups/cms-equip-membership
+offers:
+  - offer_id: off_01m1w3rgfffmyxtbn1xmat0wcb
+    offer_slug: cms-equip-austria-startup-programme
+    offer_slug_aliases: []
+    title: CMS equIP Austria
+    summary: Accepted startup members receive 50% off standard hourly legal rates for three years, up to EUR 25,000 discount per year. Application and acceptance are required.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T19:43:48Z
+    economics:
+      consideration:
+        kind: discount
+        description: 50% off standard hourly legal rates for three years, capped at EUR 25,000 discount per year.
+    benefits:
+      - benefit_id: ben_primary
+        description: 50% off standard hourly legal rates for up to three years, up to EUR 25,000 per year
+        kind: discount
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Must be an eligible startup and complete the equIP application process; acceptance is required.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m1w3rgf4php658j5fpkdn73f
+      access_operator_entity_id: ent_01m1w3rgf4php658j5fpkdn73f
+    access:
+      availability: public
+      method: form
+      url: https://cms.law/content/download/486373/file/Application_Form_EquIP_2026.pdf
+    source_ids:
+      - src_76ded3be8a8db7e5e2b8adba038b1118cc025820da427e4d6a12c7e87353613c

--- a/entities/co/coefficient.yaml
+++ b/entities/co/coefficient.yaml
@@ -1,0 +1,50 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3retaxb22rx20cg7mtvgw
+  slug: coefficient
+  slug_aliases: []
+  name: Coefficient
+  domains:
+    - value: coefficient.io
+      role: primary
+      valid_from: 2026-09-06T19:42:47Z
+  category: finance-accounting
+profile:
+  description: Coefficient provides a live data platform connecting spreadsheets to real-time business data from SaaS tools and databases.
+  links:
+    site: https://coefficient.io
+sources:
+  - source_id: src_29d7963ea1a24691193b60d585278f1fcbe5b6c654d03727a41e0d7487c1b557
+    url: https://coefficient.io/startup
+offers:
+  - offer_id: off_01m1w3retfq7w3synrc2v19s71
+    offer_slug: coefficient-for-startups
+    offer_slug_aliases: []
+    title: Coefficient for Startups
+    summary: Coefficient for Startups offers up to 50% off for the first year, with published eligibility requiring USD 20 million or less raised, bootstrapped/angel-funded/debt-funded/pre-seed/seed/Series A status, and 25 or fewer employees.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T19:42:47Z
+    economics:
+      consideration:
+        kind: discount
+        description: Up to 50% off for the first year.
+    benefits:
+      - benefit_id: ben_primary
+        description: Up to 50% off for the first year
+        kind: discount
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Must have raised USD 20 million or less, be in bootstrapped/angel-funded/debt-funded/pre-seed/seed/Series A status, and have 25 or fewer employees.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m1w3retaxb22rx20cg7mtvgw
+      access_operator_entity_id: ent_01m1w3retaxb22rx20cg7mtvgw
+    access:
+      availability: public
+      method: form
+      url: https://coefficient.io/startup
+    source_ids:
+      - src_29d7963ea1a24691193b60d585278f1fcbe5b6c654d03727a41e0d7487c1b557

--- a/entities/cr/cribl.yaml
+++ b/entities/cr/cribl.yaml
@@ -1,0 +1,55 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w5cscwqfjcckfyspvfjz0q
+  slug: cribl
+  slug_aliases: []
+  name: Cribl
+  domains:
+    - value: cribl.io
+      role: primary
+      valid_from: 2026-09-06T20:08:43Z
+  category: observability
+profile:
+  description: Cribl provides a data processing and observability platform that enables organizations to collect, process, and route machine data from any source to any destination.
+  links:
+    site: https://cribl.io
+sources:
+  - source_id: src_0e725493674efa9f35b17ae7eea3af9bf967e81eea63febe2c1bd0269624965d
+    url: https://cribl.io/startup/
+offers:
+  - offer_id: off_01m1w5csdk1r1t8e05v4fd3rmx
+    offer_slug: cribl-for-startups
+    offer_slug_aliases: []
+    title: Cribl for Startups
+    summary: Seed-through-Series-A companies building monitoring, observability, cybersecurity, or DevOps data solutions can receive free Cribl.Cloud access including Cribl Stream and Cribl Search, hands-on technical advice, and access to Cribl's partner network with co-marketing opportunities.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T20:08:43Z
+    economics:
+      consideration:
+        kind: free
+    benefits:
+      - benefit_id: ben_primary
+        description: Free access to all Cribl.Cloud products, including Cribl Stream and Cribl Search
+        kind: other
+      - benefit_id: ben_02
+        description: Hands-on technical advice and expert guidance on data strategy from Cribl's team
+        kind: other
+      - benefit_id: ben_03
+        description: Access to Cribl's partner network and go-to-market opportunities through co-marketing and startup events
+        kind: other
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Must be a Seed-through-Series-A company building monitoring, observability, cybersecurity, or DevOps data solutions; selection is made by Cribl.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m1w5cscwqfjcckfyspvfjz0q
+      access_operator_entity_id: ent_01m1w5cscwqfjcckfyspvfjz0q
+    access:
+      availability: public
+      method: form
+      url: https://cribl.io/startup/
+    source_ids:
+      - src_0e725493674efa9f35b17ae7eea3af9bf967e81eea63febe2c1bd0269624965d

--- a/entities/cr/crococlick.yaml
+++ b/entities/cr/crococlick.yaml
@@ -1,0 +1,104 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w4360shgqqm3gv6948340s
+  slug: crococlick
+  slug_aliases: []
+  name: CrocoClick
+  domains:
+  - value: crococlick.com
+    role: primary
+    valid_from: '2026-09-06T19:46:41.281Z'
+  category: productivity
+profile:
+  description: CrocoClick provides productivity and collaboration tools for businesses and teams.
+  links:
+    site: https://crococlick.com
+sources:
+- source_id: src_b9d2ec5e99697104baf658cbe8c618dc22f6afc9a233b2528e2a3158f653cbc6
+  url: https://help.crococlick.com/articles/0820414-crococlick-startup-program
+programs:
+- program_id: prg_01m1w436149g783sff7xhts4mw
+  program_slug: crococlick-young-enterprise-program
+  program_slug_aliases: []
+  title: CrocoClick Young Enterprise Program
+  summary: 'The Young Enterprise program offers qualifying companies discounted UNLIMITED access for three years: 86% in year one, 70% in year two, and 50% in year three.'
+  source_ids:
+  - src_b9d2ec5e99697104baf658cbe8c618dc22f6afc9a233b2528e2a3158f653cbc6
+offers:
+- offer_id: off_01m1w43614zak99pgrtns3gc9x
+  program_id: prg_01m1w436149g783sff7xhts4mw
+  offer_slug: young-enterprise-program-tiered-discount
+  offer_slug_aliases: []
+  title: Young Enterprise Program - Tiered Discount
+  summary: 'The Young Enterprise program offers qualifying companies discounted UNLIMITED access for three years: 86% in year one, 70% in year two, and 50% in year three.'
+  lifecycle:
+    status: active
+    effective_from: '2026-09-06T19:46:41.281Z'
+  economics:
+    benefits:
+    - benefit_id: ben_year1
+      description: 86% off UNLIMITED access in year one
+      kind: discount
+      percentage:
+        kind: exact
+        basis_points: 8600
+      duration:
+        kind: exact
+        value: P1Y
+    - benefit_id: ben_year2
+      description: 70% off UNLIMITED access in year two
+      kind: discount
+      percentage:
+        kind: exact
+        basis_points: 7000
+      duration:
+        kind: exact
+        value: P1Y
+    - benefit_id: ben_year3
+      description: 50% off UNLIMITED access in year three
+      kind: discount
+      percentage:
+        kind: exact
+        basis_points: 5000
+      duration:
+        kind: exact
+        value: P1Y
+    consideration:
+      kind: none
+  eligibility:
+    rule:
+      kind: all
+      rules:
+      - criterion_id: cri_age
+        fact: company.age_months
+        kind: predicate
+        operator: lte
+        value:
+          type: number
+          value: 12
+        statement: Company is under 12 months old.
+      - criterion_id: cri_revenue
+        fact: company.annual_revenue_usd
+        kind: predicate
+        operator: lt
+        value:
+          type: number
+          value: 25000
+        statement: Company has less than EUR 25,000 in revenue.
+      - criterion_id: cri_not_previous
+        fact: company.is_current_customer
+        kind: predicate
+        operator: eq
+        value:
+          type: boolean
+          value: false
+        statement: No previous paid CrocoClick subscription.
+  roles:
+    terms_authority_entity_id: ent_01m1w4360shgqqm3gv6948340s
+    access_operator_entity_id: ent_01m1w4360shgqqm3gv6948340s
+  access:
+    availability: public
+    method: form
+    url: https://help.crococlick.com/articles/0820414-crococlick-startup-program
+  source_ids:
+  - src_b9d2ec5e99697104baf658cbe8c618dc22f6afc9a233b2528e2a3158f653cbc6

--- a/entities/cy/cyberport.yaml
+++ b/entities/cy/cyberport.yaml
@@ -1,0 +1,50 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rmnnzpnnjhw8x872jx9q
+  slug: cyberport
+  slug_aliases: []
+  name: Cyberport
+  domains:
+    - value: cyberport.hk
+      role: primary
+      valid_from: 2026-09-06T19:46:00Z
+  category: other
+profile:
+  description: Cyberport is a digital technology hub in Hong Kong supporting tech entrepreneurs and startups with infrastructure, mentorship, and community programs.
+  links:
+    site: https://www.cyberport.hk
+sources:
+  - source_id: src_525507854119df43ea3bea9b1daebc6ff65356006050516474610d03faeec891
+    url: https://www.cyberport.hk/en/entrepreneurship/hong_kong_programme/
+offers:
+  - offer_id: off_01m1w3rmqhajavyw47a3yxtc0p
+    offer_slug: ccmf-hong-kong-programme
+    offer_slug_aliases: []
+    title: Cyberport CCMF Hong Kong Programme
+    summary: A startup-specific cash grant for digital technology projects at the idea or early development stage. The official page lists up to HKD 100,000 over six months, subject to selection and reporting milestones.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T19:46:00Z
+    economics:
+      consideration:
+        kind: grant
+        description: Up to HKD 100,000 cash grant over six months for digital technology projects.
+    benefits:
+      - benefit_id: ben_primary
+        description: Up to HKD 100,000 cash grant over six months
+        kind: grant
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Must be at the idea or early development stage for a digital technology project; individual and company eligibility routes apply; restrictions on overlapping programmes apply.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m1w3rmnnzpnnjhw8x872jx9q
+      access_operator_entity_id: ent_01m1w3rmnnzpnnjhw8x872jx9q
+    access:
+      availability: public
+      method: form
+      url: https://www.cyberport.hk/en/entrepreneurship/hong_kong_programme/
+    source_ids:
+      - src_525507854119df43ea3bea9b1daebc6ff65356006050516474610d03faeec891

--- a/entities/da/datadog.yaml
+++ b/entities/da/datadog.yaml
@@ -22,23 +22,30 @@ offers:
     offer_slug: datadog-for-startups
     offer_slug_aliases: []
     title: Datadog for Startups
-    summary: Datadog for Startups provides early-stage companies up to a year of free access to the complete Datadog platform, providing up to $100,000 in credits.
+    summary: Get up to $100,000 in Datadog credits for 1 year with no watered-down tiers, full platform access including GA products.
     lifecycle:
       status: active
       effective_from: 2026-07-27T07:40:35.276Z
     economics:
       consideration:
-        kind: unknown
-        description: The source record did not establish separate consideration.
+        kind: free
       benefits:
         - benefit_id: ben_primary
-          description: Up to $100,000 in credits (up to 1 year free)
+          description: Up to $100,000 in credits with full platform access for 1 year, including all General Availability products with no tier restrictions or hidden limits.
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 10000000
+            kind: at-least
+        - benefit_id: ben_onboarding
+          description: Technical Engagement Manager (TEM) onboarding support to help startups get started.
           kind: other
     eligibility:
       rule:
         kind: manual
         criterion_id: cri_requirement_01
-        statement: Must be Series A or earlier, referred by an official referral partner, and new to Datadog (no current/past customer status or prior DDFS credits).
+        statement: Must be Series A or earlier, referred by an official referral partner (VCs, hyperscalers, or vendor partner startup programs), and new to Datadog.
         reason: not-machine-evaluable
     roles:
       terms_authority_entity_id: ent_01kyh8fpe2hwmmvk3eex1hq433

--- a/entities/e2/e2e-networks.yaml
+++ b/entities/e2/e2e-networks.yaml
@@ -1,86 +1,50 @@
 schema_version: sourcey.entity-authoring/v1alpha1
 entity:
-  entity_id: ent_01m1tpsk8hse4ty07p836bsjqq
+  entity_id: ent_01m1w3rfg60cdr0fwfzrr3yp82
   slug: e2e-networks
   slug_aliases: []
   name: E2E Networks
   domains:
     - value: e2enetworks.com
       role: primary
-      valid_from: 2026-09-06T06:34:19.000Z
+      valid_from: 2026-09-06T19:43:17Z
   category: hosting-infra
 profile:
-  summary: Cloud infrastructure and GPU computing services for AI and machine-learning workloads.
-  description: E2E Networks provides cloud infrastructure, including GPU compute and other services for AI and general-purpose workloads.
+  description: E2E Networks provides cloud infrastructure and AI compute services for developers and AI startups.
   links:
     site: https://www.e2enetworks.com
 sources:
-  - source_id: src_f56a4e33855afad6fa5d16101b07eb9286e941ac1478e37e8e2a37d4af8364c1
+  - source_id: src_b52254ca5152c40ea9441520aa08f9e50e980b24724a5ffc3b439df914d70ade
     url: https://www.e2enetworks.com/startup-program
-programs:
-  - program_id: prg_01m1tpsk8mv6398km3sjxjcd7d
-    program_slug: startup-program
-    program_slug_aliases: []
-    title: E2E Networks Startup Program
-    summary: E2E Networks provides eligible AI startups worldwide with cloud credits or usage-based discounts and engineering support through three program tiers.
-    source_ids:
-      - src_f56a4e33855afad6fa5d16101b07eb9286e941ac1478e37e8e2a37d4af8364c1
 offers:
-  - offer_id: off_01m1tpsk8m2v8q4jjbw3xhsqrm
-    program_id: prg_01m1tpsk8mv6398km3sjxjcd7d
-    offer_slug: ai-explorer
+  - offer_id: off_01m1w3rfgpsshz6n5kj99wx8zr
+    offer_slug: e2e-networks-startup-program
     offer_slug_aliases: []
-    title: AI Explorer
-    summary: Eligible bootstrapped or early-stage AI startups receive $5,000 in free-to-use E2E Networks AI Cloud credits.
+    title: E2E Networks Startup Program
+    summary: Eligible bootstrapped or early-stage AI startups worldwide can receive USD 5,000 in free-to-use AI Cloud credits through the AI Explorer tier.
     lifecycle:
       status: active
-      effective_from: 2026-09-06T06:34:19.000Z
+      effective_from: 2026-09-06T19:43:17Z
     economics:
-      benefits:
-        - benefit_id: ben_01
-          description: $5,000 in free-to-use AI Cloud credits.
-          kind: credit
-          value:
-            amount:
-              currency: USD
-              minor_units: 500000
-            kind: exact
       consideration:
-        kind: none
+        kind: credits
+        description: USD 5,000 in AI Cloud credits through the AI Explorer tier.
+    benefits:
+      - benefit_id: ben_primary
+        description: USD 5,000 in free-to-use AI Cloud credits
+        kind: credits
     eligibility:
       rule:
-        kind: all
-        rules:
-          - criterion_id: cri_01
-            kind: manual
-            reason: external-verification
-            statement: The company is a bootstrapped or early-stage startup with an AI-first product.
-          - criterion_id: cri_02
-            fact: company.employee_count
-            kind: predicate
-            operator: lte
-            statement: The company has 10 or fewer employees.
-            value:
-              type: number
-              value: 10
-          - criterion_id: cri_03
-            fact: company.age_months
-            kind: predicate
-            operator: lte
-            statement: The company was founded within the last five years.
-            value:
-              type: number
-              value: 60
-          - criterion_id: cri_04
-            kind: manual
-            reason: external-verification
-            statement: The company is legally incorporated in any country.
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Must be a bootstrapped or early-stage AI startup; global eligibility applies.
+        reason: not-machine-evaluable
     roles:
-      terms_authority_entity_id: ent_01m1tpsk8hse4ty07p836bsjqq
-      access_operator_entity_id: ent_01m1tpsk8hse4ty07p836bsjqq
+      terms_authority_entity_id: ent_01m1w3rfg60cdr0fwfzrr3yp82
+      access_operator_entity_id: ent_01m1w3rfg60cdr0fwfzrr3yp82
     access:
       availability: public
       method: form
       url: https://www.e2enetworks.com/startup-program
     source_ids:
-      - src_f56a4e33855afad6fa5d16101b07eb9286e941ac1478e37e8e2a37d4af8364c1
+      - src_b52254ca5152c40ea9441520aa08f9e50e980b24724a5ffc3b439df914d70ade

--- a/entities/el/elia-asistent.yaml
+++ b/entities/el/elia-asistent.yaml
@@ -1,0 +1,50 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rvyf9fv8ppmesgmmzn7j
+  slug: elia-asistent
+  slug_aliases: []
+  name: ELIA Asistent
+  domains:
+    - value: elia-asistent.com
+      role: primary
+      valid_from: 2026-09-06T19:48:40Z
+  category: other
+profile:
+  description: ELIA Asistent provides AI-powered assistant and productivity tools for teams and businesses.
+  links:
+    site: https://elia-asistent.com
+sources:
+  - source_id: src_990ed196edfd7fcff2972ebcb151e04830e35628f260f5befa2323a56f6dd83d
+    url: https://elia-asistent.com/startups
+offers:
+  - offer_id: off_01m1w3rvz6xrcxjb4rheajrw93
+    offer_slug: elia-asistent-startup-discount
+    offer_slug_aliases: []
+    title: ELIA Asistent Startup Discount
+    summary: Eligible early-stage teams receive 50% off standard ELIA Asistent plans for their first six months after approval.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T19:48:40Z
+    economics:
+      consideration:
+        kind: discount
+        description: 50% off standard plans for first six months after approval.
+    benefits:
+      - benefit_id: ben_primary
+        description: 50% off standard plans for first six months
+        kind: discount
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Must be an eligible early-stage team; specific criteria are published on the vendor startup page.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m1w3rvyf9fv8ppmesgmmzn7j
+      access_operator_entity_id: ent_01m1w3rvyf9fv8ppmesgmmzn7j
+    access:
+      availability: public
+      method: form
+      url: https://elia-asistent.com/startups
+    source_ids:
+      - src_990ed196edfd7fcff2972ebcb151e04830e35628f260f5befa2323a56f6dd83d

--- a/entities/en/enterprise-singapore.yaml
+++ b/entities/en/enterprise-singapore.yaml
@@ -1,0 +1,53 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rhdnajvn1kfpywg4nm7k
+  slug: enterprise-singapore
+  slug_aliases: []
+  name: Enterprise Singapore
+  domains:
+    - value: enterprisesg.gov.sg
+      role: primary
+      valid_from: 2026-09-06T19:45:10Z
+  category: other
+profile:
+  description: Enterprise Singapore is a government agency supporting Singapore enterprises, promoting entrepreneurship and business growth.
+  links:
+    site: https://www.enterprisesg.gov.sg
+sources:
+  - source_id: src_ef81664c02cde7da07db7d711405406806710228f9d4cc174117760907e0387b
+    url: https://www.startupsg.gov.sg/programmes/4894/startup-sg-founder
+offers:
+  - offer_id: off_01m1w3rhdwe745cgktykx3r67c
+    offer_slug: startup-sg-founder
+    offer_slug_aliases: []
+    title: Startup SG Founder
+    summary: Startup SG Founder is a SGD 20,000-50,000 grant with 1:1 capital co-matching and Accredited Mentor Partner support for eligible first-time Singaporean or permanent-resident founders.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T19:45:10Z
+    economics:
+      consideration:
+        kind: grant
+        description: SGD 20,000-50,000 grant with 1:1 capital co-matching.
+    benefits:
+      - benefit_id: ben_primary
+        description: SGD 20,000-50,000 grant with 1:1 capital co-matching
+        kind: grant
+      - benefit_id: ben_02
+        description: Support from an Accredited Mentor Partner
+        kind: other
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Must be a first-time Singaporean or permanent-resident founder; additional eligibility criteria are published on the Startup SG Founder page.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m1w3rhdnajvn1kfpywg4nm7k
+      access_operator_entity_id: ent_01m1w3rhdnajvn1kfpywg4nm7k
+    access:
+      availability: public
+      method: form
+      url: https://www.startupsg.gov.sg/programmes/4894/startup-sg-founder/eligibility
+    source_ids:
+      - src_ef81664c02cde7da07db7d711405406806710228f9d4cc174117760907e0387b

--- a/entities/fl/flawtrack.yaml
+++ b/entities/fl/flawtrack.yaml
@@ -1,0 +1,50 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rj61fd3dc49cag9v75pm
+  slug: flawtrack
+  slug_aliases: []
+  name: Flawtrack
+  domains:
+    - value: flawtrack.com
+      role: primary
+      valid_from: 2026-09-06T19:45:10Z
+  category: observability
+profile:
+  description: Flawtrack provides software reliability and error tracking tools for development teams.
+  links:
+    site: https://www.flawtrack.com
+sources:
+  - source_id: src_e749af39fad0f77742d6f58028121307392c317931efa7acf9a5a1422708728d
+    url: https://www.flawtrack.com/segments/startups
+offers:
+  - offer_id: off_01m1w3rj73br9z8vafba7nxfn0
+    offer_slug: flawtrack-funded-startup-discount
+    offer_slug_aliases: []
+    title: Flawtrack Funded Startup Discount
+    summary: The vendor advertises a 90% discount for funded startups at Series A and beyond. Duration and base pricing are not published on the source page.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T19:45:10Z
+    economics:
+      consideration:
+        kind: discount
+        description: 90% discount for funded startups at Series A and beyond.
+    benefits:
+      - benefit_id: ben_primary
+        description: 90% discount for Series A and beyond funded startups
+        kind: discount
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Must be a funded startup at Series A or beyond stage.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m1w3rj61fd3dc49cag9v75pm
+      access_operator_entity_id: ent_01m1w3rj61fd3dc49cag9v75pm
+    access:
+      availability: public
+      method: form
+      url: https://www.flawtrack.com/contact
+    source_ids:
+      - src_e749af39fad0f77742d6f58028121307392c317931efa7acf9a5a1422708728d

--- a/entities/ge/getscreen-me.yaml
+++ b/entities/ge/getscreen-me.yaml
@@ -1,0 +1,50 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rgq51y3mv4q532jmd87h
+  slug: getscreen-me
+  slug_aliases: []
+  name: Getscreen.me
+  domains:
+    - value: getscreen.me
+      role: primary
+      valid_from: 2026-09-06T19:43:48Z
+  category: communication
+profile:
+  description: Getscreen.me provides remote access and screen sharing solutions for individuals and teams.
+  links:
+    site: https://getscreen.me
+sources:
+  - source_id: src_c35cf9c08df20d8705a5ee996a7305c6a95005494409bab26110d5182766900d
+    url: https://getscreen.me/en/pricing/discounts/
+offers:
+  - offer_id: off_01m1w3rgqcesbctrfd10gc3vds
+    offer_slug: getscreen-me-startup-discount
+    offer_slug_aliases: []
+    title: Getscreen.me Startup Discount
+    summary: Getscreen.me publishes a startup-specific discount of up to 25% on business subscriptions for private commercial companies less than five years old.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T19:43:48Z
+    economics:
+      consideration:
+        kind: discount
+        description: Up to 25% discount on business subscriptions.
+    benefits:
+      - benefit_id: ben_primary
+        description: Up to 25% off business subscriptions
+        kind: discount
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Must be a private commercial company less than five years old.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m1w3rgq51y3mv4q532jmd87h
+      access_operator_entity_id: ent_01m1w3rgq51y3mv4q532jmd87h
+    access:
+      availability: public
+      method: form
+      url: https://getscreen.me/en/pricing/discounts/
+    source_ids:
+      - src_c35cf9c08df20d8705a5ee996a7305c6a95005494409bab26110d5182766900d

--- a/entities/ho/honcho.yaml
+++ b/entities/ho/honcho.yaml
@@ -1,0 +1,56 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rehgj50ky9mh2r5an0pd
+  slug: honcho
+  slug_aliases: []
+  name: Honcho
+  domains:
+    - value: honcho.dev
+      role: primary
+      valid_from: 2026-09-06T19:42:47Z
+  category: ai-ml
+profile:
+  description: Honcho is a platform that helps businesses deploy and manage AI agents and applications.
+  links:
+    site: https://honcho.dev
+sources:
+  - source_id: src_02fb1fc3329d38a9961e41f6fe41e22f458814ceb8dd77a0ef4024d19fa08b1a
+    url: https://honcho.dev
+offers:
+  - offer_id: off_01m1w3rej7kp98xqre8e5pxsdn
+    offer_slug: honcho-startup-offer
+    offer_slug_aliases: []
+    title: Honcho Startup Offer
+    summary: Startups with less than USD 5 million raised can apply for USD 1,000 in credits, 12 months of subsidized pricing, and integration support.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T19:42:47Z
+    economics:
+      consideration:
+        kind: credits
+        description: USD 1,000 in platform credits plus 12 months of subsidized pricing.
+    benefits:
+      - benefit_id: ben_primary
+        description: USD 1,000 in credits
+        kind: credits
+      - benefit_id: ben_02
+        description: 12 months of subsidized pricing
+        kind: other
+      - benefit_id: ben_03
+        description: Integration support
+        kind: other
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Must have raised less than USD 5 million.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m1w3rehgj50ky9mh2r5an0pd
+      access_operator_entity_id: ent_01m1w3rehgj50ky9mh2r5an0pd
+    access:
+      availability: public
+      method: form
+      url: https://honcho.dev
+    source_ids:
+      - src_02fb1fc3329d38a9961e41f6fe41e22f458814ceb8dd77a0ef4024d19fa08b1a

--- a/entities/ho/hopohopo.yaml
+++ b/entities/ho/hopohopo.yaml
@@ -1,0 +1,53 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w435fn3rjr11pzc40wm9tx
+  slug: hopohopo
+  slug_aliases: []
+  name: Hopohopo
+  domains:
+  - value: hopohopo.io
+    role: primary
+    valid_from: '2026-09-06T19:46:41.281Z'
+  category: crm-sales
+profile:
+  description: Hopohopo is a CRM platform offering sales, marketing, and customer management tools for growing businesses.
+  links:
+    site: https://www.hopohopo.io
+sources:
+- source_id: src_7f77e7d94511f6a1b44a37af09562a3004989df68707949aa21c81326ff6db55
+  url: https://www.hopohopo.io/partner-program-welcome
+programs: []
+offers:
+- offer_id: off_01m1w435fv3pfemcd9mes6z7hy
+  offer_slug: partner-program-startup-discount
+  offer_slug_aliases: []
+  title: Partner Program Startup Discount
+  summary: Startups in participating investor or accelerator portfolios receive 50% off the Hopohopo CRM Pro Plan for one year.
+  lifecycle:
+    status: active
+    effective_from: '2026-09-06T19:46:41.281Z'
+  economics:
+    benefits:
+    - benefit_id: ben_50_off_pro_year
+      description: 50% off the Hopohopo CRM Pro Plan for one year.
+      kind: discount
+      percentage:
+        kind: exact
+        basis_points: 5000
+    consideration:
+      kind: none
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_portfolio
+      statement: Startup must belong to a participating investor or accelerator portfolio; eligibility is verified through the portfolio invitation and partner code.
+      reason: external-verification
+  roles:
+    terms_authority_entity_id: ent_01m1w435fn3rjr11pzc40wm9tx
+    access_operator_entity_id: ent_01m1w435fn3rjr11pzc40wm9tx
+  access:
+    availability: public
+    method: other
+    url: https://www.hopohopo.io/partner-program-welcome
+  source_ids:
+  - src_7f77e7d94511f6a1b44a37af09562a3004989df68707949aa21c81326ff6db55

--- a/entities/im/imeetify.yaml
+++ b/entities/im/imeetify.yaml
@@ -1,0 +1,50 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rq00nj54dr4q70k51z1d
+  slug: imeetify
+  slug_aliases: []
+  name: iMeetify
+  domains:
+    - value: imeetify.com
+      role: primary
+      valid_from: 2026-09-06T19:47:36Z
+  category: communication
+profile:
+  description: iMeetify provides appointment scheduling and meeting management tools for businesses and professionals.
+  links:
+    site: https://www.imeetify.com
+sources:
+  - source_id: src_50262836e7e5769b36d3aa17a6c38c5baac93625f33ba5c8c72697e6b0069013
+    url: https://www.imeetify.com/imeetify-credits-for-startups
+offers:
+  - offer_id: off_01m1w3rq0f13x0g85q8fzww2an
+    offer_slug: imeetify-startup-credits
+    offer_slug_aliases: []
+    title: iMeetify Startup Credits
+    summary: iMeetify publishes a startup-specific offer of USD 1,000 in credits toward its appointment scheduling platform. No credit card or commitment is required; a public application form is available.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T19:47:36Z
+    economics:
+      consideration:
+        kind: credits
+        description: USD 1,000 in credits toward the appointment scheduling platform.
+    benefits:
+      - benefit_id: ben_primary
+        description: USD 1,000 in credits toward iMeetify appointment scheduling platform
+        kind: credits
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Must be an eligible startup and apply through the vendor's public application form; no credit card or commitment required.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m1w3rq00nj54dr4q70k51z1d
+      access_operator_entity_id: ent_01m1w3rq00nj54dr4q70k51z1d
+    access:
+      availability: public
+      method: form
+      url: https://www.imeetify.com/imeetify-credits-for-startups
+    source_ids:
+      - src_50262836e7e5769b36d3aa17a6c38c5baac93625f33ba5c8c72697e6b0069013

--- a/entities/ke/kerno.yaml
+++ b/entities/ke/kerno.yaml
@@ -1,0 +1,50 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rqhdkc79f9bazvekpt3z
+  slug: kerno
+  slug_aliases: []
+  name: Kerno
+  domains:
+    - value: kerno.io
+      role: primary
+      valid_from: 2026-09-06T19:47:36Z
+  category: finance-accounting
+profile:
+  description: Kerno (FYCK Limited) provides financial and business management tools for startups and growing companies.
+  links:
+    site: https://www.kerno.io
+sources:
+  - source_id: src_37d79161df6a35ce278a6e5976f9cda3f43776edae733ee8f6d4114f425b8d79
+    url: https://www.kerno.io/pricing/
+offers:
+  - offer_id: off_01m1w3rqj1qkbqbewn4tax2b7y
+    offer_slug: kerno-startup-discount
+    offer_slug_aliases: []
+    title: Kerno Startup Discount
+    summary: Kerno offers 50% discount for pre-Series A startups with revenue under USD 2 million over the preceding 12 months.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T19:47:36Z
+    economics:
+      consideration:
+        kind: discount
+        description: 50% discount for eligible pre-Series A startups.
+    benefits:
+      - benefit_id: ben_primary
+        description: 50% discount for pre-Series A startups with revenue under USD 2 million
+        kind: discount
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Must be pre-Series A with revenue under USD 2 million over the preceding 12 months.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m1w3rqhdkc79f9bazvekpt3z
+      access_operator_entity_id: ent_01m1w3rqhdkc79f9bazvekpt3z
+    access:
+      availability: public
+      method: form
+      url: https://www.kerno.io/pricing/
+    source_ids:
+      - src_37d79161df6a35ce278a6e5976f9cda3f43776edae733ee8f6d4114f425b8d79

--- a/entities/la/laravel.yaml
+++ b/entities/la/laravel.yaml
@@ -1,0 +1,50 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rh08gtrbrdqr32e9qaxq
+  slug: laravel
+  slug_aliases: []
+  name: Laravel
+  domains:
+    - value: laravel.com
+      role: primary
+      valid_from: 2026-09-06T19:44:08Z
+  category: hosting-infra
+profile:
+  description: Laravel Cloud is a managed deployment platform for Laravel applications, providing infrastructure and hosting services.
+  links:
+    site: https://laravel.com/cloud
+sources:
+  - source_id: src_47ff47a24afdb6034cfe4872e73005f97b877c964dfa9338f709c702f19a0bd4
+    url: https://startups.aws.com/offers?lang=en-US
+offers:
+  - offer_id: off_01m1w3rh0m5mdrc867vw88mbw4
+    offer_slug: laravel-cloud-credit-through-aws-activate
+    offer_slug_aliases: []
+    title: Laravel Cloud Credit through AWS Activate
+    summary: AWS Activate currently lists USD 300 in credits to deploy anything on Laravel Cloud. This is a partner offer accessed through AWS Activate, not Laravel Cloud's ordinary public pricing.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T19:44:08Z
+    economics:
+      consideration:
+        kind: credits
+        description: USD 300 in Laravel Cloud credits through AWS Activate.
+    benefits:
+      - benefit_id: ben_primary
+        description: USD 300 in credits toward Laravel Cloud usage
+        kind: credits
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Must meet AWS Activate membership and business eligibility requirements as published by AWS.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m1w3rh08gtrbrdqr32e9qaxq
+      access_operator_entity_id: ent_01kyh8fpe10b164tj935t8k5zb
+    access:
+      availability: public
+      method: form
+      url: https://startups.aws.com/offers?lang=en-US
+    source_ids:
+      - src_47ff47a24afdb6034cfe4872e73005f97b877c964dfa9338f709c702f19a0bd4

--- a/entities/la/layer-pr.yaml
+++ b/entities/la/layer-pr.yaml
@@ -1,0 +1,50 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rjq79m3mttr9v00wax7f
+  slug: layer-pr
+  slug_aliases: []
+  name: Layer PR
+  domains:
+    - value: layerpr.com
+      role: primary
+      valid_from: 2026-09-06T19:45:10Z
+  category: marketing
+profile:
+  description: Layer PR is a public relations platform providing tools and services for startup and technology company communications.
+  links:
+    site: https://layerpr.com
+sources:
+  - source_id: src_a1cde3e748239f4ac2c3138b4a7b967b309f54cb31b3ce03645f486784f667c9
+    url: https://layerpr.com/startup-program/
+offers:
+  - offer_id: off_01m1w3rjqt1p7p5q3rqm1ktrqk
+    offer_slug: layer-pr-startup-program
+    offer_slug_aliases: []
+    title: Layer PR Startup Program
+    summary: Layer PR offers qualifying revenue-generating startups up to 50% off invoices during its one-year startup program.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T19:45:10Z
+    economics:
+      consideration:
+        kind: discount
+        description: Up to 50% off invoices during the one-year program.
+    benefits:
+      - benefit_id: ben_primary
+        description: Up to 50% off invoices during the one-year startup program
+        kind: discount
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Must be a revenue-generating startup; specific criteria are published on the vendor startup program page.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m1w3rjq79m3mttr9v00wax7f
+      access_operator_entity_id: ent_01m1w3rjq79m3mttr9v00wax7f
+    access:
+      availability: public
+      method: form
+      url: https://layerpr.com/startup-program/
+    source_ids:
+      - src_a1cde3e748239f4ac2c3138b4a7b967b309f54cb31b3ce03645f486784f667c9

--- a/entities/le/lead-liaison.yaml
+++ b/entities/le/lead-liaison.yaml
@@ -1,0 +1,53 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rg5vfe2htdetwspdxwky
+  slug: lead-liaison
+  slug_aliases: []
+  name: Lead Liaison
+  domains:
+    - value: leadliaison.com
+      role: primary
+      valid_from: 2026-09-06T19:43:17Z
+  category: crm-sales
+profile:
+  description: Lead Liaison provides sales and marketing automation software including CRM, marketing, and revenue operations tools.
+  links:
+    site: https://www.leadliaison.com
+sources:
+  - source_id: src_07e182c86eb05bcd40febc39e5d8f6e9c55bc896a3ce771eb2dd8ee1ae77acd2
+    url: https://www.leadliaison.com/startups/
+offers:
+  - offer_id: off_01m1w3rg6h2fbw3xnyxc0b7kyb
+    offer_slug: lead-liaison-seed-stage-startup-discount
+    offer_slug_aliases: []
+    title: Lead Liaison Seed-Stage Startup Discount
+    summary: The vendor publishes 90% off subscription licenses for 24 months, then 50% for 12 months, with funding, partner affiliation, new-customer, and second-year training conditions.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T19:43:17Z
+    economics:
+      consideration:
+        kind: discount
+        description: 90% off for 24 months, then 50% off for 12 months on subscription licenses.
+    benefits:
+      - benefit_id: ben_primary
+        description: 90% off subscription licenses for 24 months
+        kind: discount
+      - benefit_id: ben_02
+        description: 50% off for an additional 12 months
+        kind: discount
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Subject to funding, partner affiliation, new-customer, and second-year training conditions as published on the vendor startup page.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m1w3rg5vfe2htdetwspdxwky
+      access_operator_entity_id: ent_01m1w3rg5vfe2htdetwspdxwky
+    access:
+      availability: public
+      method: form
+      url: https://www.leadliaison.com/startups/
+    source_ids:
+      - src_07e182c86eb05bcd40febc39e5d8f6e9c55bc896a3ce771eb2dd8ee1ae77acd2

--- a/entities/le/lettermint.yaml
+++ b/entities/le/lettermint.yaml
@@ -1,0 +1,50 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rmckdt857tkc5fya50f5
+  slug: lettermint
+  slug_aliases: []
+  name: Lettermint
+  domains:
+    - value: lettermint.co
+      role: primary
+      valid_from: 2026-09-06T19:46:00Z
+  category: productivity
+profile:
+  description: Lettermint provides document and letter management tools for businesses and professionals.
+  links:
+    site: https://lettermint.co
+sources:
+  - source_id: src_182544062d8aceb638d5eccdbf9e53a250b9c3fbb1fecc73f5491c636b152400
+    url: https://lettermint.co/promo-codes-and-discounts/startups
+offers:
+  - offer_id: off_01m1w3rmd51h99jdvdqf0y27dy
+    offer_slug: lettermint-startup-account-credit
+    offer_slug_aliases: []
+    title: Lettermint Startup Account Credit
+    summary: Lettermint offers a startup-specific EUR 60 account credit, valid for 12 months after activation.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T19:46:00Z
+    economics:
+      consideration:
+        kind: credits
+        description: EUR 60 account credit, valid for 12 months after activation.
+    benefits:
+      - benefit_id: ben_primary
+        description: EUR 60 account credit, valid for 12 months after activation
+        kind: credits
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Must be an eligible startup and complete the vendor's application process.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m1w3rmckdt857tkc5fya50f5
+      access_operator_entity_id: ent_01m1w3rmckdt857tkc5fya50f5
+    access:
+      availability: public
+      method: form
+      url: https://lettermint.co/promo-codes-and-discounts/startups
+    source_ids:
+      - src_182544062d8aceb638d5eccdbf9e53a250b9c3fbb1fecc73f5491c636b152400

--- a/entities/li/liveblocks.yaml
+++ b/entities/li/liveblocks.yaml
@@ -1,0 +1,50 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rhnjk9123k0q7rgk5921
+  slug: liveblocks
+  slug_aliases: []
+  name: Liveblocks
+  domains:
+    - value: liveblocks.io
+      role: primary
+      valid_from: 2026-09-06T19:45:10Z
+  category: devtools-other
+profile:
+  description: Liveblocks provides real-time collaboration infrastructure for building multiplayer applications with CRDTs and conflict-free data types.
+  links:
+    site: https://liveblocks.io
+sources:
+  - source_id: src_3ace73d1f69e2e086572b2eda19520018da0eeee7f3c8b6875dcad7be0b4cd0d
+    url: https://liveblocks.io/startups
+offers:
+  - offer_id: off_01m1w3rhnqvh09g5kagd6h2h0a
+    offer_slug: liveblocks-startup-program-discount
+    offer_slug_aliases: []
+    title: Liveblocks Startup Program
+    summary: The Liveblocks startup page advertises a startup program discount with an application form. Specific discount percentage and duration are not published.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T19:45:10Z
+    economics:
+      consideration:
+        kind: discount
+        description: Startup program discount; specific terms are not publicly published.
+    benefits:
+      - benefit_id: ben_primary
+        description: Startup program discount (specific terms not published)
+        kind: discount
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Must be an eligible startup; specific criteria are published on the vendor startup page and evaluated on application.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m1w3rhnjk9123k0q7rgk5921
+      access_operator_entity_id: ent_01m1w3rhnjk9123k0q7rgk5921
+    access:
+      availability: public
+      method: form
+      url: https://liveblocks.io/startups
+    source_ids:
+      - src_3ace73d1f69e2e086572b2eda19520018da0eeee7f3c8b6875dcad7be0b4cd0d

--- a/entities/ma/manylayers.yaml
+++ b/entities/ma/manylayers.yaml
@@ -1,0 +1,50 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rtysp36jfdcnegafgew9
+  slug: manylayers
+  slug_aliases: []
+  name: ManyLayers
+  domains:
+    - value: manylayers.io
+      role: primary
+      valid_from: 2026-09-06T19:48:40Z
+  category: ai-ml
+profile:
+  description: ManyLayers provides AI model deployment and management infrastructure for AI-first teams and startups.
+  links:
+    site: https://manylayers.io
+sources:
+  - source_id: src_3018885f7b4bf6e62e858a48b516964f5066f15a6e9c76f083b525bff768ad2c
+    url: https://manylayers.io/startup-program/
+offers:
+  - offer_id: off_01m1w3rtyz83wemmn45esb9r3g
+    offer_slug: manylayers-startup-program
+    offer_slug_aliases: []
+    title: ManyLayers Startup Program
+    summary: Eligible AI-first startups receive the ManyLayers Team tier free for 12 months, with platform access and dedicated support.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T19:48:40Z
+    economics:
+      consideration:
+        kind: free-period
+        description: Team tier free for 12 months with platform access and dedicated support.
+    benefits:
+      - benefit_id: ben_primary
+        description: ManyLayers Team tier free for 12 months with platform access and dedicated support
+        kind: free-period
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Must be an AI-first startup; specific eligibility criteria are published on the vendor startup program page.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m1w3rtysp36jfdcnegafgew9
+      access_operator_entity_id: ent_01m1w3rtysp36jfdcnegafgew9
+    access:
+      availability: public
+      method: form
+      url: https://manylayers.io/startup-program/
+    source_ids:
+      - src_3018885f7b4bf6e62e858a48b516964f5066f15a6e9c76f083b525bff768ad2c

--- a/entities/ma/mawio.yaml
+++ b/entities/ma/mawio.yaml
@@ -1,0 +1,53 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rxnpx0bsrs6tfrem7wdx
+  slug: mawio
+  slug_aliases: []
+  name: Mawio
+  domains:
+    - value: mawio.dev
+      role: primary
+      valid_from: 2026-09-06T19:49:38Z
+  category: ai-ml
+profile:
+  description: Mawio provides AI agent infrastructure and APIs for pre-seed to Series A AI-agent startups.
+  links:
+    site: https://mawio.dev
+sources:
+  - source_id: src_52fe16970547fb364601287dd30283e20a5ada6fb3760bee78e151f73a2b5672
+    url: https://mawio.dev/startups
+offers:
+  - offer_id: off_01m1w3rxnvg1zxd2fgy600pam7
+    offer_slug: mawio-startup-program
+    offer_slug_aliases: []
+    title: Mawio Startup Program
+    summary: The page advertises USD 10,000 in free API credits for approved pre-seed to Series A AI-agent startups younger than three years and below USD 5 million annual revenue, alongside a six-month Startup Tier. Applications go to startups@mawio.dev.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T19:49:38Z
+    economics:
+      consideration:
+        kind: credits
+        description: USD 10,000 in free API credits for approved startups, with a six-month Startup Tier.
+    benefits:
+      - benefit_id: ben_primary
+        description: USD 10,000 in free API credits
+        kind: credits
+      - benefit_id: ben_02
+        description: Six-month Startup Tier with platform access
+        kind: other
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Must be a pre-seed to Series A AI-agent startup younger than three years with below USD 5 million annual revenue.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m1w3rxnpx0bsrs6tfrem7wdx
+      access_operator_entity_id: ent_01m1w3rxnpx0bsrs6tfrem7wdx
+    access:
+      availability: public
+      method: email
+      url: mailto:startups@mawio.dev
+    source_ids:
+      - src_52fe16970547fb364601287dd30283e20a5ada6fb3760bee78e151f73a2b5672

--- a/entities/mo/morris-james.yaml
+++ b/entities/mo/morris-james.yaml
@@ -1,0 +1,50 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rr0tcfvc242ahdd0ftvc
+  slug: morris-james
+  slug_aliases: []
+  name: Morris James LLP
+  domains:
+    - value: morrisjames.com
+      role: primary
+      valid_from: 2026-09-06T19:47:36Z
+  category: legal-compliance
+profile:
+  description: Morris James LLP is a regional law firm in the United States providing corporate and business legal services, including to startups and entrepreneurs.
+  links:
+    site: https://www.morrisjames.com
+sources:
+  - source_id: src_1590816f64f2d1d2bf7b10039e9cb3b05ba5c07ca7d7c5aa884565fb8b8b3532
+    url: https://www.morrisjames.com/service/corporate-ma/start-up-program/
+offers:
+  - offer_id: off_01m1w3rr164y03798fvddvewkb
+    offer_slug: morris-james-start-up-program
+    offer_slug_aliases: []
+    title: Morris James Start-Up Program
+    summary: The Morris James Start-Up Program offers qualifying companies 30% off standard corporate legal rates for the first year of engagement. Qualification is case-by-case.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T19:47:36Z
+    economics:
+      consideration:
+        kind: discount
+        description: 30% off standard corporate legal rates for the first year of engagement.
+    benefits:
+      - benefit_id: ben_primary
+        description: 30% off standard corporate legal rates for the first year
+        kind: discount
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Qualification is case-by-case; typical criteria include early-stage status and legal needs consistent with startup representation.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m1w3rr0tcfvc242ahdd0ftvc
+      access_operator_entity_id: ent_01m1w3rr0tcfvc242ahdd0ftvc
+    access:
+      availability: public
+      method: form
+      url: https://www.morrisjames.com/service/corporate-ma/start-up-program/
+    source_ids:
+      - src_1590816f64f2d1d2bf7b10039e9cb3b05ba5c07ca7d7c5aa884565fb8b8b3532

--- a/entities/nv/nvoip.yaml
+++ b/entities/nv/nvoip.yaml
@@ -1,0 +1,50 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rx9c0q6k34tte4x37f7c
+  slug: nvoip
+  slug_aliases: []
+  name: Nvoip
+  domains:
+    - value: nvoip.com.br
+      role: primary
+      valid_from: 2026-09-06T19:49:38Z
+  category: communication
+profile:
+  description: Nvoip provides communication and VoIP services and APIs for businesses and startups.
+  links:
+    site: https://www.nvoip.com.br
+sources:
+  - source_id: src_c770b4d01831f74317f071e33871ce355bd6cb89d619f2175f83e1aa544e973b
+    url: https://www.nvoip.com.br/en/nvoip-for-startups/
+offers:
+  - offer_id: off_01m1w3rxa57eys533440jzfqn5
+    offer_slug: nvoip-for-startups
+    offer_slug_aliases: []
+    title: Nvoip for Startups
+    summary: Nvoip's English-language startup program page offers discounts on its communication plans for startups connected with Nvoip partner hubs. The current page advertises up to 90% off, with the benefit dependent on startup maturity and lasting up to two years.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T19:49:38Z
+    economics:
+      consideration:
+        kind: discount
+        description: Up to 90% off communication plans for up to two years for startups connected with Nvoip partner hubs.
+    benefits:
+      - benefit_id: ben_primary
+        description: Up to 90% off communication plans for up to two years through partner hub connection
+        kind: discount
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Must be a startup connected with an Nvoip partner hub; specific eligibility and discount levels are dependent on startup maturity.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m1w3rx9c0q6k34tte4x37f7c
+      access_operator_entity_id: ent_01m1w3rx9c0q6k34tte4x37f7c
+    access:
+      availability: public
+      method: form
+      url: https://www.nvoip.com.br/en/nvoip-for-startups/
+    source_ids:
+      - src_c770b4d01831f74317f071e33871ce355bd6cb89d619f2175f83e1aa544e973b

--- a/entities/ol/olqan.yaml
+++ b/entities/ol/olqan.yaml
@@ -1,0 +1,50 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rvdpj5wmc7tfmnsdabpa
+  slug: olqan
+  slug_aliases: []
+  name: Olqan
+  domains:
+    - value: olqan.com
+      role: primary
+      valid_from: 2026-09-06T19:48:40Z
+  category: devtools-other
+profile:
+  description: Olqan provides development and analytics tools for startups and growth-stage companies.
+  links:
+    site: https://olqan.com
+sources:
+  - source_id: src_587824448b383cdaea1772737b1df1a866a67cb35e7a38299fb66551802f25dc
+    url: https://olqan.com/startup-program/
+offers:
+  - offer_id: off_01m1w3rve254d2nv61nrdnaeh5
+    offer_slug: olqan-startup-program
+    offer_slug_aliases: []
+    title: Olqan Startup Program
+    summary: Eligible new users receive the Olqan Growth plan free for 12 months, including onboarding, migration, and priority support.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T19:48:40Z
+    economics:
+      consideration:
+        kind: free-period
+        description: Growth plan free for 12 months, including onboarding, migration, and priority support.
+    benefits:
+      - benefit_id: ben_primary
+        description: Growth plan free for 12 months with onboarding, migration, and priority support
+        kind: free-period
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Must be an eligible new user; specific criteria are published on the vendor startup program page.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m1w3rvdpj5wmc7tfmnsdabpa
+      access_operator_entity_id: ent_01m1w3rvdpj5wmc7tfmnsdabpa
+    access:
+      availability: public
+      method: form
+      url: https://olqan.com/startup-program/
+    source_ids:
+      - src_587824448b383cdaea1772737b1df1a866a67cb35e7a38299fb66551802f25dc

--- a/entities/op/oprex.yaml
+++ b/entities/op/oprex.yaml
@@ -1,0 +1,50 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rf7mbtjqpj8am05cc1mh
+  slug: oprex
+  slug_aliases: []
+  name: Oprex
+  domains:
+    - value: oprex.id
+      role: primary
+      valid_from: 2026-09-06T19:42:47Z
+  category: productivity
+profile:
+  description: Oprex is a productivity and workflow platform for teams in Indonesia and Southeast Asia.
+  links:
+    site: https://oprex.id
+sources:
+  - source_id: src_79d65093bb8ade590fc6ad05865e0c99f2426eeb5b4109595d88efd7d24da5f0
+    url: https://oprex.id/company/startup-program
+offers:
+  - offer_id: off_01m1w3rf7z05x7be2j663hdd5b
+    offer_slug: oprex-startup-program
+    offer_slug_aliases: []
+    title: Oprex Startup Program
+    summary: Eligible early-stage teams receive the Oprex Pro plan free for 12 months. The public pricing page lists Pro at Rp 1,490,000 per month.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T19:42:47Z
+    economics:
+      consideration:
+        kind: free-period
+        description: Pro plan free for 12 months (Rp 1,490,000/month value).
+    benefits:
+      - benefit_id: ben_primary
+        description: Oprex Pro plan free for 12 months
+        kind: free-period
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Must be an early-stage team; specific criteria are published on the vendor startup program page.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m1w3rf7mbtjqpj8am05cc1mh
+      access_operator_entity_id: ent_01m1w3rf7mbtjqpj8am05cc1mh
+    access:
+      availability: public
+      method: form
+      url: https://oprex.id/company/startup-program
+    source_ids:
+      - src_79d65093bb8ade590fc6ad05865e0c99f2426eeb5b4109595d88efd7d24da5f0

--- a/entities/pa/paypercut.yaml
+++ b/entities/pa/paypercut.yaml
@@ -1,0 +1,50 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rsm18kdmxmm54ha0zjnj
+  slug: paypercut
+  slug_aliases: []
+  name: Paypercut
+  domains:
+    - value: paypercut.com
+      role: primary
+      valid_from: 2026-09-06T19:47:36Z
+  category: finance-accounting
+profile:
+  description: Paypercut provides payment and transaction services for businesses in Europe.
+  links:
+    site: https://paypercut.com
+sources:
+  - source_id: src_1907a1f06514a59d726dd006717ec20e2ea71afb6db19c765dbbfa9bf8add5fa
+    url: https://paypercut.com/paypercut-for-startups
+offers:
+  - offer_id: off_01m1w3rsm7gk3j4y60zscy4raj
+    offer_slug: paypercut-for-startups
+    offer_slug_aliases: []
+    title: Paypercut for Startups
+    summary: Paypercut for Startups provides eligible early-stage European startups with transaction-fee waivers and reduced pricing for up to 24 months, capped at EUR 10,000 in aggregate fee savings.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T19:47:36Z
+    economics:
+      consideration:
+        kind: fee-waiver
+        description: Transaction-fee waivers and reduced pricing for up to 24 months, capped at EUR 10,000 aggregate savings.
+    benefits:
+      - benefit_id: ben_primary
+        description: Transaction-fee waivers and reduced pricing for up to 24 months, capped at EUR 10,000
+        kind: fee-waiver
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Must be an eligible early-stage European startup; specific criteria are published on the vendor startup page.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m1w3rsm18kdmxmm54ha0zjnj
+      access_operator_entity_id: ent_01m1w3rsm18kdmxmm54ha0zjnj
+    access:
+      availability: public
+      method: form
+      url: https://paypercut.com/paypercut-for-startups
+    source_ids:
+      - src_1907a1f06514a59d726dd006717ec20e2ea71afb6db19c765dbbfa9bf8add5fa

--- a/entities/pu/pulseadt.yaml
+++ b/entities/pu/pulseadt.yaml
@@ -1,0 +1,53 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rrtnzqfhcaeaq5decct3
+  slug: pulseadt
+  slug_aliases: []
+  name: PulseADT
+  domains:
+    - value: getpulseadt.com
+      role: primary
+      valid_from: 2026-09-06T19:47:36Z
+  category: devtools-other
+profile:
+  description: PulseADT provides API development and testing tools for developers and teams.
+  links:
+    site: https://getpulseadt.com
+sources:
+  - source_id: src_90bc10365386d1e40cd29886098e1270557f90c23b2f3bacb96b571c8efe2c16
+    url: https://getpulseadt.com/for-startups
+offers:
+  - offer_id: off_01m1w3rrttzbmxnzf9v6h8vpjw
+    offer_slug: pulseadt-startup-credit-program
+    offer_slug_aliases: []
+    title: PulseADT Startup Credit Program
+    summary: The API Builder track grants eligible early-stage technology startups a USD 250 platform credit valid for 12 months after spending at least USD 100 on API credits within 90 days, followed by an ongoing 30% discount.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T19:47:36Z
+    economics:
+      consideration:
+        kind: credits
+        description: USD 250 platform credit plus ongoing 30% discount after initial spending requirement.
+    benefits:
+      - benefit_id: ben_primary
+        description: USD 250 platform credit valid for 12 months after USD 100 spending within 90 days
+        kind: credits
+      - benefit_id: ben_02
+        description: 30% ongoing discount thereafter
+        kind: discount
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Must be an early-stage technology startup; the credit requires spending at least USD 100 on API credits within 90 days.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m1w3rrtnzqfhcaeaq5decct3
+      access_operator_entity_id: ent_01m1w3rrtnzqfhcaeaq5decct3
+    access:
+      availability: public
+      method: form
+      url: https://getpulseadt.com/for-startups
+    source_ids:
+      - src_90bc10365386d1e40cd29886098e1270557f90c23b2f3bacb96b571c8efe2c16

--- a/entities/py/pylon.yaml
+++ b/entities/py/pylon.yaml
@@ -1,79 +1,50 @@
 schema_version: sourcey.entity-authoring/v1alpha1
 entity:
-  entity_id: ent_01m1v6swhdrkffwgyep3qsxn2s
+  entity_id: ent_01m1w3rw9h60cqynh2jw8gh4pc
   slug: pylon
   slug_aliases: []
   name: Pylon
   domains:
     - value: usepylon.com
       role: primary
-      valid_from: 2026-09-06T11:14:06.519Z
+      valid_from: 2026-09-06T19:49:38Z
   category: support
 profile:
-  summary: Pylon provides B2B customer support software with AI agents, ticketing, knowledge bases, and support across multiple channels.
-  description: Pylon provides B2B customer support software with AI agents, ticketing, knowledge bases, and support across multiple channels.
+  description: Pylon is a B2B support platform providing helpdesk, customer service, and support operations tools.
   links:
-    site: https://www.usepylon.com/
+    site: https://www.usepylon.com
 sources:
-  - source_id: src_7a7475661d885cdb1aab73305ca564c52dd2d511136005761d955875c9b28837
-    url: https://www.usepylon.com/
-  - source_id: src_63e1ec20a913cbb10619743d0bb78ad21e4aaeb5e189f1ec5c38a78badedf45d
-    url: https://www.brex.com/support/brex-partner-perks
-  - source_id: src_e96fa7e2506e2ca564581c244eb8e510e6292362218d0de08a2c6610e08b3a6a
+  - source_id: src_76a17f6024cd46b532d607dfae5c514c5154c821d53021b26bfd69aa464c190b
     url: https://www.brex.com/dayzerostack
-  - source_id: src_f98677a98aaaf58a2696c90c2c12392dc4d32493645bc1ad4474f204706e56ff
-    url: https://www.usepylon.com/legal/terms
-programs: []
 offers:
-  - offer_id: off_01m1v6swhqpsm17qj1x82qv7pe
-    offer_slug: brex-day-zero-stack-annual-contract-discount
+  - offer_id: off_01m1w3rwa4yqfb4ytc0hmpgs4v
+    offer_slug: pylon-brex-day-zero-stack-discount
     offer_slug_aliases: []
-    title: Brex Day Zero Stack annual-contract discount
-    summary: Eligible Brex cardholders who are new Pylon customers can receive 15% off Pylon annual contracts through the Day Zero Stack partner perk.
+    title: Pylon Annual Contract Discount through Brex Day Zero Stack
+    summary: Brex publicly lists a 15% discount on Pylon annual contracts for new customers. Access is for eligible Brex cardholders through the Brex Day Zero Stack rewards program.
     lifecycle:
       status: active
-      effective_from: 2026-09-06T11:14:06.519Z
+      effective_from: 2026-09-06T19:49:38Z
     economics:
       consideration:
-        kind: variable
-        description: Customers pay Pylon the fees specified in their Order Form.
-      benefits:
-        - benefit_id: ben_annual_contract_discount
-          kind: discount
-          description: 15% off Pylon annual contracts.
-          applies_to: Pylon annual contracts
-          percentage:
-            kind: exact
-            basis_points: 1500
+        kind: discount
+        description: 15% discount on annual contracts.
+    benefits:
+      - benefit_id: ben_primary
+        description: 15% off Pylon annual contracts
+        kind: discount
     eligibility:
       rule:
-        kind: all
-        rules:
-          - criterion_id: cri_new_customer
-            kind: predicate
-            fact: company.is_current_customer
-            operator: eq
-            value:
-              type: boolean
-              value: false
-            statement: New Pylon customers only.
-          - criterion_id: cri_brex_cardholder
-            kind: manual
-            reason: external-verification
-            statement: Must be a Brex cardholder with access to the Pylon partner perk.
-          - criterion_id: cri_account_availability
-            kind: manual
-            reason: external-verification
-            statement: The Pylon perk must still appear in the account's Rewards > Perks and discounts list.
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Must be an eligible Brex cardholder and new Pylon customer; access is through the Brex Day Zero Stack rewards program.
+        reason: not-machine-evaluable
     roles:
-      terms_authority_entity_id: ent_01m1v6swhdrkffwgyep3qsxn2s
+      terms_authority_entity_id: ent_01m1w3rw9h60cqynh2jw8gh4pc
       access_operator_entity_id: ent_01kyyts97rczvy7tt3n9gd0y3n
     access:
-      availability: membership
-      method: other
-      url: https://www.brex.com/support/brex-partner-perks
-      instructions: A Brex account or card admin, or another user with the required product capability, opens Rewards > Perks and discounts in the dashboard, selects Pylon, reviews any qualification requirements, and follows the displayed redemption instructions.
+      availability: restricted
+      method: partner-code
+      url: https://www.brex.com/dayzerostack
     source_ids:
-      - src_63e1ec20a913cbb10619743d0bb78ad21e4aaeb5e189f1ec5c38a78badedf45d
-      - src_e96fa7e2506e2ca564581c244eb8e510e6292362218d0de08a2c6610e08b3a6a
-      - src_f98677a98aaaf58a2696c90c2c12392dc4d32493645bc1ad4474f204706e56ff
+      - src_76a17f6024cd46b532d607dfae5c514c5154c821d53021b26bfd69aa464c190b

--- a/entities/si/sinatra.yaml
+++ b/entities/si/sinatra.yaml
@@ -1,0 +1,50 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rk4skcsjp6p846b4dcb4
+  slug: sinatra
+  slug_aliases: []
+  name: Sinatra
+  domains:
+    - value: sinatra.dev
+      role: primary
+      valid_from: 2026-09-06T19:45:10Z
+  category: devtools-other
+profile:
+  description: Sinatra provides development tools and infrastructure for building and deploying applications.
+  links:
+    site: https://www.sinatra.dev
+sources:
+  - source_id: src_72bd5de0c66499948398b5a11082b8cfb1b6024c9acf0309cf79248e6473d202
+    url: https://www.sinatra.dev/startups
+offers:
+  - offer_id: off_01m1w3rk5mm2x9rmnpj4g4a5t7
+    offer_slug: sinatra-startup-discount
+    offer_slug_aliases: []
+    title: Sinatra Startup Discount
+    summary: Approved startup teams receive 50% off monthly seats for 12 months.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T19:45:10Z
+    economics:
+      consideration:
+        kind: discount
+        description: 50% off monthly seats for 12 months.
+    benefits:
+      - benefit_id: ben_primary
+        description: 50% off monthly seats for 12 months
+        kind: discount
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Must be an approved startup team; specific criteria are published on the vendor startup page.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m1w3rk4skcsjp6p846b4dcb4
+      access_operator_entity_id: ent_01m1w3rk4skcsjp6p846b4dcb4
+    access:
+      availability: public
+      method: form
+      url: https://www.sinatra.dev/startups
+    source_ids:
+      - src_72bd5de0c66499948398b5a11082b8cfb1b6024c9acf0309cf79248e6473d202

--- a/entities/so/soax.yaml
+++ b/entities/so/soax.yaml
@@ -1,0 +1,50 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rkjk3mprk07k20safeae
+  slug: soax
+  slug_aliases: []
+  name: SOAX
+  domains:
+    - value: soax.com
+      role: primary
+      valid_from: 2026-09-06T19:45:10Z
+  category: devtools-other
+profile:
+  description: SOAX provides residential proxy and web scraping infrastructure for businesses and developers.
+  links:
+    site: https://www.soax.com
+sources:
+  - source_id: src_40822929901d4e3ce2f7a6bf7c2f7bbb86ee1d079c882ab73b126a29bbeb1aa9
+    url: https://www.soax.com/pricing/startups
+offers:
+  - offer_id: off_01m1w3rkkgbe6ch1tbsv7mb2pw
+    offer_slug: soax-startup-discount
+    offer_slug_aliases: []
+    title: SOAX Startup Discount
+    summary: SOAX offers eligible startups 50% off Enterprise plans.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T19:45:10Z
+    economics:
+      consideration:
+        kind: discount
+        description: 50% off Enterprise plans for eligible startups.
+    benefits:
+      - benefit_id: ben_primary
+        description: 50% off Enterprise plans
+        kind: discount
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Must be an eligible startup; specific criteria are published on the vendor startup pricing page.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m1w3rkjk3mprk07k20safeae
+      access_operator_entity_id: ent_01m1w3rkjk3mprk07k20safeae
+    access:
+      availability: public
+      method: form
+      url: https://www.soax.com/pricing/startups
+    source_ids:
+      - src_40822929901d4e3ce2f7a6bf7c2f7bbb86ee1d079c882ab73b126a29bbeb1aa9

--- a/entities/st/stripe.yaml
+++ b/entities/st/stripe.yaml
@@ -18,6 +18,8 @@ sources:
     url: https://stripe.com/startups
   - source_id: src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d
     url: https://pulley.com/perks
+  - source_id: src_1a1831792959a97a00d127e9899e50bf9540843d46a62120770b232b5312fd95
+    url: https://stripe.com/atlas
 programs:
   - program_id: prg_01kyygma8309wepbqk3a8d21wm
     program_slug: stripe-startup-programme
@@ -26,6 +28,13 @@ programs:
     summary: Designed to support venture-backed businesses with financial benefits, exclusive discounts, community, and expert resources.
     source_ids:
       - src_4410dda4d44891aad0cc0b21bb409ed3d27032c5bc1852a256708b3df0b1ff45
+  - program_id: prg_01m1w3be87kp3yyyr8m2brh4k4
+    program_slug: stripe-atlas
+    program_slug_aliases: []
+    title: Stripe Atlas
+    summary: Helps entrepreneurs worldwide incorporate a US company in Delaware (C corp or LLC).
+    source_ids:
+      - src_1a1831792959a97a00d127e9899e50bf9540843d46a62120770b232b5312fd95
 offers:
   - offer_id: off_01kyygma8386545a4wn8g6q28y
     program_id: prg_01kyygma8309wepbqk3a8d21wm
@@ -101,3 +110,46 @@ offers:
       method: other
     source_ids:
       - src_5af15c175b972ada7f6e0487dc9385f214ca5825c52bf7ecdb54e53d1946183d
+  - offer_id: off_01m1w3be87e4sh4d135q2er9e3
+    program_id: prg_01m1w3be87kp3yyyr8m2brh4k4
+    offer_slug: stripe-atlas-incorporation
+    offer_slug_aliases: []
+    title: Stripe Atlas Incorporation
+    summary: Incorporate a US company in Delaware for $500, including EIN, share documents, and $2,500 in Stripe product credits.
+    lifecycle:
+      status: active
+      effective_from: 2026-08-06T00:00:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: $500 one-time setup fee (includes government fees and first year of registered agent services)
+          kind: cost
+          value:
+            amount:
+              currency: USD
+              minor_units: 50000
+            kind: exact
+        - benefit_id: ben_02
+          description: $2,500 in Stripe product credits for first year
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 250000
+            kind: exact
+      consideration:
+        kind: payment
+    eligibility:
+      rule:
+        kind: constant
+        statement: Open to any entrepreneur worldwide.
+        value: true
+    roles:
+      terms_authority_entity_id: ent_01kyygma830fqh16kvj744sk1c
+      access_operator_entity_id: ent_01kyygma830fqh16kvj744sk1c
+    access:
+      availability: public
+      method: form
+      url: https://stripe.com/atlas
+    source_ids:
+      - src_1a1831792959a97a00d127e9899e50bf9540843d46a62120770b232b5312fd95

--- a/entities/ta/tally.yaml
+++ b/entities/ta/tally.yaml
@@ -1,0 +1,50 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rm2svr8w97bs0zcp2cag
+  slug: tally
+  slug_aliases: []
+  name: Tally
+  domains:
+    - value: tally.so
+      role: primary
+      valid_from: 2026-09-06T19:46:00Z
+  category: productivity
+profile:
+  description: Tally is an online form builder that helps teams create, manage, and analyze forms and surveys.
+  links:
+    site: https://tally.so
+sources:
+  - source_id: src_06a4089b0738754063e6f5d1d6958762c3dd0e3f0d876a5f1686a0fa710aab13
+    url: https://tally.so/help/tally-for-startups
+offers:
+  - offer_id: off_01m1w3rm3cq0ttfdmqdmt8z58v
+    offer_slug: tally-for-startups
+    offer_slug_aliases: []
+    title: Tally for Startups
+    summary: Tally publishes a startup-specific offer of 50% off Tally Pro for one year through its Partner Program. Eligibility requires a partner membership, partner code, free Tally account, no previous paid customer, and compliance with cancellation restrictions.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T19:46:00Z
+    economics:
+      consideration:
+        kind: discount
+        description: 50% off Tally Pro for one year through the Partner Program.
+    benefits:
+      - benefit_id: ben_primary
+        description: 50% off Tally Pro for one year
+        kind: discount
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Must have a partner membership and code, a free Tally account, no previous paid Tally subscription, and comply with cancellation restrictions.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m1w3rm2svr8w97bs0zcp2cag
+      access_operator_entity_id: ent_01m1w3rm2svr8w97bs0zcp2cag
+    access:
+      availability: public
+      method: form
+      url: https://tally.so/r/kwoOVw
+    source_ids:
+      - src_06a4089b0738754063e6f5d1d6958762c3dd0e3f0d876a5f1686a0fa710aab13

--- a/entities/ta/taskgate.yaml
+++ b/entities/ta/taskgate.yaml
@@ -1,0 +1,50 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rr98k8nfz7bptzjfbffk
+  slug: taskgate
+  slug_aliases: []
+  name: TaskGate.io
+  domains:
+    - value: taskgate.io
+      role: primary
+      valid_from: 2026-09-06T19:47:36Z
+  category: crm-sales
+profile:
+  description: TaskGate.io provides CRM, HRM, ERP, and project management platform solutions for businesses.
+  links:
+    site: https://www.taskgate.io
+sources:
+  - source_id: src_8453b5619af6dee3a1e11aafcfc00539136a1eb6e910c4aee8949478ee906c6e
+    url: https://www.taskgate.io/general-9
+offers:
+  - offer_id: off_01m1w3rrb3vmsjjwvkpwb2d4hg
+    offer_slug: taskgate-startup-program
+    offer_slug_aliases: []
+    title: TaskGate.io Startup Program
+    summary: Eligible registered startups can receive up to 50% off TaskGate.io annual packages, covering its CRM, HRM, ERP, and project management platform.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T19:47:36Z
+    economics:
+      consideration:
+        kind: discount
+        description: Up to 50% off annual packages.
+    benefits:
+      - benefit_id: ben_primary
+        description: Up to 50% off annual packages covering CRM, HRM, ERP, and project management
+        kind: discount
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Must be a registered startup; specific criteria are published on the vendor startup page.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m1w3rr98k8nfz7bptzjfbffk
+      access_operator_entity_id: ent_01m1w3rr98k8nfz7bptzjfbffk
+    access:
+      availability: public
+      method: form
+      url: https://www.taskgate.io/general-9
+    source_ids:
+      - src_8453b5619af6dee3a1e11aafcfc00539136a1eb6e910c4aee8949478ee906c6e

--- a/entities/tu/tuple.yaml
+++ b/entities/tu/tuple.yaml
@@ -1,0 +1,50 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3re4nq09xh055pwdz5q2y
+  slug: tuple
+  slug_aliases: []
+  name: Tuple
+  domains:
+    - value: tuple.app
+      role: primary
+      valid_from: 2026-09-06T19:42:18Z
+  category: devtools-other
+profile:
+  description: Tuple is a screen-sharing app built specifically for pair programming, offering high-quality, low-bandwidth sessions.
+  links:
+    site: https://tuple.app
+sources:
+  - source_id: src_613578dab6b49a3424aa2a711f469f65ab95d7ce92e5dff6385ad3c4f5559d3a
+    url: https://tuple.app/startups
+offers:
+  - offer_id: off_01m1w3re510s7rm1e5yks1r23g
+    offer_slug: tuple-startup-plan
+    offer_slug_aliases: []
+    title: Tuple Startup Plan
+    summary: Eligible startups receive a startup subscription discount through the vendor's public pricing page and startup application form.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T19:42:18Z
+    economics:
+      consideration:
+        kind: discount
+        description: The source record did not establish separate consideration.
+    benefits:
+      - benefit_id: ben_primary
+        description: Startup subscription discount through the vendor-linked application
+        kind: other
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Must be an early-stage startup; specific eligibility criteria are published on the vendor startup application page.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m1w3re4nq09xh055pwdz5q2y
+      access_operator_entity_id: ent_01m1w3re4nq09xh055pwdz5q2y
+    access:
+      availability: public
+      method: form
+      url: https://tuple.app/startups
+    source_ids:
+      - src_613578dab6b49a3424aa2a711f469f65ab95d7ce92e5dff6385ad3c4f5559d3a

--- a/entities/ve/vectara.yaml
+++ b/entities/ve/vectara.yaml
@@ -1,0 +1,59 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rfrt6a0c33twvqykyr1p
+  slug: vectara
+  slug_aliases: []
+  name: Vectara
+  domains:
+    - value: vectara.com
+      role: primary
+      valid_from: 2026-09-06T19:43:17Z
+  category: ai-ml
+profile:
+  description: Vectara provides a neural search platform and APIs for building semantic search and retrieval-augmented generation applications.
+  links:
+    site: https://vectara.com
+sources:
+  - source_id: src_2047721b416eeaec0a7a01ff6868e883d4832be76aa92c1fc2d76dae5c88a689
+    url: https://www.vectara.com/startups
+offers:
+  - offer_id: off_01m1w3rfshbpy4c5azk3kxghdm
+    offer_slug: vectara-startup-partnerships
+    offer_slug_aliases: []
+    title: Vectara Startup Partnerships
+    summary: Vectara offers startups credits, discounts, tailored onboarding and support, plus co-marketing and go-to-market alignment through its Startup Partnerships program.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T19:43:17Z
+    economics:
+      consideration:
+        kind: other
+        description: Startup credits, discounts, and tailored onboarding.
+    benefits:
+      - benefit_id: ben_primary
+        description: Startup credits
+        kind: credits
+      - benefit_id: ben_02
+        description: Discounts on Vectara usage
+        kind: discount
+      - benefit_id: ben_03
+        description: Tailored onboarding and support
+        kind: other
+      - benefit_id: ben_04
+        description: Co-marketing and go-to-market alignment
+        kind: other
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Must be an eligible startup; specific criteria are published on the vendor startup partnerships page.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m1w3rfrt6a0c33twvqykyr1p
+      access_operator_entity_id: ent_01m1w3rfrt6a0c33twvqykyr1p
+    access:
+      availability: public
+      method: form
+      url: https://www.vectara.com/startups
+    source_ids:
+      - src_2047721b416eeaec0a7a01ff6868e883d4832be76aa92c1fc2d76dae5c88a689

--- a/entities/wa/warestack.yaml
+++ b/entities/wa/warestack.yaml
@@ -1,0 +1,93 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w43588h8ah31m13ggqamrx
+  slug: warestack
+  slug_aliases: []
+  name: Warestack
+  domains:
+  - value: warestack.com
+    role: primary
+    valid_from: '2026-09-06T19:46:41.281Z'
+  category: hosting-infra
+profile:
+  description: Warestack provides managed cloud platform services for deploying applications, databases, and caches with built-in scaling and monitoring.
+  links:
+    site: https://www.warestack.com
+sources:
+- source_id: src_1727fb8fc538afda407014b419930c493060d4ef71670d27090610f2f7293ef8
+  url: https://www.warestack.com/startup-program
+programs:
+- program_id: prg_01m1w4358e1bd4eacrg4x48g0x
+  program_slug: warestack-startup-program
+  program_slug_aliases: []
+  title: Warestack Startup Program
+  summary: Warestack gives qualifying early-stage companies the Starter plan free for six months, with published usage limits and up to $2,000 in savings.
+  source_ids:
+  - src_1727fb8fc538afda407014b419930c493060d4ef71670d27090610f2f7293ef8
+offers:
+- offer_id: off_01m1w4358ex3fr76dqzrbzk9fc
+  program_id: prg_01m1w4358e1bd4eacrg4x48g0x
+  offer_slug: starter-plan-free-for-six-months
+  offer_slug_aliases: []
+  title: Starter Plan Free for Six Months
+  summary: Qualifying startups receive the Warestack Starter plan free for six months, with published usage limits and up to $2,000 in savings versus standard rates.
+  lifecycle:
+    status: active
+    effective_from: '2026-09-06T19:46:41.281Z'
+  economics:
+    benefits:
+    - benefit_id: ben_starter_six_months
+      description: Starter plan free for six months, with published usage limits and up to $2,000 in savings versus standard rates.
+      kind: credit
+      value:
+        amount:
+          currency: USD
+          minor_units: 200000
+        kind: up-to
+    consideration:
+      kind: none
+  eligibility:
+    rule:
+      kind: all
+      rules:
+      - criterion_id: cri_age
+        fact: company.age_months
+        kind: predicate
+        operator: lte
+        value:
+          type: number
+          value: 60
+        statement: Company is under five years old.
+      - criterion_id: cri_funding
+        fact: company.funding_raised_usd
+        kind: predicate
+        operator: lte
+        value:
+          type: number
+          value: 2000000
+        statement: Company has raised under $2 million in funding or revenue.
+      - criterion_id: cri_employees
+        fact: company.employee_count
+        kind: predicate
+        operator: lt
+        value:
+          type: number
+          value: 50
+        statement: Company has fewer than 50 employees.
+      - criterion_id: cri_not_customer
+        fact: company.is_current_customer
+        kind: predicate
+        operator: eq
+        value:
+          type: boolean
+          value: false
+        statement: Not a current paying Warestack customer.
+  roles:
+    terms_authority_entity_id: ent_01m1w43588h8ah31m13ggqamrx
+    access_operator_entity_id: ent_01m1w43588h8ah31m13ggqamrx
+  access:
+    availability: public
+    method: form
+    url: https://www.warestack.com/startup-program
+  source_ids:
+  - src_1727fb8fc538afda407014b419930c493060d4ef71670d27090610f2f7293ef8

--- a/entities/we/wevestr.yaml
+++ b/entities/we/wevestr.yaml
@@ -1,0 +1,50 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rwj6fyv2hea10ha1wsv4
+  slug: wevestr
+  slug_aliases: []
+  name: WE.VESTR
+  domains:
+    - value: wevestr.com
+      role: primary
+      valid_from: 2026-09-06T19:49:38Z
+  category: finance-accounting
+profile:
+  description: WE.VESTR provides equity management and cap table tools for startups and growth companies.
+  links:
+    site: https://wevestr.com
+sources:
+  - source_id: src_01704c2d908c655015a9c7a11c5041cda459057d0a8246f0afaf64196e840b50
+    url: https://wevestr.com/microsoft-for-startups
+offers:
+  - offer_id: off_01m1w3rwjkrq56yr1b6g4b755s
+    offer_slug: wevestr-microsoft-for-startups-discount
+    offer_slug_aliases: []
+    title: WE.VESTR Microsoft for Startups Discount
+    summary: Microsoft for Startups members can receive a first-year discount on WE.VESTR equity-management plans. Microsoft's benefit documentation specifies 70% off for eligible new customers with 30 or more stakeholders, valid for 12 months, with access gated through the Microsoft for Startups Benefits page.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T19:49:38Z
+    economics:
+      consideration:
+        kind: discount
+        description: 70% off for the first year for eligible new customers with 30 or more stakeholders.
+    benefits:
+      - benefit_id: ben_primary
+        description: 70% off WE.VESTR equity-management plans for 12 months
+        kind: discount
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Must be a Microsoft for Startups member and a new WE.VESTR customer with 30 or more stakeholders.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m1w3rwj6fyv2hea10ha1wsv4
+      access_operator_entity_id: ent_01kyh8fpe3n3yye39kmzvy410z
+    access:
+      availability: restricted
+      method: form
+      url: https://learn.microsoft.com/en-us/startups/benefits/technical-benefits/third-party-benefits/we-vestr
+    source_ids:
+      - src_01704c2d908c655015a9c7a11c5041cda459057d0a8246f0afaf64196e840b50

--- a/entities/ze/zenphi.yaml
+++ b/entities/ze/zenphi.yaml
@@ -1,0 +1,53 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rvnemsxp8qhhn0mszxyz
+  slug: zenphi
+  slug_aliases: []
+  name: Zenphi
+  domains:
+    - value: zenphi.com
+      role: primary
+      valid_from: 2026-09-06T19:48:40Z
+  category: productivity
+profile:
+  description: Zenphi provides robotic process automation and workflow automation tools for businesses on Google Workspace.
+  links:
+    site: https://zenphi.com
+sources:
+  - source_id: src_507dd7fabec36c8843715355ef09c651ac9986d7a011070ac96f1b5f738de1ca
+    url: https://zenphi.com/zenphi-for-startups/
+offers:
+  - offer_id: off_01m1w3rvnyqq1dqe6bm7ncks13
+    offer_slug: zenphi-startup-program
+    offer_slug_aliases: []
+    title: Zenphi for Startups
+    summary: Eligible startups receive six months free on the Zenphi Pro plan, followed by six months at 50% off.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T19:48:40Z
+    economics:
+      consideration:
+        kind: discount
+        description: Six months free on Pro plan, followed by six months at 50% off.
+    benefits:
+      - benefit_id: ben_primary
+        description: Six months free on Zenphi Pro plan
+        kind: free-period
+      - benefit_id: ben_02
+        description: Six months at 50% off
+        kind: discount
+    eligibility:
+      rule:
+        kind: manual
+        criterion_id: cri_requirement_01
+        statement: Must be an eligible startup; specific criteria are published on the vendor startup page.
+        reason: not-machine-evaluable
+    roles:
+      terms_authority_entity_id: ent_01m1w3rvnemsxp8qhhn0mszxyz
+      access_operator_entity_id: ent_01m1w3rvnemsxp8qhhn0mszxyz
+    access:
+      availability: public
+      method: form
+      url: https://zenphi.com/zenphi-for-startups/
+    source_ids:
+      - src_507dd7fabec36c8843715355ef09c651ac9986d7a011070ac96f1b5f738de1ca


### PR DESCRIPTION
## Summary

### Stripe Atlas
- Add new source `https://stripe.com/atlas`
- Add new program `stripe-atlas`
- Add new offer `stripe-atlas-incorporation` for $500 US company incorporation with $2,500 in credits

### Datadog enrichment
- Change `consideration.kind` from `unknown` to `free`
- Expand `ben_primary` to describe full platform access with GA products
- Add `ben_onboarding` for TEM support
- Clarify eligibility with referral partner categories

## Sources

- https://stripe.com/atlas
- https://www.datadoghq.com/partner/datadog-for-startups/

---

Signed-off-by: pilars <pilars@users.noreply.github.com>