### PR TITLE
data: add TwentyThree Startup Program

### DIFF
--- a/entities/tw/twentythree.yaml
+++ b/entities/tw/twentythree.yaml
@@ -46,6 +46,8 @@ offers:
               currency: EUR
               minor_units: 1000000
             kind: exact
+      consideration:
+        kind: none
     eligibility:
       rule:
         criterion_id: cri_01

--- a/entities/tw/twentythree.yaml
+++ b/entities/tw/twentythree.yaml
@@ -1,0 +1,84 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w607s83r4jjk913t1q0756
+  slug: twentythree
+  slug_aliases:
+    - twenty-three
+  name: TwentyThree
+  domains:
+    - value: twentythree.com
+      role: primary
+      valid_from: 2026-09-06T20:20:00.000Z
+  category: marketing
+profile:
+  description: TwentyThree is a European video marketing platform for webinars, video libraries, branding, and product storytelling.
+  links:
+    site: https://www.twentythree.com
+sources:
+  - source_id: src_e616d9d7466a8c34a294e998f4031ecdeaadef94e82e28ac1491c5462fdb98da
+    url: https://video.twentythree.com/twentythree-summit-keynote-2026
+programs:
+  - program_id: prg_01m1w607s8cm4srxvrdh2ma9z8
+    program_slug: twentythree-startup-program
+    program_slug_aliases: []
+    title: TwentyThree Startup Program
+    summary: TwentyThree Startup Program gives eligible European startups less than three years old 10,000 Euro in platform credits, granted through venture-capital or agency partners.
+    source_ids:
+      - src_e616d9d7466a8c34a294e998f4031ecdeaadef94e82e28ac1491c5462fdb98da
+offers:
+  - offer_id: off_01m1w607s88g5rgsc4cmpdde66
+    program_id: prg_01m1w607s8cm4srxvrdh2ma9z8
+    offer_slug: 10000-euro-credits
+    offer_slug_aliases: []
+    title: 10,000 Euro in TwentyThree credits
+    summary: Eligible European startups less than three years old receive 10,000 Euro in TwentyThree credits, granted through a venture capitalist or TwentyThree agency partner.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T20:20:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: 10,000 Euro in TwentyThree platform credits for video marketing, webinars, and related product marketing use
+          kind: credit
+          value:
+            amount:
+              currency: EUR
+              minor_units: 1000000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: not-machine-evaluable
+            statement: The company is a European startup that is just getting going.
+          - criterion_id: cri_02
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: The company is less than three years old.
+            value:
+              type: number
+              value: 36
+          - criterion_id: cri_03
+            kind: manual
+            reason: not-machine-evaluable
+            statement: The company is bootstrapped or venture-funded and receives the credits through a venture capitalist or TwentyThree agency partner that can grant them.
+          - criterion_id: cri_04
+            kind: manual
+            reason: vendor-discretion
+            statement: Credits are granted through TwentyThree's venture-capital or agency partners; acceptance and grant mechanics are subject to TwentyThree and partner processes.
+    roles:
+      terms_authority_entity_id: ent_01m1w607s83r4jjk913t1q0756
+      access_operator_entity_id: ent_01m1w607s83r4jjk913t1q0756
+    access:
+      availability: partners
+      method: other
+      instructions: Request TwentyThree Startup Program credits through a participating venture capitalist or TwentyThree agency partner that can grant the 10,000 Euro credit package to an eligible European startup less than three years old. Program details were announced in the first-party TwentyThree Summit 2026 keynote.
+      url: https://video.twentythree.com/twentythree-summit-keynote-2026
+    terms_url: https://video.twentythree.com/twentythree-summit-keynote-2026
+    source_ids:
+      - src_e616d9d7466a8c34a294e998f4031ecdeaadef94e82e28ac1491c5462fdb98da

--- a/entities/tw/twentythree.yaml
+++ b/entities/tw/twentythree.yaml
@@ -75,7 +75,7 @@ offers:
       terms_authority_entity_id: ent_01m1w607s83r4jjk913t1q0756
       access_operator_entity_id: ent_01m1w607s83r4jjk913t1q0756
     access:
-      availability: partners
+      availability: other
       method: other
       instructions: Request TwentyThree Startup Program credits through a participating venture capitalist or TwentyThree agency partner that can grant the 10,000 Euro credit package to an eligible European startup less than three years old. Program details were announced in the first-party TwentyThree Summit 2026 keynote.
       url: https://video.twentythree.com/twentythree-summit-keynote-2026

--- a/entities/tw/twentythree.yaml
+++ b/entities/tw/twentythree.yaml
@@ -11,6 +11,7 @@ entity:
       valid_from: 2026-09-06T20:20:00.000Z
   category: marketing
 profile:
+  summary: European video marketing platform for webinars, video libraries, and product storytelling.
   description: TwentyThree is a European video marketing platform for webinars, video libraries, branding, and product storytelling.
   links:
     site: https://www.twentythree.com
@@ -38,7 +39,7 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: 10,000 Euro in TwentyThree platform credits for video marketing, webinars, and related product marketing use
+          description: 10,000 Euro in credits
           kind: credit
           value:
             amount:
@@ -54,23 +55,15 @@ offers:
           - criterion_id: cri_01
             kind: manual
             reason: not-machine-evaluable
-            statement: The company is a European startup that is just getting going.
+            statement: The company is a European startup that is just about getting going.
           - criterion_id: cri_02
-            fact: company.age_months
-            kind: predicate
-            operator: lt
+            kind: manual
+            reason: not-machine-evaluable
             statement: The company is less than three years old.
-            value:
-              type: number
-              value: 36
           - criterion_id: cri_03
             kind: manual
             reason: not-machine-evaluable
-            statement: The company is bootstrapped or venture-funded and receives the credits through a venture capitalist or TwentyThree agency partner that can grant them.
-          - criterion_id: cri_04
-            kind: manual
-            reason: vendor-discretion
-            statement: Credits are granted through TwentyThree's venture-capital or agency partners; acceptance and grant mechanics are subject to TwentyThree and partner processes.
+            statement: The company is a bootstrap company or venture-funded company and receives the credits through a venture capitalist or TwentyThree agency partners that can grant the credits.
     roles:
       terms_authority_entity_id: ent_01m1w607s83r4jjk913t1q0756
       access_operator_entity_id: ent_01m1w607s83r4jjk913t1q0756

--- a/entities/tw/twentythree.yaml
+++ b/entities/tw/twentythree.yaml
@@ -46,24 +46,12 @@ offers:
               currency: EUR
               minor_units: 1000000
             kind: exact
-      consideration:
-        kind: none
     eligibility:
       rule:
-        kind: all
-        rules:
-          - criterion_id: cri_01
-            kind: manual
-            reason: not-machine-evaluable
-            statement: The company is a European startup that is just about getting going.
-          - criterion_id: cri_02
-            kind: manual
-            reason: not-machine-evaluable
-            statement: The company is less than three years old.
-          - criterion_id: cri_03
-            kind: manual
-            reason: not-machine-evaluable
-            statement: The company is a bootstrap company or venture-funded company and receives the credits through a venture capitalist or TwentyThree agency partners that can grant the credits.
+        criterion_id: cri_01
+        kind: manual
+        reason: not-machine-evaluable
+        statement: The company is a European bootstrap or venture-funded startup less than three years old that is just about getting going, and receives the credits through a venture capitalist or TwentyThree agency partners that can grant the credits.
     roles:
       terms_authority_entity_id: ent_01m1w607s83r4jjk913t1q0756
       access_operator_entity_id: ent_01m1w607s83r4jjk913t1q0756


### PR DESCRIPTION
## Summary
- Adds `entities/tw/twentythree.yaml` for the TwentyThree Startup Program (Missing issue #1270).
- First-party source: TwentyThree Summit 2026 keynote transcript page https://video.twentythree.com/twentythree-summit-keynote-2026 (HTTP 200). Published offer: **10,000 Euro in credits** for European startups less than three years old, granted through a venture capitalist or agency partner.
- No duplicate entity/PR for TwentyThree on main or open PRs at open time. Pylon and other Sep-6 Missing issues skipped (already covered by open PRs including #1440).

Closes #1270

## Test plan
- [ ] `validate catalog change` / `sourcey/validation` CI green
- [ ] DCO Signed-off-by present
- [ ] Reviewer confirms EUR 10,000 credit amount and partner-grant access match the keynote transcript