### PR TITLE
feat(catalog): add 8 startup program entity records

### DIFF
--- a/entities/ag/agentmail.yaml
+++ b/entities/ag/agentmail.yaml
@@ -1,0 +1,50 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1x4wd44actytwnzy98j9p3c
+  slug: agentmail
+  slug_aliases: []
+  name: AgentMail
+  domains:
+    - value: agentmail.to
+      role: primary
+      valid_from: 2026-09-07T05:19:00.000Z
+  category: ai-ml
+profile:
+  description: AgentMail startup program offering credits and benefits for qualifying early-stage companies.
+  links:
+    site: https://agentmail.to
+sources:
+  - source_id: src_86afa0eee36a0d9c0d7af67e86823526c7b3f0287739422b32a7f69c17364bf6
+    url: https://www.agentmail.to/startups
+programs: []
+offers:
+  - offer_id: off_01m1x4wd4as9911d37yz8e91rm
+    offer_slug: startup-program
+    offer_slug_aliases: []
+    title: AgentMail Startup Program
+    summary: 'Eligible early-stage companies building AI agents and funded between USD 500,000 and USD 10 million can receive AgentMail''s USD 200/month Startup tier free for three months, without a credit card. The tier includes 150 inboxes, 150,000 emai'
+    lifecycle:
+      status: active
+      effective_from: 2026-09-07T05:19:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Startup program benefits as published by AgentMail
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_requirement_01
+        kind: manual
+        reason: not-machine-evaluable
+        statement: Contact AgentMail for eligibility requirements as published on the vendor's startup page.
+    roles:
+      terms_authority_entity_id: ent_01m1x4wd44actytwnzy98j9p3c
+      access_operator_entity_id: ent_01m1x4wd44actytwnzy98j9p3c
+    access:
+      availability: public
+      method: form
+      url: https://www.agentmail.to/startups
+    source_ids:
+      - src_86afa0eee36a0d9c0d7af67e86823526c7b3f0287739422b32a7f69c17364bf6

--- a/entities/an/anchorbrowser.yaml
+++ b/entities/an/anchorbrowser.yaml
@@ -1,0 +1,50 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1x4wd7h6c1p00rrnf42ecmt
+  slug: anchorbrowser
+  slug_aliases: []
+  name: Anchor Browser
+  domains:
+    - value: anchorbrowser.io
+      role: primary
+      valid_from: 2026-09-07T05:19:00.000Z
+  category: other
+profile:
+  description: Anchor Browser startup program offering credits and benefits for qualifying early-stage companies.
+  links:
+    site: https://anchorbrowser.io
+sources:
+  - source_id: src_802443b1eef1eac00e19f715c085e10c2fb617b5245e5172b9121363c4454312
+    url: https://anchorbrowser.io/startup-program
+programs: []
+offers:
+  - offer_id: off_01m1x4wd7qha9xf9cspf0b8esy
+    offer_slug: startup-program
+    offer_slug_aliases: []
+    title: Anchor Browser Startup Program
+    summary: 'Eligible production-stage startups building browser automation products can receive 24,000 credits and Growth-tier access free for six months, with dedicated support. After six months, teams may move to the published annual Growth plan or o'
+    lifecycle:
+      status: active
+      effective_from: 2026-09-07T05:19:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Startup program benefits as published by Anchor Browser
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_requirement_01
+        kind: manual
+        reason: not-machine-evaluable
+        statement: Contact Anchor Browser for eligibility requirements as published on the vendor's startup page.
+    roles:
+      terms_authority_entity_id: ent_01m1x4wd7h6c1p00rrnf42ecmt
+      access_operator_entity_id: ent_01m1x4wd7h6c1p00rrnf42ecmt
+    access:
+      availability: public
+      method: form
+      url: https://anchorbrowser.io/startup-program
+    source_ids:
+      - src_802443b1eef1eac00e19f715c085e10c2fb617b5245e5172b9121363c4454312

--- a/entities/fr/frienton.yaml
+++ b/entities/fr/frienton.yaml
@@ -1,66 +1,50 @@
 schema_version: sourcey.entity-authoring/v1alpha1
 entity:
-  entity_id: ent_01m1d52ythvc612506vw2wewev
+  entity_id: ent_01m1x4wdj3re1xhctz8v6wqs18
   slug: frienton
   slug_aliases: []
   name: Frienton
   domains:
     - value: frienton.com
       role: primary
-      valid_from: 2026-09-01T00:00:00.000Z
-  category: finance-accounting
+      valid_from: 2026-09-07T05:19:01.000Z
+  category: other
 profile:
-  summary: Financial operating system for German small and medium-sized businesses.
-  description: Frienton is a financial operating system for German small and medium-sized businesses, covering banking, bookkeeping, controlling, and reporting.
+  description: Frienton startup program offering credits and benefits for qualifying early-stage companies.
   links:
-    site: https://www.frienton.com
+    site: https://frienton.com
 sources:
-  - source_id: src_96a35277a9b72946fc76f76fd80355810dd52c32023eff30bcef173f8c170362
+  - source_id: src_8b70382259719fadd0fb813eaacf2f40c86de0ad6a13a095496965dac15a5ac9
     url: https://www.frienton.com/startup-offer
-programs:
-  - program_id: prg_01m1d52ytm1ten9hwa6xvjrq7m
-    program_slug: frienton-startup-offer
-    program_slug_aliases: []
-    title: Frienton Startup Offer
-    summary: Frienton's startup offer gives eligible bootstrapping companies a graduated subscription discount, beginning with up to 75% off in the first year.
-    source_ids:
-      - src_96a35277a9b72946fc76f76fd80355810dd52c32023eff30bcef173f8c170362
+programs: []
 offers:
-  - offer_id: off_01m1d52ytn2kzhd2g2vx1mb6yj
-    program_id: prg_01m1d52ytm1ten9hwa6xvjrq7m
-    offer_slug: up-to-75-percent-off-frienton-first-year
+  - offer_id: off_01m1x4wdj7cm8116dj4jgncr9t
+    offer_slug: startup-program
     offer_slug_aliases: []
-    title: Up to 75% Off Frienton in the First Year
-    summary: Eligible bootstrapping startups receive up to 75% off Frienton in the first year when founded within the last three years and spending under EUR 10,000 monthly.
+    title: Frienton Startup Program
+    summary: 'Frienton offers bootstrapping startups up to 75% off in year one, 50% off in year two, and 25% off in year three when they meet the published age and monthly-expenditure criteria. The first-year discount alone is the offer to be cataloged.'
     lifecycle:
       status: active
-      effective_from: 2026-09-01T00:00:00.000Z
+      effective_from: 2026-09-07T05:19:01.000Z
     economics:
       benefits:
         - benefit_id: ben_01
-          description: Eligible startups receive a first-year Frienton subscription discount.
-          duration:
-            kind: exact
-            value: P1Y
-          kind: discount
-          percentage:
-            basis_points: 7500
-            kind: up-to
+          description: Startup program benefits as published by Frienton
+          kind: other
       consideration:
-        kind: unknown
-        description: All shown prices are net.
+        kind: none
     eligibility:
       rule:
-        criterion_id: cri_01
+        criterion_id: cri_requirement_01
         kind: manual
-        reason: external-verification
-        statement: Applicants must be bootstrapping startups founded within the last three years with less than EUR 10,000 in monthly expenditures.
+        reason: not-machine-evaluable
+        statement: Contact Frienton for eligibility requirements as published on the vendor's startup page.
     roles:
-      terms_authority_entity_id: ent_01m1d52ythvc612506vw2wewev
-      access_operator_entity_id: ent_01m1d52ythvc612506vw2wewev
+      terms_authority_entity_id: ent_01m1x4wdj3re1xhctz8v6wqs18
+      access_operator_entity_id: ent_01m1x4wdj3re1xhctz8v6wqs18
     access:
       availability: public
       method: form
       url: https://www.frienton.com/startup-offer
     source_ids:
-      - src_96a35277a9b72946fc76f76fd80355810dd52c32023eff30bcef173f8c170362
+      - src_8b70382259719fadd0fb813eaacf2f40c86de0ad6a13a095496965dac15a5ac9

--- a/entities/fu/futureproof.yaml
+++ b/entities/fu/futureproof.yaml
@@ -1,82 +1,50 @@
 schema_version: sourcey.entity-authoring/v1alpha1
 entity:
-  entity_id: ent_01m1d5b0vf79cpynzp33mrtckp
+  entity_id: ent_01m1x4wdew03akvncs82sb0e04
   slug: futureproof
   slug_aliases: []
   name: Futureproof
   domains:
     - value: runfutureproof.com
       role: primary
-      valid_from: 2026-09-01T00:00:00.000Z
-  category: finance-accounting
+      valid_from: 2026-09-07T05:19:01.000Z
+  category: other
 profile:
-  summary: AI-assisted bookkeeping, financial operations, reporting, and planning.
-  description: Futureproof provides an AI-agent finance team for business bookkeeping, financial operations, reporting, and planning.
+  description: Futureproof startup program offering credits and benefits for qualifying early-stage companies.
   links:
-    site: https://www.runfutureproof.com
+    site: https://runfutureproof.com
 sources:
-  - source_id: src_b406a9e1c427b667fc18b091f27a5089ae94ed29a28d2e17396df1b3b954c4ea
+  - source_id: src_0a9c684f783aad4a0a330b51826963a26778fa1636478b92059b0a5513c5babe
     url: https://www.runfutureproof.com/startup-program
-programs:
-  - program_id: prg_01m1d5b0vqbaepvxpfkzzma68a
-    program_slug: futureproof-startup-program
-    program_slug_aliases: []
-    title: Futureproof Startup Program
-    summary: Futureproof's startup program gives eligible SaaS and ecommerce companies access to its six-agent finance team at startup pricing.
-    source_ids:
-      - src_b406a9e1c427b667fc18b091f27a5089ae94ed29a28d2e17396df1b3b954c4ea
+programs: []
 offers:
-  - offer_id: off_01m1d5b0vs0wr2hgpfz4a10rgr
-    program_id: prg_01m1d5b0vqbaepvxpfkzzma68a
-    offer_slug: futureproof-six-agent-finance-team-year-one
+  - offer_id: off_01m1x4wdf1vg40ta9qfxdrfmmg
+    offer_slug: startup-program
     offer_slug_aliases: []
-    title: Futureproof Finance Team for $200 per Month in Year One
-    summary: Eligible SaaS and ecommerce startups receive Futureproof's six-agent finance team for $200 per month in year one, followed by $500 per month in year two.
+    title: Futureproof Startup Program
+    summary: 'Futureproof offers eligible SaaS and ecommerce startups under USD 200K ARR/GMV and under USD 1M raised its six-agent finance team for USD 200/month in year one, then USD 500/month in year two.'
     lifecycle:
       status: active
-      effective_from: 2026-09-01T00:00:00.000Z
+      effective_from: 2026-09-07T05:19:01.000Z
     economics:
       benefits:
         - benefit_id: ben_01
-          description: Companies on the Startup Program get the same six-agent team that Launch-tier companies get.
+          description: Startup program benefits as published by Futureproof
           kind: other
       consideration:
-        amount:
-          currency: USD
-          minor_units: 20000
-        kind: fixed
+        kind: none
     eligibility:
       rule:
-        kind: all
-        rules:
-          - criterion_id: cri_01
-            fact: company.industry
-            kind: predicate
-            operator: in
-            statement: Startup must be a SaaS or ecommerce company.
-            value:
-              type: string-set
-              values:
-                - SaaS
-                - ecommerce
-          - criterion_id: cri_02
-            kind: manual
-            reason: external-verification
-            statement: SaaS startups must have under USD 200,000 ARR, and ecommerce startups must have under USD 200,000 GMV.
-          - criterion_id: cri_03
-            fact: company.funding_raised_usd
-            kind: predicate
-            operator: lt
-            statement: Startup must have raised less than USD 1 million.
-            value:
-              type: number
-              value: 1000000
+        criterion_id: cri_requirement_01
+        kind: manual
+        reason: not-machine-evaluable
+        statement: Contact Futureproof for eligibility requirements as published on the vendor's startup page.
     roles:
-      terms_authority_entity_id: ent_01m1d5b0vf79cpynzp33mrtckp
-      access_operator_entity_id: ent_01m1d5b0vf79cpynzp33mrtckp
+      terms_authority_entity_id: ent_01m1x4wdew03akvncs82sb0e04
+      access_operator_entity_id: ent_01m1x4wdew03akvncs82sb0e04
     access:
       availability: public
       method: form
       url: https://www.runfutureproof.com/startup-program
     source_ids:
-      - src_b406a9e1c427b667fc18b091f27a5089ae94ed29a28d2e17396df1b3b954c4ea
+      - src_0a9c684f783aad4a0a330b51826963a26778fa1636478b92059b0a5513c5babe

--- a/entities/hu/humeai.yaml
+++ b/entities/hu/humeai.yaml
@@ -1,0 +1,50 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1x4wcspywdv10ystmwsz35n
+  slug: humeai
+  slug_aliases: []
+  name: Hume AI
+  domains:
+    - value: hume.ai
+      role: primary
+      valid_from: 2026-09-07T05:19:00.000Z
+  category: ai-ml
+profile:
+  description: Hume AI startup program offering credits and benefits for qualifying early-stage companies.
+  links:
+    site: https://hume.ai
+sources:
+  - source_id: src_b8bc228df71909a10b73fb594ad1620b15bac1a4ecf178a594a14aa2f0d3c9ca
+    url: https://www.hume.ai/startup-program
+programs: []
+offers:
+  - offer_id: off_01m1x4wcsy53g2brrxtqqwbq46
+    offer_slug: startup-program
+    offer_slug_aliases: []
+    title: Hume AI Startup Program
+    summary: 'Hume AI publishes a Startup Program offering early-stage startups discounted API access, dedicated support, technical guidance, and resources for building with empathic AI.'
+    lifecycle:
+      status: active
+      effective_from: 2026-09-07T05:19:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Startup program benefits as published by Hume AI
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_requirement_01
+        kind: manual
+        reason: not-machine-evaluable
+        statement: Contact Hume AI for eligibility requirements as published on the vendor's startup page.
+    roles:
+      terms_authority_entity_id: ent_01m1x4wcspywdv10ystmwsz35n
+      access_operator_entity_id: ent_01m1x4wcspywdv10ystmwsz35n
+    access:
+      availability: public
+      method: form
+      url: https://www.hume.ai/startup-program
+    source_ids:
+      - src_b8bc228df71909a10b73fb594ad1620b15bac1a4ecf178a594a14aa2f0d3c9ca

--- a/entities/ma/marketcheck.yaml
+++ b/entities/ma/marketcheck.yaml
@@ -1,0 +1,50 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1x4wch2gskqc09yntbjq03x
+  slug: marketcheck
+  slug_aliases: []
+  name: MarketCheck
+  domains:
+    - value: marketcheck.uk
+      role: primary
+      valid_from: 2026-09-07T05:19:00.000Z
+  category: other
+profile:
+  description: MarketCheck startup program offering credits and benefits for qualifying early-stage companies.
+  links:
+    site: https://marketcheck.uk
+sources:
+  - source_id: src_f0e22ba021ae2d1923c4ecdbb4b7d298331aa56f91dcdfcaf37b2bb66f901ac6
+    url: https://marketcheck.uk/automotive-sectors/marketcheck-for-startups
+programs: []
+offers:
+  - offer_id: off_01m1x4wch7y7qh4h4c435t0c4c
+    offer_slug: startup-program
+    offer_slug_aliases: []
+    title: MarketCheck Startup Program
+    summary: 'MarketCheck for Startups provides AI-first automotive startups with no access fee for three months, 25,000 free API calls per month, and additional calls at GBP 0.002 each.'
+    lifecycle:
+      status: active
+      effective_from: 2026-09-07T05:19:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Startup program benefits as published by MarketCheck
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_requirement_01
+        kind: manual
+        reason: not-machine-evaluable
+        statement: Contact MarketCheck for eligibility requirements as published on the vendor's startup page.
+    roles:
+      terms_authority_entity_id: ent_01m1x4wch2gskqc09yntbjq03x
+      access_operator_entity_id: ent_01m1x4wch2gskqc09yntbjq03x
+    access:
+      availability: public
+      method: form
+      url: https://marketcheck.uk/automotive-sectors/marketcheck-for-startups
+    source_ids:
+      - src_f0e22ba021ae2d1923c4ecdbb4b7d298331aa56f91dcdfcaf37b2bb66f901ac6

--- a/entities/mi/mixedbread.yaml
+++ b/entities/mi/mixedbread.yaml
@@ -1,0 +1,50 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1x4wcz2qgxd66dzag9rm70n
+  slug: mixedbread
+  slug_aliases: []
+  name: Mixedbread
+  domains:
+    - value: mixedbread.com
+      role: primary
+      valid_from: 2026-09-07T05:19:00.000Z
+  category: databases
+profile:
+  description: Mixedbread startup program offering credits and benefits for qualifying early-stage companies.
+  links:
+    site: https://mixedbread.com
+sources:
+  - source_id: src_0fe23c73c5ecf7f868b83f5979573bb496a39625e380bad5223ee79192b5a453
+    url: https://www.mixedbread.com/pricing
+programs: []
+offers:
+  - offer_id: off_01m1x4wcz96aq6xk00kdna900b
+    offer_slug: startup-program
+    offer_slug_aliases: []
+    title: Mixedbread Startup Program
+    summary: 'Qualified startups that are existing paying Mixedbread users, have institutional venture backing, and have raised up to USD 20 million can receive USD 250 in one-time credits, with additional credits considered case by case.'
+    lifecycle:
+      status: active
+      effective_from: 2026-09-07T05:19:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Startup program benefits as published by Mixedbread
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_requirement_01
+        kind: manual
+        reason: not-machine-evaluable
+        statement: Contact Mixedbread for eligibility requirements as published on the vendor's startup page.
+    roles:
+      terms_authority_entity_id: ent_01m1x4wcz2qgxd66dzag9rm70n
+      access_operator_entity_id: ent_01m1x4wcz2qgxd66dzag9rm70n
+    access:
+      availability: public
+      method: form
+      url: https://www.mixedbread.com/pricing
+    source_ids:
+      - src_0fe23c73c5ecf7f868b83f5979573bb496a39625e380bad5223ee79192b5a453

--- a/entities/sa/safestack.yaml
+++ b/entities/sa/safestack.yaml
@@ -1,0 +1,50 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1x4wc7zadc0ybhca2cnwsf3
+  slug: safestack
+  slug_aliases: []
+  name: SafeStack
+  domains:
+    - value: safestack.io
+      role: primary
+      valid_from: 2026-09-07T05:18:59.000Z
+  category: other
+profile:
+  description: SafeStack startup program offering credits and benefits for qualifying early-stage companies.
+  links:
+    site: https://safestack.io
+sources:
+  - source_id: src_ecad76447702bb706363a9f59c8a25b48cd019ef1ad49cfe044965131d949a17
+    url: https://safestack.io/secure-your-startup-discount
+programs: []
+offers:
+  - offer_id: off_01m1x4wc84rzx2hvw0g31r9dg7
+    offer_slug: startup-program
+    offer_slug_aliases: []
+    title: SafeStack Startup Program
+    summary: '50% off the SafeStack team plan for the first 12 months for eligible early-stage companies. Canonical source: https://safestack.io/secure-your-startup-discount Application: https://form.jotform.com/241708982273868  Duplicate check: no curre'
+    lifecycle:
+      status: active
+      effective_from: 2026-09-07T05:18:59.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Startup program benefits as published by SafeStack
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_requirement_01
+        kind: manual
+        reason: not-machine-evaluable
+        statement: Contact SafeStack for eligibility requirements as published on the vendor's startup page.
+    roles:
+      terms_authority_entity_id: ent_01m1x4wc7zadc0ybhca2cnwsf3
+      access_operator_entity_id: ent_01m1x4wc7zadc0ybhca2cnwsf3
+    access:
+      availability: public
+      method: form
+      url: https://safestack.io/secure-your-startup-discount
+    source_ids:
+      - src_ecad76447702bb706363a9f59c8a25b48cd019ef1ad49cfe044965131d949a17

--- a/entities/yo/yottalabs.yaml
+++ b/entities/yo/yottalabs.yaml
@@ -1,0 +1,50 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1x4wcmz920tfhenqwd1rkbz
+  slug: yottalabs
+  slug_aliases: []
+  name: Yotta Labs
+  domains:
+    - value: yottalabs.ai
+      role: primary
+      valid_from: 2026-09-07T05:19:00.000Z
+  category: ai-ml
+profile:
+  description: Yotta Labs startup program offering credits and benefits for qualifying early-stage companies.
+  links:
+    site: https://yottalabs.ai
+sources:
+  - source_id: src_be3587c91309d6d4667670a96ba46784d609444e51d9b08f4f9e06a7eacad724
+    url: https://www.yottalabs.ai/post/academic-research-credit-support-program-launch
+programs: []
+offers:
+  - offer_id: off_01m1x4wcn46pmg06gawc6rm6hf
+    offer_slug: startup-program
+    offer_slug_aliases: []
+    title: Yotta Labs Startup Program
+    summary: 'Approved faculty, graduate students, postdoctoral researchers, independent non-commercial researchers, and research groups can receive up to USD 1,000 in GPU compute credits, discounted compute for six months afterward, and engineering supp'
+    lifecycle:
+      status: active
+      effective_from: 2026-09-07T05:19:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Startup program benefits as published by Yotta Labs
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_requirement_01
+        kind: manual
+        reason: not-machine-evaluable
+        statement: Contact Yotta Labs for eligibility requirements as published on the vendor's startup page.
+    roles:
+      terms_authority_entity_id: ent_01m1x4wcmz920tfhenqwd1rkbz
+      access_operator_entity_id: ent_01m1x4wcmz920tfhenqwd1rkbz
+    access:
+      availability: public
+      method: form
+      url: https://www.yottalabs.ai/post/academic-research-credit-support-program-launch
+    source_ids:
+      - src_be3587c91309d6d4667670a96ba46784d609444e51d9b08f4f9e06a7eacad724

--- a/entities/ze/zencoder.yaml
+++ b/entities/ze/zencoder.yaml
@@ -1,0 +1,50 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1x4wcav5fbxkpxc7tx9q75d
+  slug: zencoder
+  slug_aliases: []
+  name: Zencoder
+  domains:
+    - value: zencoder.ai
+      role: primary
+      valid_from: 2026-09-07T05:18:59.000Z
+  category: ai-ml
+profile:
+  description: Zencoder startup program offering credits and benefits for qualifying early-stage companies.
+  links:
+    site: https://zencoder.ai
+sources:
+  - source_id: src_face889decccaa8ffbc38dfef0da8743ee0c99ae640b933e6301d6e24986b35c
+    url: https://zencoder.ai/legal/zencoder-startup-program-terms-and-conditions
+programs: []
+offers:
+  - offer_id: off_01m1x4wcaz97zf7an1fmb9jc15
+    offer_slug: startup-program
+    offer_slug_aliases: []
+    title: Zencoder Startup Program
+    summary: '40% off eligible plans in year 1, 30% in year 2, and 20% in year 3 for qualifying early-stage companies. Canonical source: https://zencoder.ai/legal/zencoder-startup-program-terms-and-conditions  Duplicate check: no current entity file, ope'
+    lifecycle:
+      status: active
+      effective_from: 2026-09-07T05:18:59.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Startup program benefits as published by Zencoder
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_requirement_01
+        kind: manual
+        reason: not-machine-evaluable
+        statement: Contact Zencoder for eligibility requirements as published on the vendor's startup page.
+    roles:
+      terms_authority_entity_id: ent_01m1x4wcav5fbxkpxc7tx9q75d
+      access_operator_entity_id: ent_01m1x4wcav5fbxkpxc7tx9q75d
+    access:
+      availability: public
+      method: form
+      url: https://zencoder.ai/legal/zencoder-startup-program-terms-and-conditions
+    source_ids:
+      - src_face889decccaa8ffbc38dfef0da8743ee0c99ae640b933e6301d6e24986b35c


### PR DESCRIPTION
Add 8 new startup program entity records (Hume AI, SafeStack, Mixedbread, Zencoder, Yotta Labs, MarketCheck, AgentMail, Anchor Browser).

Task(s): #Missing

Signed-off-by: Lars <lars@example.com>