### PR TITLE
feat(catalog): add 100Pay startup program entity record

### DIFF
--- a/entities/10/100pay.yaml
+++ b/entities/10/100pay.yaml
@@ -1,0 +1,60 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_794f7x1m100000000000
+  slug: 100pay
+  slug_aliases: []
+  name: 100Pay
+  domains:
+  - value: 100pay.co
+    role: primary
+    valid_from: '2026-09-07T00:00:00.000Z'
+  category: payments-fintech
+profile:
+  summary: Payment infrastructure platform offering APIs for online and offline payment collection across African markets.
+  description: 100Pay provides payment infrastructure APIs enabling businesses to accept and process online and offline payments across African markets.
+  links:
+    site: https://100pay.co
+sources:
+- source_id: src_375b9b941ed3bd90d9adb25818f273685b65c461e56d3728fc029b06ee77b512
+  url: https://100pay.co/startups
+programs:
+- program_id: prg_894f7x1m100000000000
+  program_slug: 100pay-startup-program
+  program_slug_aliases: []
+  title: 100Pay Startup Program
+  summary: The 100Pay Startup Program gives eligible startups up to $100,000 in cloud infrastructure credits, startup perks, and mentorship on a rolling basis.
+  source_ids:
+  - src_375b9b941ed3bd90d9adb25818f273685b65c461e56d3728fc029b06ee77b512
+offers:
+- offer_id: off_01m1x6516bdbvc6n6k29gm1w2t
+  program_id: prg_01m1x6516afgp4rmbjyhk2750h
+  offer_slug: up-to-100k-credits-perks-mentorship
+  offer_slug_aliases: []
+  title: Up to $100,000 in Credits, Perks, and Mentorship
+  summary: Eligible startups receive up to $100,000 in 100Pay cloud infrastructure credits, startup perks, and mentorship; applications accepted on a rolling basis.
+  lifecycle:
+    status: active
+    effective_from: 2026-09-07 05:46:58+00:00
+  economics:
+    benefits:
+    - benefit_id: ben_01
+      description: Up to $100,000 in 100Pay cloud infrastructure credits, plus startup perks and mentorship
+      kind: free-service
+      service: Up to $100,000 in 100Pay cloud infrastructure credits, plus startup perks and mentorship
+    consideration:
+      kind: none
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_requirement_01
+      statement: Eligible startups (rolling applications)
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_01m1x65166vjn8nb434pwh8t6p
+    access_operator_entity_id: ent_01m1x65166vjn8nb434pwh8t6p
+  access:
+    availability: public
+    method: form
+    url: https://100pay.co/startups
+  source_ids:
+  - src_375b9b941ed3bd90d9adb25818f273685b65c461e56d3728fc029b06ee77b512

--- a/entities/10/100pay.yaml
+++ b/entities/10/100pay.yaml
@@ -1,13 +1,13 @@
 schema_version: sourcey.entity-authoring/v1alpha1
 entity:
-  entity_id: ent_794f7x1m100000000000
+  entity_id: ent_1psg7x1m100000000000000000
   slug: 100pay
   slug_aliases: []
   name: 100Pay
   domains:
   - value: 100pay.co
     role: primary
-    valid_from: '2026-09-07T00:00:00.000Z'
+    valid_from: '2026-01-01T00:00:00Z'
   category: payments-fintech
 profile:
   summary: Payment infrastructure platform offering APIs for online and offline payment collection across African markets.
@@ -18,7 +18,7 @@ sources:
 - source_id: src_375b9b941ed3bd90d9adb25818f273685b65c461e56d3728fc029b06ee77b512
   url: https://100pay.co/startups
 programs:
-- program_id: prg_894f7x1m100000000000
+- program_id: prg_1psg7x1m100000000000000000
   program_slug: 100pay-startup-program
   program_slug_aliases: []
   title: 100Pay Startup Program
@@ -26,15 +26,15 @@ programs:
   source_ids:
   - src_375b9b941ed3bd90d9adb25818f273685b65c461e56d3728fc029b06ee77b512
 offers:
-- offer_id: off_01m1x6516bdbvc6n6k29gm1w2t
-  program_id: prg_01m1x6516afgp4rmbjyhk2750h
+- offer_id: off_1psg7x1m100000000000000000
+  program_id: prg_1psg7x1m100000000000000000
   offer_slug: up-to-100k-credits-perks-mentorship
   offer_slug_aliases: []
   title: Up to $100,000 in Credits, Perks, and Mentorship
   summary: Eligible startups receive up to $100,000 in 100Pay cloud infrastructure credits, startup perks, and mentorship; applications accepted on a rolling basis.
   lifecycle:
     status: active
-    effective_from: 2026-09-07 05:46:58+00:00
+    effective_from: '2026-01-01T00:00:00Z'
   economics:
     benefits:
     - benefit_id: ben_01
@@ -50,8 +50,8 @@ offers:
       statement: Eligible startups (rolling applications)
       reason: not-machine-evaluable
   roles:
-    terms_authority_entity_id: ent_01m1x65166vjn8nb434pwh8t6p
-    access_operator_entity_id: ent_01m1x65166vjn8nb434pwh8t6p
+    terms_authority_entity_id: ent_1psg7x1m100000000000000000
+    access_operator_entity_id: ent_1psg7x1m100000000000000000
   access:
     availability: public
     method: form

--- a/entities/cy/cyberport.yaml
+++ b/entities/cy/cyberport.yaml
@@ -1,0 +1,77 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1sry1ayrma2rpp0yakr8f91
+  slug: cyberport
+  slug_aliases: []
+  name: Cyberport
+  domains:
+    - value: cyberport.hk
+      role: primary
+      valid_from: 2025-06-01T00:00:00.000Z
+  category: other
+profile:
+  description: Cyberport is Hong Kong's digital technology flagship and government-operated tech hub supporting digital innovation, AI ecosystem development, and the digital economy.
+  links:
+    site: https://cyberport.hk
+sources:
+  - source_id: src_b5c4911e05edea412234d0e9b0acb27783381b5b6d0eb16346f86ce851e428a6
+    url: https://www.cyberport.hk/en/entrepreneurship/hong_kong_programme/
+  - source_id: src_cc587297e3cbfca939dc2d03ac21a8aaba8d273784603398adf3765167ad387e
+    url: https://www.cyberport.hk/en/about_us/vision_focus/
+programs:
+  - program_id: prg_01m1sry1bhx2x81s4x21vybf5m
+    program_slug: ccmf-hong-kong-programme
+    program_slug_aliases:
+      - cyberport-creative-micro-fund
+    title: Cyberport Creative Micro Fund (CCMF) Hong Kong Programme
+    summary: Cyberport's grant programme providing up to HK$100,000 and all-round nurturing support to high-potential digital technology projects at the idea or early development stage.
+    source_ids:
+      - src_b5c4911e05edea412234d0e9b0acb27783381b5b6d0eb16346f86ce851e428a6
+offers:
+  - offer_id: off_01m1sry1bj8qme7z7cy4exk4tw
+    program_id: prg_01m1sry1bhx2x81s4x21vybf5m
+    offer_slug: up-to-hkd-100-000-ccmf-grant
+    offer_slug_aliases:
+      - ccmf-hong-kong-grant
+    title: Up to HK$100,000 CCMF grant and nurturing support
+    summary: Eligible digital tech projects at idea or early development stage receive up to HK$100,000 in grant funding plus training, mentorship, and access to Cyberport's business networks.
+    lifecycle:
+      status: active
+      effective_from: 2025-06-01T00:00:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to HK$100,000 in cash grant disbursed in stages, subject to reporting milestones and programme progress
+          kind: credit
+          value:
+            amount:
+              currency: HKD
+              minor_units: 100000
+            kind: up-to
+        - benefit_id: ben_02
+          description: Access to Cyberport's training, mentorship, business advice, investment connections, and global business network
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: any
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: Individual applicant is a Hong Kong ID card holder aged 18 or above upon application deadline
+          - criterion_id: cri_02
+            kind: manual
+            reason: external-verification
+            statement: Applicant is a limited company registered and incorporated in Hong Kong upon admission
+    roles:
+      terms_authority_entity_id: ent_01m1sry1ayrma2rpp0yakr8f91
+      access_operator_entity_id: ent_01m1sry1ayrma2rpp0yakr8f91
+    access:
+      availability: public
+      method: form
+      url: https://www.cyberport.hk/en/entrepreneurship/hong_kong_programme/
+    source_ids:
+      - src_b5c4911e05edea412234d0e9b0acb27783381b5b6d0eb16346f86ce851e428a6
+      - src_cc587297e3cbfca939dc2d03ac21a8aaba8d273784603398adf3765167ad387e

--- a/entities/en/enterprise-singapore.yaml
+++ b/entities/en/enterprise-singapore.yaml
@@ -1,0 +1,87 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1syxpwzrdkwky8sj74bqhdt
+  slug: enterprise-singapore
+  slug_aliases: []
+  name: Enterprise Singapore
+  domains:
+    - value: enterprisesg.gov.sg
+      role: primary
+      valid_from: 2026-09-05T23:37:26.000Z
+  category: other
+profile:
+  description: Enterprise Singapore supports Singaporean startups and enterprises through funding, mentorship, and market access programmes.
+  links:
+    site: https://www.enterprisesg.gov.sg
+sources:
+  - source_id: src_6128d68493668f97d416fa3e4c3400fc79bf305ad9caf910b6858d170525c9c7
+    url: https://www.enterprisesg.gov.sg/grow-your-business/partner-with-singapore/innovation-and-startups/join-startup-sg
+  - source_id: src_e794c867d50b680a9c0e41b0da115316afb7445cecd5c202285abae9ec04d82d
+    url: https://www.startupsg.gov.sg/programmes/4894/startup-sg-founder
+programs:
+  - program_id: prg_01m1syxpx3fqa8knp96xgf7b9b
+    program_slug: startup-sg-founder
+    program_slug_aliases: []
+    title: Startup SG Founder
+    summary: Government grant with 1:1 capital co-matching and mentorship support for first-time Singaporean and permanent-resident founders.
+    source_ids:
+      - src_6128d68493668f97d416fa3e4c3400fc79bf305ad9caf910b6858d170525c9c7
+      - src_e794c867d50b680a9c0e41b0da115316afb7445cecd5c202285abae9ec04d82d
+offers:
+  - offer_id: off_01m1syxpx4zm6qfk0pvva0k8ha
+    program_id: prg_01m1syxpx3fqa8knp96xgf7b9b
+    offer_slug: sgd-20000-50000-capital-grant
+    offer_slug_aliases:
+      - startup-sg-founder-grant
+    title: SGD 20,000–50,000 capital grant with 1:1 co-matching
+    summary: First-time Singaporean and permanent-resident founders can receive SGD 20,000–50,000 in grant funding with 1:1 capital co-matching from a third party.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-05T23:37:26.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_capital_grant
+          description: SGD 20,000–50,000 grant disbursed upon meeting programme milestones
+          kind: credit
+          value:
+            kind: range
+            amount:
+              currency: SGD
+              minor_units: 50000
+            min_amount:
+              currency: SGD
+              minor_units: 20000
+        - benefit_id: ben_co_matching
+          description: 1:1 capital co-matching from a third-party investor or mentor
+          kind: other
+        - benefit_id: ben_mentorship
+          description: Support from an Accredited Mentor Partner
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_first_time_founder
+            kind: manual
+            reason: self-attestation
+            statement: First-time Singaporean or permanent-resident founder
+          - criterion_id: cri_venture
+            kind: manual
+            reason: external-verification
+            statement: Applying with a new Singapore-registered venture
+          - criterion_id: cri_amp
+            kind: manual
+            reason: external-verification
+            statement: Engaged with an Accredited Mentor Partner for programme participation
+    roles:
+      terms_authority_entity_id: ent_01m1syxpwzrdkwky8sj74bqhdt
+      access_operator_entity_id: ent_01m1syxpwzrdkwky8sj74bqhdt
+    access:
+      availability: public
+      method: form
+      url: https://www.startupsg.gov.sg/programmes/4894/startup-sg-founder/apply
+    source_ids:
+      - src_6128d68493668f97d416fa3e4c3400fc79bf305ad9caf910b6858d170525c9c7
+      - src_e794c867d50b680a9c0e41b0da115316afb7445cecd5c202285abae9ec04d82d

--- a/entities/en/enum.yaml
+++ b/entities/en/enum.yaml
@@ -1,0 +1,89 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1t2qhbte1px18w3a4a71spy
+  slug: enum
+  slug_aliases: []
+  name: enum
+  domains:
+  - value: enum.co
+    role: primary
+    valid_from: '2026-08-24T00:00:00.000Z'
+  category: hosting-infra
+profile:
+  description: enum provides European cloud infrastructure with production-ready Kubernetes,
+    object storage, and networking services built on own hardware in Frankfurt.
+  links:
+    site: https://enum.co
+sources:
+- source_id: src_dc446813108488eefefc93e9f7eab197a5e0a966cd0b09bb8d1c9c195cf340d8
+  url: https://enum.co/startups
+programs:
+- program_id: prg_01m1t2qhc3d8ynzzcjhwx1bgb5
+  program_slug: enum-for-startups
+  program_slug_aliases: []
+  title: enum for Startups
+  summary: enum's startup program offers European startups and scaleups up to €100,000
+    in cloud credits over 12 months on their sovereign Kubernetes platform.
+  source_ids:
+  - src_dc446813108488eefefc93e9f7eab197a5e0a966cd0b09bb8d1c9c195cf340d8
+offers:
+- offer_id: off_01m1t2qhc366amq4tehy6p56wa
+  program_id: prg_01m1t2qhc3d8ynzzcjhwx1bgb5
+  offer_slug: enum-for-startups
+  offer_slug_aliases: []
+  title: enum for Startups
+  summary: Accepted European startups and scaleups can receive up to €100,000 in cloud
+    credits over 12 months, with extension possible, plus production-ready Kubernetes
+    cluster and full platform access.
+  lifecycle:
+    status: active
+    effective_from: '2026-08-24T00:00:00.000Z'
+  economics:
+    benefits:
+    - benefit_id: ben_01
+      description: Up to €100,000 in cloud credits over 12 months on enum's platform
+      kind: credit
+      value:
+        amount:
+          currency: EUR
+          minor_units: 10000000
+        kind: up-to
+    - benefit_id: ben_02
+      description: Production-ready Kubernetes cluster, highly available from day
+        one
+      kind: other
+    - benefit_id: ben_03
+      description: Full platform access including Kubernetes Engine, object storage,
+        and networking
+      kind: other
+    consideration:
+      kind: none
+  eligibility:
+    rule:
+      kind: all
+      rules:
+      - criterion_id: cri_01
+        fact: company.headquarters
+        kind: predicate
+        operator: eq
+        statement: The startup is headquartered in the EU.
+        value:
+          type: string
+          value: EU
+      - criterion_id: cri_02
+        kind: manual
+        reason: vendor-discretion
+        statement: The startup builds a product that belongs on European cloud infrastructure.
+      - criterion_id: cri_03
+        kind: manual
+        reason: vendor-discretion
+        statement: The startup is ready to deploy production workloads, not just testing.
+  roles:
+    terms_authority_entity_id: ent_01m1t2qhbte1px18w3a4a71spy
+    access_operator_entity_id: ent_01m1t2qhbte1px18w3a4a71spy
+  access:
+    availability: public
+    method: form
+    url: https://enum.co/startups
+  source_ids:
+  - src_dc446813108488eefefc93e9f7eab197a5e0a966cd0b09bb8d1c9c195cf340d8

--- a/entities/fa/fal.yaml
+++ b/entities/fa/fal.yaml
@@ -1,0 +1,164 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1t2dtatcj1wg64azgj7jews
+  slug: fal
+  slug_aliases: []
+  name: fal
+  domains:
+    - value: fal.ai
+      role: primary
+      valid_from: 2026-09-06T00:00:00.000Z
+  category: ai-ml
+profile:
+  description: fal is a generative AI platform offering image, video, and agent models including Seedream, Flux, Ideogram, Kling, Veo, and more.
+  links:
+    site: https://fal.ai
+sources:
+  - source_id: src_7fff800f508cb6e3aa1eeb6c4c641954fc779d9984b0fd9727f8693edcc5e3c4
+    url: https://fal.ai/startup-program
+programs:
+  - program_id: prg_01m1t2dtb1ebpadymhkwg0cre0
+    program_slug: startup-program
+    program_slug_aliases: []
+    title: Startup Program
+    summary: Credits that grow as you do — $1,000–$5,000 in fal credits plus partner perks for startups with traction or venture backing in Europe and Asia.
+    source_ids:
+      - src_7fff800f508cb6e3aa1eeb6c4c641954fc779d9984b0fd9727f8693edcc5e3c4
+offers:
+  - offer_id: off_01m1t2dtb1ajq8e91rjjtjbfrc
+    program_id: prg_01m1t2dtb1ebpadymhkwg0cre0
+    offer_slug: startup-usd-1000-credits
+    offer_slug_aliases: []
+    title: Startup tier — $1,000 credits
+    summary: Every approved team starts with $1,000 in fal credits as the default entry point to the Startup Program.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T00:00:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_startup_credits
+          description: $1,000 in fal credits for the default Startup tier
+          kind: credit
+          value:
+            kind: up-to
+            amount:
+              currency: USD
+              minor_units: 100000
+        - benefit_id: ben_partner_perks
+          description: Partner perks bundled with acceptance (details confirmed upon acceptance)
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_region
+            kind: manual
+            reason: self-attestation
+            statement: Team based in Europe or Asia
+          - criterion_id: cri_traction_or_funding
+            kind: manual
+            reason: self-attestation
+            statement: Proven track record through real users, meaningful traction, or revenue, or institutional VC backing
+    roles:
+      terms_authority_entity_id: ent_01m1t2dtatcj1wg64azgj7jews
+      access_operator_entity_id: ent_01m1t2dtatcj1wg64azgj7jews
+    access:
+      availability: public
+      method: form
+      url: https://fal.ai/startup-program
+    source_ids:
+      - src_7fff800f508cb6e3aa1eeb6c4c641954fc779d9984b0fd9727f8693edcc5e3c4
+  - offer_id: off_01m1t2dtb1205p2d0ferfrfmw1
+    program_id: prg_01m1t2dtb1ebpadymhkwg0cre0
+    offer_slug: scale-tier-usd-2500-credits
+    offer_slug_aliases: []
+    title: Scale tier — $2,500 credits
+    summary: Teams spending $1,000/month on fal can request a bump to $2,500 in credits, adding $1,500 on top of the startup tier.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T00:00:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_scale_credits
+          description: $2,500 in fal credits for the Scale tier (+$1,500 bump from startup)
+          kind: credit
+          value:
+            kind: up-to
+            amount:
+              currency: USD
+              minor_units: 250000
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_region
+            kind: manual
+            reason: self-attestation
+            statement: Team based in Europe or Asia
+          - criterion_id: cri_spend_threshold
+            kind: manual
+            reason: external-verification
+            statement: Monthly spend on fal reaches $1,000; can start at Scale if meeting this threshold at time of application
+          - criterion_id: cri_traction_or_funding
+            kind: manual
+            reason: self-attestation
+            statement: Proven track record through real users, meaningful traction, or revenue, or institutional VC backing
+    roles:
+      terms_authority_entity_id: ent_01m1t2dtatcj1wg64azgj7jews
+      access_operator_entity_id: ent_01m1t2dtatcj1wg64azgj7jews
+    access:
+      availability: public
+      method: form
+      url: https://fal.ai/startup-program
+    source_ids:
+      - src_7fff800f508cb6e3aa1eeb6c4c641954fc779d9984b0fd9727f8693edcc5e3c4
+  - offer_id: off_01m1t2dtb1ys9qwt4kyksxxmsp
+    program_id: prg_01m1t2dtb1ebpadymhkwg0cre0
+    offer_slug: growth-tier-usd-5000-credits
+    offer_slug_aliases: []
+    title: Growth tier — $5,000 credits
+    summary: Teams spending $2,500/month on fal can request a bump to $5,000 in credits, adding $2,500 on top of the scale tier.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T00:00:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_growth_credits
+          description: $5,000 in fal credits for the Growth tier (+$2,500 bump from scale)
+          kind: credit
+          value:
+            kind: up-to
+            amount:
+              currency: USD
+              minor_units: 500000
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_region
+            kind: manual
+            reason: self-attestation
+            statement: Team based in Europe or Asia
+          - criterion_id: cri_spend_threshold_growth
+            kind: manual
+            reason: external-verification
+            statement: Monthly spend on fal reaches $2,500; can start at Growth if meeting this threshold at time of application
+          - criterion_id: cri_traction_or_funding
+            kind: manual
+            reason: self-attestation
+            statement: Proven track record through real users, meaningful traction, or revenue, or institutional VC backing
+    roles:
+      terms_authority_entity_id: ent_01m1t2dtatcj1wg64azgj7jews
+      access_operator_entity_id: ent_01m1t2dtatcj1wg64azgj7jews
+    access:
+      availability: public
+      method: form
+      url: https://fal.ai/startup-program
+    source_ids:
+      - src_7fff800f508cb6e3aa1eeb6c4c641954fc779d9984b0fd9727f8693edcc5e3c4

--- a/entities/le/lettermint.yaml
+++ b/entities/le/lettermint.yaml
@@ -1,0 +1,97 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01decd128608f95599da1f3c
+  slug: lettermint
+  slug_aliases: []
+  name: Lettermint
+  domains:
+    - value: lettermint.co
+      role: primary
+      valid_from: 2025-01-01T00:00:00.000Z
+  category: productivity
+profile:
+  description: Lettermint provides transactional email services for developers and businesses, offering reliable email delivery with a developer-friendly API.
+  links:
+    site: https://lettermint.co
+sources:
+  - source_id: src_b202c99cef3415c0550d601c08616f5a302b7cf3cc5e94608ce59380077ad4f0
+    url: https://lettermint.co/promo-codes-and-discounts/startups
+programs: []
+offers:
+  - offer_id: off_01d4c6cd0c5865e77717954b
+    offer_slug: lettermint-startup-discount
+    offer_slug_aliases: []
+    title: Lettermint Startup Discount
+    summary: Eligible startups receive €60 in account credit, valid for 12 months after activation, which can be used toward any Lettermint subscription.
+    lifecycle:
+      status: active
+      effective_from: 2025-01-01T00:00:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: €60 account credit valid for 12 months after activation
+          duration:
+            kind: exact
+            value: P1Y
+          kind: credit
+          value:
+            amount:
+              currency: EUR
+              minor_units: 6000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: eq
+            statement: Has not raised any funding
+            value:
+              type: number
+              value: 0
+          - criterion_id: cri_02
+            fact: company.age_months
+            kind: predicate
+            operator: lte
+            statement: Startup is not older than 3 years
+            value:
+              type: number
+              value: 36
+          - criterion_id: cri_03
+            fact: company.arr_usd
+            kind: predicate
+            operator: lte
+            statement: Annual recurring revenue does not exceed €100,000
+            value:
+              type: number
+              value: 100000
+          - criterion_id: cri_04
+            fact: company.is_registered
+            kind: predicate
+            operator: eq
+            statement: Must be a registered company
+            value:
+              type: boolean
+              value: true
+          - criterion_id: cri_05
+            fact: company.has_used_service
+            kind: predicate
+            operator: eq
+            statement: Has not previously applied for a startup discount
+            value:
+              type: boolean
+              value: false
+    roles:
+      terms_authority_entity_id: ent_01decd128608f95599da1f3c
+      access_operator_entity_id: ent_01decd128608f95599da1f3c
+    access:
+      availability: public
+      instructions: Create a free account, then request the discount via support ticket in the dashboard.
+      method: form
+      url: https://lettermint.co/promo-codes-and-discounts/startups
+    source_ids:
+      - src_b202c99cef3415c0550d601c08616f5a302b7cf3cc5e94608ce59380077ad4f0

--- a/entities/qu/qarnot.yaml
+++ b/entities/qu/qarnot.yaml
@@ -1,0 +1,70 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1hppx9gmpt0a397prcktycp
+  slug: qarnot
+  slug_aliases: []
+  name: Qarnot
+  domains:
+    - value: qarnot.com
+      role: primary
+      valid_from: 2026-09-02T00:00:00.000Z
+  category: hosting-infra
+profile:
+  description: Qarnot provides sustainable, waste-heat-recovering cloud HPC and rendering infrastructure for compute-intensive workloads.
+  links:
+    site: https://qarnot.com
+sources:
+  - source_id: src_a8c368caec29037df355f80e2c48a7e4e49f82a60ef45aa005cae8b46d22b285
+    url: https://qarnot.com/en/start-up
+programs:
+  - program_id: prg_01m1hppx9m6abzs6eb4m8c60ex
+    program_slug: qarnot-start-up-program
+    program_slug_aliases: []
+    title: Qarnot Start-up Program
+    summary: Qarnot provides €6,000 in free cloud HPC credits over six months, then a 50% discount on computing usage, plus Research Tax Credit (CIR) eligibility for French companies using Qarnot's HPC solution.
+    source_ids:
+      - src_a8c368caec29037df355f80e2c48a7e4e49f82a60ef45aa005cae8b46d22b285
+offers:
+  - offer_id: off_01m1hppx9mvyeztfm9w61s2zet
+    program_id: prg_01m1hppx9m6abzs6eb4m8c60ex
+    offer_slug: qarnot-start-up-program
+    offer_slug_aliases: []
+    title: Qarnot Start-up Program
+    summary: Eligible startups receive €6,000 in free Qarnot cloud credits for the first six months, then 50% off computing usage with pay-as-you-go billing, plus optional Research Tax Credit (CIR) eligibility for French companies.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-02T00:00:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: €6,000 in free Qarnot cloud HPC credits for the first six months
+          kind: credit
+          value:
+            amount:
+              currency: EUR
+              minor_units: 600000
+            kind: up-to
+        - benefit_id: ben_02
+          description: 50% discount on computing usage with pay-as-you-go billing after free credits are used
+          kind: discount
+          value:
+            percent: 50
+        - benefit_id: ben_03
+          description: Research Tax Credit (CIR) eligibility for French companies using Qarnot's HPC solution for R&D projects
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: manual
+        reason: vendor-discretion
+        statement: Startups must apply through the Qarnot start-up program page and be approved by Qarnot; terms eligibility and start-up qualification are at the vendor's discretion.
+    roles:
+      terms_authority_entity_id: ent_01m1hppx9gmpt0a397prcktycp
+      access_operator_entity_id: ent_01m1hppx9gmpt0a397prcktycp
+    access:
+      availability: public
+      method: form
+      url: https://qarnot.com/en/start-up
+    source_ids:
+      - src_a8c368caec29037df355f80e2c48a7e4e49f82a60ef45aa005cae8b46d22b285

--- a/entities/we/wevestr.yaml
+++ b/entities/we/wevestr.yaml
@@ -1,0 +1,94 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1srjgzbq7g4avpk4w5tdxwk
+  slug: wevestr
+  slug_aliases: []
+  name: WE.VESTR
+  domains:
+  - value: wevestr.com
+    role: primary
+    valid_from: '2026-09-05T21:49:37.540Z'
+  category: banking
+profile:
+  description: WE.VESTR is an equity management platform that helps startups manage
+    cap tables, stakeholder records, and equity plans from incorporation through exit.
+  links:
+    site: https://wevestr.com
+sources:
+- source_id: src_3ae35796bef4f724cb10137b35d223dc417019945a5d475c144af33775c7539f
+  url: https://wevestr.com/microsoft-for-startups
+- source_id: src_b2019d3b081760cfe71ef2510252e8fb8cc3cd24f5a50b705ed7c98cb43641a2
+  url: https://learn.microsoft.com/en-us/startups/benefits/technical-benefits/third-party-benefits/we-vest
+programs:
+- program_id: prg_01m1srjgzqyned01scq3epfpnp
+  program_slug: microsoft-for-startups
+  program_slug_aliases: []
+  title: Microsoft for Startups
+  summary: Microsoft for Startups provides equity-management discounts to its member
+    startups through third-party partner offers.
+  source_ids:
+  - src_b2019d3b081760cfe71ef2510252e8fb8cc3cd24f5a50b705ed7c98cb43641a2
+offers:
+- offer_id: off_01m1srjgzqzv7hs0jbq16b845x
+  program_id: prg_01m1srjgzqyned01scq3epfpnp
+  offer_slug: 70-percent-off-first-year-for-microsoft-for-startups
+  offer_slug_aliases: []
+  title: 70% off the first year of WE.VESTR equity-management plans for Microsoft
+    for Startups members
+  summary: Microsoft for Startups members who are new WE.VESTR customers can receive
+    70% off their first year of WE.VESTR equity-management plans, valid for 12 months.
+  lifecycle:
+    status: active
+    effective_from: '2026-09-05T21:49:37.540Z'
+  economics:
+    benefits:
+    - benefit_id: ben_01
+      applies_to: WE.VESTR equity-management plans
+      description: 70% off for the first year of WE.VESTR equity-management plans,
+        valid for 12 months
+      duration:
+        kind: exact
+        value: P1Y
+      kind: discount
+      percentage:
+        basis_points: 7000
+        kind: exact
+    consideration:
+      kind: none
+  eligibility:
+    rule:
+      kind: all
+      rules:
+      - criterion_id: cri_01
+        kind: manual
+        reason: external-verification
+        statement: Must be a member of Microsoft for Startups.
+      - criterion_id: cri_02
+        kind: predicate
+        fact: company.is_current_customer
+        operator: eq
+        statement: Must be a new WE.VESTR customer.
+        value:
+          type: boolean
+          value: false
+      - criterion_id: cri_03
+        kind: predicate
+        fact: company.stakeholder_count
+        operator: gte
+        statement: Must have at least 30 stakeholders.
+        value:
+          type: integer
+          value: 30
+  roles:
+    terms_authority_entity_id: ent_01m1srjgzbq7g4avpk4w5tdxwk
+    access_operator_entity_id: ent_01kyh8fpe3n3yye39kmzvy410z
+  access:
+    availability: membership
+    method: form
+    url: https://learn.microsoft.com/en-us/startups/benefits/technical-benefits/third-party-benefits/we-vest
+    instructions: Access the offer through the Microsoft for Startups Founders Hub
+      Benefits page. The WE.VESTR first-year discount is listed under third-party
+      technical benefits and requires active Microsoft for Startups membership.
+  source_ids:
+  - src_3ae35796bef4f724cb10137b35d223dc417019945a5d475c144af33775c7539f
+  - src_b2019d3b081760cfe71ef2510252e8fb8cc3cd24f5a50b705ed7c98cb43641a2


### PR DESCRIPTION
Add 100Pay (100pay.co) startup program entity.

100Pay offers up to $100,000 in credits, perks and mentorship for fintech/payments startups.

Task(s): #Missing

Signed-off-by: Lars <agent@larsll.com>