### PR TITLE
data: add Tapflare Startup Program

### DIFF
--- a/entities/ta/tapflare.yaml
+++ b/entities/ta/tapflare.yaml
@@ -1,0 +1,84 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1wfte5xag8680nevjd1t5yp
+  slug: tapflare
+  slug_aliases: []
+  name: Tapflare
+  domains:
+    - value: tapflare.com
+      role: primary
+      valid_from: 2026-09-06T23:10:00.000Z
+  category: design
+profile:
+  summary: Tapflare provides subscription graphic design and website development with a dedicated project manager and senior specialists.
+  description: Tapflare provides subscription graphic design and website development with a dedicated project manager and senior specialists.
+  links:
+    site: https://tapflare.com
+sources:
+  - source_id: src_075d94557dc77bbb1775845b30770b13c1ea1356dc23a8c2f74d73e8bb4fe6a1
+    url: https://tapflare.com/startups
+programs:
+  - program_id: prg_01m1wfte62m1p178e0b9exz70d
+    program_slug: tapflare-startup-program
+    program_slug_aliases: []
+    title: Tapflare Startup Program
+    summary: Qualified startups can receive up to $1,500 in Tapflare credits toward any plan, covering about 1–3 months of graphic design and website development.
+    source_ids:
+      - src_075d94557dc77bbb1775845b30770b13c1ea1356dc23a8c2f74d73e8bb4fe6a1
+offers:
+  - offer_id: off_01m1wfte62qsd1cwjczs470rme
+    program_id: prg_01m1wfte62m1p178e0b9exz70d
+    offer_slug: up-to-1500-design-credits
+    offer_slug_aliases: []
+    title: Up to $1,500 in design and website development credit
+    summary: Eligible startups receive up to $1,500 in Tapflare credits applied to any Tapflare plan, typically covering 1–3 months of senior graphic design and website development.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T23:10:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to $1,500 in Tapflare credits toward any Tapflare plan for graphic design and website development
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 150000
+            kind: up-to
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: vendor-discretion
+            statement: Building a software-based product or service.
+          - criterion_id: cri_02
+            fact: company.age_months
+            kind: predicate
+            operator: lte
+            statement: Founded within the last 5 years.
+            value:
+              type: number
+              value: 60
+          - criterion_id: cri_03
+            kind: manual
+            reason: vendor-discretion
+            statement: Funded from $50k up to $5M.
+          - criterion_id: cri_04
+            kind: manual
+            reason: vendor-discretion
+            statement: Founder has a LinkedIn profile and the company has a valid website and email address.
+    roles:
+      terms_authority_entity_id: ent_01m1wfte5xag8680nevjd1t5yp
+      access_operator_entity_id: ent_01m1wfte5xag8680nevjd1t5yp
+    access:
+      availability: public
+      method: form
+      instructions: Complete the form on the Tapflare startups page to apply for the startup program.
+      url: https://tapflare.com/startups
+    terms_url: https://tapflare.com/startups
+    source_ids:
+      - src_075d94557dc77bbb1775845b30770b13c1ea1356dc23a8c2f74d73e8bb4fe6a1


### PR DESCRIPTION
## Summary
- Adds `entities/ta/tapflare.yaml` for Missing issue #1036.
- First-party https://tapflare.com/startups publishes **up to $1,500** in Tapflare credits toward any plan for qualified startups (software-based product/service, founded within 5 years, funded $50k–$5M, LinkedIn + valid website/email), via public application form.

## Test plan
- [ ] CI `validate catalog change` / `sourcey/validation` green
- [ ] Admission can locate $1,500 credit and eligibility copy on https://tapflare.com/startups

Closes #1036