### PR TITLE
data: add NeuroAPI for Startups

### DIFF
--- a/entities/ne/neuroapi.yaml
+++ b/entities/ne/neuroapi.yaml
@@ -1,0 +1,92 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1wp9hgdea883dtrt999rb5z
+  slug: neuroapi
+  slug_aliases: []
+  name: NeuroAPI
+  domains:
+    - value: neuroapi.me
+      role: primary
+      valid_from: 2026-09-07T01:00:00.000Z
+  category: data-analytics
+profile:
+  summary: NeuroAPI provides a web data API for scrape, search, crawl, map, and extract, with a native MCP server.
+  description: NeuroAPI provides a web data API for scrape, search, crawl, map, extract, and screenshots, with a native MCP server for AI agents.
+  links:
+    site: https://neuroapi.me
+sources:
+  - source_id: src_2a33d9a39e73c668cc68ee2f59e5641ebc8ea58519b5d4ef48cdaddbaae9cd26
+    url: https://neuroapi.me/startup-credits
+programs:
+  - program_id: prg_01m1wp9hh5bjbgy3abemf60snp
+    program_slug: neuroapi-for-startups
+    program_slug_aliases: []
+    title: NeuroAPI for Startups
+    summary: NeuroAPI for Startups grants eligible early-stage product, agent, or research-tool teams 5,000 to 100,000 free credits with no card or contract.
+    source_ids:
+      - src_2a33d9a39e73c668cc68ee2f59e5641ebc8ea58519b5d4ef48cdaddbaae9cd26
+offers:
+  - offer_id: off_01m1wp9hh6c6dx3xqggskkh80g
+    program_id: prg_01m1wp9hh5bjbgy3abemf60snp
+    offer_slug: up-to-100000-neuroapi-credits
+    offer_slug_aliases: []
+    title: Up to 100,000 NeuroAPI credits
+    summary: Approved startups receive a vendor-determined grant of 5,000 to 100,000 NeuroAPI credits usable across all endpoints, with no card or contract required.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-07T01:00:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to 100,000 NeuroAPI credits (grants range from 5,000 to 100,000 credits)
+          kind: other
+        - benefit_id: ben_02
+          description: All endpoints unlocked, including scrape, search, crawl, map, extract, screenshots, and MCP
+          kind: free-service
+          service: NeuroAPI endpoints and MCP access
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.age_months
+            kind: predicate
+            operator: lte
+            statement: Founded within the last 2 years.
+            value:
+              type: number
+              value: 24
+          - criterion_id: cri_02
+            fact: company.website_url
+            kind: predicate
+            operator: present
+            statement: Have a live, public-facing website.
+          - criterion_id: cri_03
+            kind: manual
+            reason: not-machine-evaluable
+            statement: Building a product, agent or research tool — not an agency.
+          - criterion_id: cri_04
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lte
+            statement: Not previously funded with more than $5M (soft cap).
+            value:
+              type: number
+              value: 5000000
+          - criterion_id: cri_05
+            kind: manual
+            reason: vendor-discretion
+            statement: Credit grant size is decided by NeuroAPI based on stage, scale, use-case fit, traction, and projected volume.
+    roles:
+      terms_authority_entity_id: ent_01m1wp9hgdea883dtrt999rb5z
+      access_operator_entity_id: ent_01m1wp9hgdea883dtrt999rb5z
+    access:
+      availability: public
+      method: form
+      instructions: Create a free NeuroAPI account, sign in, and complete the startup credit application. Applications are reviewed within 3 business days.
+      url: https://neuroapi.me/startup-credits
+    terms_url: https://neuroapi.me/startup-credits
+    source_ids:
+      - src_2a33d9a39e73c668cc68ee2f59e5641ebc8ea58519b5d4ef48cdaddbaae9cd26

--- a/entities/ne/neuroapi.yaml
+++ b/entities/ne/neuroapi.yaml
@@ -85,7 +85,6 @@ offers:
     access:
       availability: public
       method: form
-      instructions: Create your free account first, sign in to apply, and complete the 2-minute application. Reviewed in 3 days.
       url: https://neuroapi.me/startup-credits
     source_ids:
       - src_2a33d9a39e73c668cc68ee2f59e5641ebc8ea58519b5d4ef48cdaddbaae9cd26

--- a/entities/ne/neuroapi.yaml
+++ b/entities/ne/neuroapi.yaml
@@ -10,8 +10,8 @@ entity:
       valid_from: 2026-09-07T01:00:00.000Z
   category: data-analytics
 profile:
-  summary: NeuroAPI provides a web data API for scrape, search, crawl, map, and extract, with a native MCP server.
-  description: NeuroAPI provides a web data API for scrape, search, crawl, map, extract, and screenshots, with a native MCP server for AI agents.
+  summary: NeuroAPI is the web data API behind AI agents — one endpoint for scrape, search, crawl, map and extract, with a native MCP server.
+  description: NeuroAPI is a web data API for scrape, search, crawl, map and extract for AI agents and products, with a native MCP server included.
   links:
     site: https://neuroapi.me
 sources:
@@ -38,12 +38,12 @@ offers:
     economics:
       benefits:
         - benefit_id: ben_01
-          description: Up to 100,000 NeuroAPI credits (grants range from 5,000 to 100,000 credits)
+          description: Up to 100,000 credits
           kind: other
         - benefit_id: ben_02
-          description: All endpoints unlocked, including scrape, search, crawl, map, extract, screenshots, and MCP
+          description: All endpoints unlocked
           kind: free-service
-          service: NeuroAPI endpoints and MCP access
+          service: Scrape, search, crawl, map, extract, screenshots and MCP
       consideration:
         kind: none
     eligibility:
@@ -54,7 +54,7 @@ offers:
             fact: company.age_months
             kind: predicate
             operator: lte
-            statement: Founded within the last 2 years.
+            statement: Founded within the last 2 years
             value:
               type: number
               value: 24
@@ -85,8 +85,7 @@ offers:
     access:
       availability: public
       method: form
-      instructions: Create a free NeuroAPI account, sign in, and complete the startup credit application. Applications are reviewed within 3 business days.
+      instructions: Create your free account first, sign in to apply, and complete the 2-minute application. Reviewed in 3 days.
       url: https://neuroapi.me/startup-credits
-    terms_url: https://neuroapi.me/startup-credits
     source_ids:
       - src_2a33d9a39e73c668cc68ee2f59e5641ebc8ea58519b5d4ef48cdaddbaae9cd26


### PR DESCRIPTION
## Summary

Closes #649

Adds NeuroAPI (`entities/ne/neuroapi.yaml`) for the public **NeuroAPI for Startups** program.

### First-party evidence

https://neuroapi.me/startup-credits

### Economics (on-page)

- **Up to 100,000 credits** for startups (vendor grants range **5,000 to 100,000 credits** — usage credits, not USD).
- All endpoints unlocked (scrape, search, crawl, map, extract, screenshots, MCP).
- **No card required**; grant is fully free with no card or contract.
- Application reviewed within 3 business days.

### Eligibility (on-page)

- Founded within the last 2 years
- Live, public-facing website
- Building a product, agent or research tool — not an agency
- Not previously funded with > \$5M (soft cap)

Prior closed PR #650 used the old vendor-authoring schema path; this is a fresh entity-authoring/v1alpha1 record with new IDs. No competing open PR; entity absent from main.

## Test plan

- [ ] `sourcey/validation` passes on changed entity closure
- [ ] Admission reviews cited first-party URL economics/eligibility