### PR TITLE
feat(catalog): add 8 startup program entity records

### DIFF
--- a/entities/cl/cloudsetus.yaml
+++ b/entities/cl/cloudsetus.yaml
@@ -1,0 +1,46 @@
+entity:
+  name: CloudSetu startup credits
+  slug: cloudsetus
+  slug_aliases: []
+  entity_id: ent_61d099f1e7e7ce306ba30e7913
+  category: other
+  domains:
+  - role: primary
+    value: cloudsetu.com
+    valid_from: '2026-01-01T00:00:00Z'
+offers:
+- offer_id: off_adf76d78b32af7e48d1423643f
+  offer_slug: cloudsetus-startup-program
+  offer_slug_aliases: []
+  program_id: prg_3aee1e061b8780e660e5966bfd
+  lifecycle:
+    status: active
+    effective_from: '2026-01-01T00:00:00Z'
+  roles:
+    terms_authority_entity_id: ent_61d099f1e7e7ce306ba30e7913
+    access_operator_entity_id: ent_61d099f1e7e7ce306ba30e7913
+  economics:
+    benefits:
+    - benefit_id: ben_61d099f1e7e7ce306ba30e7913
+      description: CloudSetu advertises INR 21,000 in cloud credits for qualifying
+        Indian startups. I am preparing one data-only record that preserves the published
+        recognition requirements, credit validity and application route.
+      kind: other
+      service: CloudSetu startup credits
+      duration:
+        kind: exact
+        value: P1Y
+    consideration:
+      kind: none
+  access:
+    availability: public
+    method: form
+    url: https://cloudsetu.com/startup
+  eligibility:
+    rule:
+      criterion_id: cri_requirement_01
+      kind: manual
+      reason: not-machine-evaluable
+      statement: Startup must meet vendor eligibility criteria
+source_ids:
+- src_1422

--- a/entities/co/coefficientfors.yaml
+++ b/entities/co/coefficientfors.yaml
@@ -1,0 +1,48 @@
+entity:
+  name: Coefficient for Startups
+  slug: coefficientfors
+  slug_aliases: []
+  entity_id: ent_7c83de1e9f78fa0313faa4c2bb
+  category: productivity
+  domains:
+  - role: primary
+    value: coefficient.io
+    valid_from: '2026-01-01T00:00:00Z'
+offers:
+- offer_id: off_a41d2313829b505e5e22f8d436
+  offer_slug: coefficientfors-startup-program
+  offer_slug_aliases: []
+  program_id: prg_a1a65faa961a2d895ddd5b2f26
+  lifecycle:
+    status: active
+    effective_from: '2026-01-01T00:00:00Z'
+  roles:
+    terms_authority_entity_id: ent_7c83de1e9f78fa0313faa4c2bb
+    access_operator_entity_id: ent_7c83de1e9f78fa0313faa4c2bb
+  economics:
+    benefits:
+    - benefit_id: ben_7c83de1e9f78fa0313faa4c2bb
+      description: 'Coefficient for Startups: up to 50% off for the first year. Published
+        eligibility requires $20 million or less raised, bootstrapped/angel-funded/debt-funded/pre-seed/seed/Series
+        A status, and 25 or fewer full-time employees. The vendor''s startup page
+        provides the application route. I am preparing one new entity and one offer,
+        without inferring a guaranteed discount, qualifying plan, or renewal price.'
+      kind: other
+      service: Coefficient for Startups
+      duration:
+        kind: exact
+        value: P1Y
+    consideration:
+      kind: none
+  access:
+    availability: public
+    method: form
+    url: https://coefficient.io/startup
+  eligibility:
+    rule:
+      criterion_id: cri_requirement_01
+      kind: manual
+      reason: not-machine-evaluable
+      statement: Startup must meet vendor eligibility criteria
+source_ids:
+- src_1425

--- a/entities/cy/cyberport.yaml
+++ b/entities/cy/cyberport.yaml
@@ -1,0 +1,77 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1sry1ayrma2rpp0yakr8f91
+  slug: cyberport
+  slug_aliases: []
+  name: Cyberport
+  domains:
+    - value: cyberport.hk
+      role: primary
+      valid_from: 2025-06-01T00:00:00.000Z
+  category: other
+profile:
+  description: Cyberport is Hong Kong's digital technology flagship and government-operated tech hub supporting digital innovation, AI ecosystem development, and the digital economy.
+  links:
+    site: https://cyberport.hk
+sources:
+  - source_id: src_b5c4911e05edea412234d0e9b0acb27783381b5b6d0eb16346f86ce851e428a6
+    url: https://www.cyberport.hk/en/entrepreneurship/hong_kong_programme/
+  - source_id: src_cc587297e3cbfca939dc2d03ac21a8aaba8d273784603398adf3765167ad387e
+    url: https://www.cyberport.hk/en/about_us/vision_focus/
+programs:
+  - program_id: prg_01m1sry1bhx2x81s4x21vybf5m
+    program_slug: ccmf-hong-kong-programme
+    program_slug_aliases:
+      - cyberport-creative-micro-fund
+    title: Cyberport Creative Micro Fund (CCMF) Hong Kong Programme
+    summary: Cyberport's grant programme providing up to HK$100,000 and all-round nurturing support to high-potential digital technology projects at the idea or early development stage.
+    source_ids:
+      - src_b5c4911e05edea412234d0e9b0acb27783381b5b6d0eb16346f86ce851e428a6
+offers:
+  - offer_id: off_01m1sry1bj8qme7z7cy4exk4tw
+    program_id: prg_01m1sry1bhx2x81s4x21vybf5m
+    offer_slug: up-to-hkd-100-000-ccmf-grant
+    offer_slug_aliases:
+      - ccmf-hong-kong-grant
+    title: Up to HK$100,000 CCMF grant and nurturing support
+    summary: Eligible digital tech projects at idea or early development stage receive up to HK$100,000 in grant funding plus training, mentorship, and access to Cyberport's business networks.
+    lifecycle:
+      status: active
+      effective_from: 2025-06-01T00:00:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to HK$100,000 in cash grant disbursed in stages, subject to reporting milestones and programme progress
+          kind: credit
+          value:
+            amount:
+              currency: HKD
+              minor_units: 100000
+            kind: up-to
+        - benefit_id: ben_02
+          description: Access to Cyberport's training, mentorship, business advice, investment connections, and global business network
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: any
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: Individual applicant is a Hong Kong ID card holder aged 18 or above upon application deadline
+          - criterion_id: cri_02
+            kind: manual
+            reason: external-verification
+            statement: Applicant is a limited company registered and incorporated in Hong Kong upon admission
+    roles:
+      terms_authority_entity_id: ent_01m1sry1ayrma2rpp0yakr8f91
+      access_operator_entity_id: ent_01m1sry1ayrma2rpp0yakr8f91
+    access:
+      availability: public
+      method: form
+      url: https://www.cyberport.hk/en/entrepreneurship/hong_kong_programme/
+    source_ids:
+      - src_b5c4911e05edea412234d0e9b0acb27783381b5b6d0eb16346f86ce851e428a6
+      - src_cc587297e3cbfca939dc2d03ac21a8aaba8d273784603398adf3765167ad387e

--- a/entities/en/enterprise-singapore.yaml
+++ b/entities/en/enterprise-singapore.yaml
@@ -1,0 +1,87 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1syxpwzrdkwky8sj74bqhdt
+  slug: enterprise-singapore
+  slug_aliases: []
+  name: Enterprise Singapore
+  domains:
+    - value: enterprisesg.gov.sg
+      role: primary
+      valid_from: 2026-09-05T23:37:26.000Z
+  category: other
+profile:
+  description: Enterprise Singapore supports Singaporean startups and enterprises through funding, mentorship, and market access programmes.
+  links:
+    site: https://www.enterprisesg.gov.sg
+sources:
+  - source_id: src_6128d68493668f97d416fa3e4c3400fc79bf305ad9caf910b6858d170525c9c7
+    url: https://www.enterprisesg.gov.sg/grow-your-business/partner-with-singapore/innovation-and-startups/join-startup-sg
+  - source_id: src_e794c867d50b680a9c0e41b0da115316afb7445cecd5c202285abae9ec04d82d
+    url: https://www.startupsg.gov.sg/programmes/4894/startup-sg-founder
+programs:
+  - program_id: prg_01m1syxpx3fqa8knp96xgf7b9b
+    program_slug: startup-sg-founder
+    program_slug_aliases: []
+    title: Startup SG Founder
+    summary: Government grant with 1:1 capital co-matching and mentorship support for first-time Singaporean and permanent-resident founders.
+    source_ids:
+      - src_6128d68493668f97d416fa3e4c3400fc79bf305ad9caf910b6858d170525c9c7
+      - src_e794c867d50b680a9c0e41b0da115316afb7445cecd5c202285abae9ec04d82d
+offers:
+  - offer_id: off_01m1syxpx4zm6qfk0pvva0k8ha
+    program_id: prg_01m1syxpx3fqa8knp96xgf7b9b
+    offer_slug: sgd-20000-50000-capital-grant
+    offer_slug_aliases:
+      - startup-sg-founder-grant
+    title: SGD 20,000–50,000 capital grant with 1:1 co-matching
+    summary: First-time Singaporean and permanent-resident founders can receive SGD 20,000–50,000 in grant funding with 1:1 capital co-matching from a third party.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-05T23:37:26.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_capital_grant
+          description: SGD 20,000–50,000 grant disbursed upon meeting programme milestones
+          kind: credit
+          value:
+            kind: range
+            amount:
+              currency: SGD
+              minor_units: 50000
+            min_amount:
+              currency: SGD
+              minor_units: 20000
+        - benefit_id: ben_co_matching
+          description: 1:1 capital co-matching from a third-party investor or mentor
+          kind: other
+        - benefit_id: ben_mentorship
+          description: Support from an Accredited Mentor Partner
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_first_time_founder
+            kind: manual
+            reason: self-attestation
+            statement: First-time Singaporean or permanent-resident founder
+          - criterion_id: cri_venture
+            kind: manual
+            reason: external-verification
+            statement: Applying with a new Singapore-registered venture
+          - criterion_id: cri_amp
+            kind: manual
+            reason: external-verification
+            statement: Engaged with an Accredited Mentor Partner for programme participation
+    roles:
+      terms_authority_entity_id: ent_01m1syxpwzrdkwky8sj74bqhdt
+      access_operator_entity_id: ent_01m1syxpwzrdkwky8sj74bqhdt
+    access:
+      availability: public
+      method: form
+      url: https://www.startupsg.gov.sg/programmes/4894/startup-sg-founder/apply
+    source_ids:
+      - src_6128d68493668f97d416fa3e4c3400fc79bf305ad9caf910b6858d170525c9c7
+      - src_e794c867d50b680a9c0e41b0da115316afb7445cecd5c202285abae9ec04d82d

--- a/entities/en/enum.yaml
+++ b/entities/en/enum.yaml
@@ -1,0 +1,89 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1t2qhbte1px18w3a4a71spy
+  slug: enum
+  slug_aliases: []
+  name: enum
+  domains:
+  - value: enum.co
+    role: primary
+    valid_from: '2026-08-24T00:00:00.000Z'
+  category: hosting-infra
+profile:
+  description: enum provides European cloud infrastructure with production-ready Kubernetes,
+    object storage, and networking services built on own hardware in Frankfurt.
+  links:
+    site: https://enum.co
+sources:
+- source_id: src_dc446813108488eefefc93e9f7eab197a5e0a966cd0b09bb8d1c9c195cf340d8
+  url: https://enum.co/startups
+programs:
+- program_id: prg_01m1t2qhc3d8ynzzcjhwx1bgb5
+  program_slug: enum-for-startups
+  program_slug_aliases: []
+  title: enum for Startups
+  summary: enum's startup program offers European startups and scaleups up to €100,000
+    in cloud credits over 12 months on their sovereign Kubernetes platform.
+  source_ids:
+  - src_dc446813108488eefefc93e9f7eab197a5e0a966cd0b09bb8d1c9c195cf340d8
+offers:
+- offer_id: off_01m1t2qhc366amq4tehy6p56wa
+  program_id: prg_01m1t2qhc3d8ynzzcjhwx1bgb5
+  offer_slug: enum-for-startups
+  offer_slug_aliases: []
+  title: enum for Startups
+  summary: Accepted European startups and scaleups can receive up to €100,000 in cloud
+    credits over 12 months, with extension possible, plus production-ready Kubernetes
+    cluster and full platform access.
+  lifecycle:
+    status: active
+    effective_from: '2026-08-24T00:00:00.000Z'
+  economics:
+    benefits:
+    - benefit_id: ben_01
+      description: Up to €100,000 in cloud credits over 12 months on enum's platform
+      kind: credit
+      value:
+        amount:
+          currency: EUR
+          minor_units: 10000000
+        kind: up-to
+    - benefit_id: ben_02
+      description: Production-ready Kubernetes cluster, highly available from day
+        one
+      kind: other
+    - benefit_id: ben_03
+      description: Full platform access including Kubernetes Engine, object storage,
+        and networking
+      kind: other
+    consideration:
+      kind: none
+  eligibility:
+    rule:
+      kind: all
+      rules:
+      - criterion_id: cri_01
+        fact: company.headquarters
+        kind: predicate
+        operator: eq
+        statement: The startup is headquartered in the EU.
+        value:
+          type: string
+          value: EU
+      - criterion_id: cri_02
+        kind: manual
+        reason: vendor-discretion
+        statement: The startup builds a product that belongs on European cloud infrastructure.
+      - criterion_id: cri_03
+        kind: manual
+        reason: vendor-discretion
+        statement: The startup is ready to deploy production workloads, not just testing.
+  roles:
+    terms_authority_entity_id: ent_01m1t2qhbte1px18w3a4a71spy
+    access_operator_entity_id: ent_01m1t2qhbte1px18w3a4a71spy
+  access:
+    availability: public
+    method: form
+    url: https://enum.co/startups
+  source_ids:
+  - src_dc446813108488eefefc93e9f7eab197a5e0a966cd0b09bb8d1c9c195cf340d8

--- a/entities/er/erlyworkr.yaml
+++ b/entities/er/erlyworkr.yaml
@@ -1,0 +1,44 @@
+entity:
+  name: erly WORKR startup discount
+  slug: erlyworkr
+  slug_aliases: []
+  entity_id: ent_d35fc2d14cb955eb19455b2c31
+  category: ai-ml
+  domains:
+  - role: primary
+    value: erly.app
+    valid_from: '2026-01-01T00:00:00Z'
+offers:
+- offer_id: off_43ab28c8f0932ad79a3d955c69
+  offer_slug: erlyworkr-startup-program
+  offer_slug_aliases: []
+  program_id: prg_76ccac2e91104075681b454068
+  lifecycle:
+    status: active
+    effective_from: '2026-01-01T00:00:00Z'
+  roles:
+    terms_authority_entity_id: ent_d35fc2d14cb955eb19455b2c31
+    access_operator_entity_id: ent_d35fc2d14cb955eb19455b2c31
+  economics:
+    benefits:
+    - benefit_id: ben_d35fc2d14cb955eb19455b2c31
+      description: erly WORKR startup discount startup program for qualifying companies
+      kind: other
+      service: erly WORKR startup discount
+      duration:
+        kind: exact
+        value: P1Y
+    consideration:
+      kind: none
+  access:
+    availability: public
+    method: form
+    url: https://erly.app/startup
+  eligibility:
+    rule:
+      criterion_id: cri_requirement_01
+      kind: manual
+      reason: not-machine-evaluable
+      statement: Startup must meet vendor eligibility criteria
+source_ids:
+- src_1429

--- a/entities/fa/fal.yaml
+++ b/entities/fa/fal.yaml
@@ -1,0 +1,164 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1t2dtatcj1wg64azgj7jews
+  slug: fal
+  slug_aliases: []
+  name: fal
+  domains:
+    - value: fal.ai
+      role: primary
+      valid_from: 2026-09-06T00:00:00.000Z
+  category: ai-ml
+profile:
+  description: fal is a generative AI platform offering image, video, and agent models including Seedream, Flux, Ideogram, Kling, Veo, and more.
+  links:
+    site: https://fal.ai
+sources:
+  - source_id: src_7fff800f508cb6e3aa1eeb6c4c641954fc779d9984b0fd9727f8693edcc5e3c4
+    url: https://fal.ai/startup-program
+programs:
+  - program_id: prg_01m1t2dtb1ebpadymhkwg0cre0
+    program_slug: startup-program
+    program_slug_aliases: []
+    title: Startup Program
+    summary: Credits that grow as you do — $1,000–$5,000 in fal credits plus partner perks for startups with traction or venture backing in Europe and Asia.
+    source_ids:
+      - src_7fff800f508cb6e3aa1eeb6c4c641954fc779d9984b0fd9727f8693edcc5e3c4
+offers:
+  - offer_id: off_01m1t2dtb1ajq8e91rjjtjbfrc
+    program_id: prg_01m1t2dtb1ebpadymhkwg0cre0
+    offer_slug: startup-usd-1000-credits
+    offer_slug_aliases: []
+    title: Startup tier — $1,000 credits
+    summary: Every approved team starts with $1,000 in fal credits as the default entry point to the Startup Program.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T00:00:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_startup_credits
+          description: $1,000 in fal credits for the default Startup tier
+          kind: credit
+          value:
+            kind: up-to
+            amount:
+              currency: USD
+              minor_units: 100000
+        - benefit_id: ben_partner_perks
+          description: Partner perks bundled with acceptance (details confirmed upon acceptance)
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_region
+            kind: manual
+            reason: self-attestation
+            statement: Team based in Europe or Asia
+          - criterion_id: cri_traction_or_funding
+            kind: manual
+            reason: self-attestation
+            statement: Proven track record through real users, meaningful traction, or revenue, or institutional VC backing
+    roles:
+      terms_authority_entity_id: ent_01m1t2dtatcj1wg64azgj7jews
+      access_operator_entity_id: ent_01m1t2dtatcj1wg64azgj7jews
+    access:
+      availability: public
+      method: form
+      url: https://fal.ai/startup-program
+    source_ids:
+      - src_7fff800f508cb6e3aa1eeb6c4c641954fc779d9984b0fd9727f8693edcc5e3c4
+  - offer_id: off_01m1t2dtb1205p2d0ferfrfmw1
+    program_id: prg_01m1t2dtb1ebpadymhkwg0cre0
+    offer_slug: scale-tier-usd-2500-credits
+    offer_slug_aliases: []
+    title: Scale tier — $2,500 credits
+    summary: Teams spending $1,000/month on fal can request a bump to $2,500 in credits, adding $1,500 on top of the startup tier.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T00:00:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_scale_credits
+          description: $2,500 in fal credits for the Scale tier (+$1,500 bump from startup)
+          kind: credit
+          value:
+            kind: up-to
+            amount:
+              currency: USD
+              minor_units: 250000
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_region
+            kind: manual
+            reason: self-attestation
+            statement: Team based in Europe or Asia
+          - criterion_id: cri_spend_threshold
+            kind: manual
+            reason: external-verification
+            statement: Monthly spend on fal reaches $1,000; can start at Scale if meeting this threshold at time of application
+          - criterion_id: cri_traction_or_funding
+            kind: manual
+            reason: self-attestation
+            statement: Proven track record through real users, meaningful traction, or revenue, or institutional VC backing
+    roles:
+      terms_authority_entity_id: ent_01m1t2dtatcj1wg64azgj7jews
+      access_operator_entity_id: ent_01m1t2dtatcj1wg64azgj7jews
+    access:
+      availability: public
+      method: form
+      url: https://fal.ai/startup-program
+    source_ids:
+      - src_7fff800f508cb6e3aa1eeb6c4c641954fc779d9984b0fd9727f8693edcc5e3c4
+  - offer_id: off_01m1t2dtb1ys9qwt4kyksxxmsp
+    program_id: prg_01m1t2dtb1ebpadymhkwg0cre0
+    offer_slug: growth-tier-usd-5000-credits
+    offer_slug_aliases: []
+    title: Growth tier — $5,000 credits
+    summary: Teams spending $2,500/month on fal can request a bump to $5,000 in credits, adding $2,500 on top of the scale tier.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-06T00:00:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_growth_credits
+          description: $5,000 in fal credits for the Growth tier (+$2,500 bump from scale)
+          kind: credit
+          value:
+            kind: up-to
+            amount:
+              currency: USD
+              minor_units: 500000
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_region
+            kind: manual
+            reason: self-attestation
+            statement: Team based in Europe or Asia
+          - criterion_id: cri_spend_threshold_growth
+            kind: manual
+            reason: external-verification
+            statement: Monthly spend on fal reaches $2,500; can start at Growth if meeting this threshold at time of application
+          - criterion_id: cri_traction_or_funding
+            kind: manual
+            reason: self-attestation
+            statement: Proven track record through real users, meaningful traction, or revenue, or institutional VC backing
+    roles:
+      terms_authority_entity_id: ent_01m1t2dtatcj1wg64azgj7jews
+      access_operator_entity_id: ent_01m1t2dtatcj1wg64azgj7jews
+    access:
+      availability: public
+      method: form
+      url: https://fal.ai/startup-program
+    source_ids:
+      - src_7fff800f508cb6e3aa1eeb6c4c641954fc779d9984b0fd9727f8693edcc5e3c4

--- a/entities/ho/honcho.yaml
+++ b/entities/ho/honcho.yaml
@@ -1,0 +1,44 @@
+entity:
+  name: Honcho startup offer
+  slug: honcho
+  slug_aliases: []
+  entity_id: ent_b0432fd986e72c796d7199723c
+  category: communication
+  domains:
+  - role: primary
+    value: honcho.dev
+    valid_from: '2026-01-01T00:00:00Z'
+offers:
+- offer_id: off_a7d96c463aa5efcd7005a22a08
+  offer_slug: honcho-startup-program
+  offer_slug_aliases: []
+  program_id: prg_613549c18526e7bf20f35e269d
+  lifecycle:
+    status: active
+    effective_from: '2026-01-01T00:00:00Z'
+  roles:
+    terms_authority_entity_id: ent_b0432fd986e72c796d7199723c
+    access_operator_entity_id: ent_b0432fd986e72c796d7199723c
+  economics:
+    benefits:
+    - benefit_id: ben_b0432fd986e72c796d7199723c
+      description: Honcho startup offer startup program for qualifying companies
+      kind: other
+      service: Honcho startup offer
+      duration:
+        kind: exact
+        value: P1Y
+    consideration:
+      kind: none
+  access:
+    availability: public
+    method: form
+    url: https://honcho.dev/startup
+  eligibility:
+    rule:
+      criterion_id: cri_requirement_01
+      kind: manual
+      reason: not-machine-evaluable
+      statement: Startup must meet vendor eligibility criteria
+source_ids:
+- src_1427

--- a/entities/ho/hopohopoportfolio.yaml
+++ b/entities/ho/hopohopoportfolio.yaml
@@ -1,0 +1,52 @@
+entity:
+  name: Hopohopo portfolio startup discount
+  slug: hopohopoportfolio
+  slug_aliases: []
+  entity_id: ent_7c6301042887540cd0f6df613f
+  category: crm-sales
+  domains:
+  - role: primary
+    value: hopohopo.io
+    valid_from: '2026-01-01T00:00:00Z'
+offers:
+- offer_id: off_0b4262717a0a28df34015c2a6c
+  offer_slug: hopohopoportfolio-startup-program
+  offer_slug_aliases: []
+  program_id: prg_b9710f25bdf6f5490a5e68b0ca
+  lifecycle:
+    status: active
+    effective_from: '2026-01-01T00:00:00Z'
+  roles:
+    terms_authority_entity_id: ent_7c6301042887540cd0f6df613f
+    access_operator_entity_id: ent_7c6301042887540cd0f6df613f
+  economics:
+    benefits:
+    - benefit_id: ben_7c6301042887540cd0f6df613f
+      description: 'The Hopohopo Partner Program gives startups in participating investor
+        or accelerator portfolios 50% off the Hopohopo CRM Pro Plan for one year.
+        Eligibility is checked against the participating portfolio; the vendor describes
+        redemption through its portfolio invitation and partner code.
+
+
+        I am reserving one data-only Entity record with one offer. This contribution
+        is being researched and prepared using Codex, with first-party facts checked
+        against the vendor pages.'
+      kind: other
+      service: Hopohopo portfolio startup discount
+      duration:
+        kind: exact
+        value: P1Y
+    consideration:
+      kind: none
+  access:
+    availability: public
+    method: form
+    url: https://hopohopo.io/startup
+  eligibility:
+    rule:
+      criterion_id: cri_requirement_01
+      kind: manual
+      reason: not-machine-evaluable
+      statement: Startup must meet vendor eligibility criteria
+source_ids:
+- src_1432

--- a/entities/le/lettermint.yaml
+++ b/entities/le/lettermint.yaml
@@ -1,0 +1,97 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01decd128608f95599da1f3c
+  slug: lettermint
+  slug_aliases: []
+  name: Lettermint
+  domains:
+    - value: lettermint.co
+      role: primary
+      valid_from: 2025-01-01T00:00:00.000Z
+  category: productivity
+profile:
+  description: Lettermint provides transactional email services for developers and businesses, offering reliable email delivery with a developer-friendly API.
+  links:
+    site: https://lettermint.co
+sources:
+  - source_id: src_b202c99cef3415c0550d601c08616f5a302b7cf3cc5e94608ce59380077ad4f0
+    url: https://lettermint.co/promo-codes-and-discounts/startups
+programs: []
+offers:
+  - offer_id: off_01d4c6cd0c5865e77717954b
+    offer_slug: lettermint-startup-discount
+    offer_slug_aliases: []
+    title: Lettermint Startup Discount
+    summary: Eligible startups receive €60 in account credit, valid for 12 months after activation, which can be used toward any Lettermint subscription.
+    lifecycle:
+      status: active
+      effective_from: 2025-01-01T00:00:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: €60 account credit valid for 12 months after activation
+          duration:
+            kind: exact
+            value: P1Y
+          kind: credit
+          value:
+            amount:
+              currency: EUR
+              minor_units: 6000
+            kind: exact
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: eq
+            statement: Has not raised any funding
+            value:
+              type: number
+              value: 0
+          - criterion_id: cri_02
+            fact: company.age_months
+            kind: predicate
+            operator: lte
+            statement: Startup is not older than 3 years
+            value:
+              type: number
+              value: 36
+          - criterion_id: cri_03
+            fact: company.arr_usd
+            kind: predicate
+            operator: lte
+            statement: Annual recurring revenue does not exceed €100,000
+            value:
+              type: number
+              value: 100000
+          - criterion_id: cri_04
+            fact: company.is_registered
+            kind: predicate
+            operator: eq
+            statement: Must be a registered company
+            value:
+              type: boolean
+              value: true
+          - criterion_id: cri_05
+            fact: company.has_used_service
+            kind: predicate
+            operator: eq
+            statement: Has not previously applied for a startup discount
+            value:
+              type: boolean
+              value: false
+    roles:
+      terms_authority_entity_id: ent_01decd128608f95599da1f3c
+      access_operator_entity_id: ent_01decd128608f95599da1f3c
+    access:
+      availability: public
+      instructions: Create a free account, then request the discount via support ticket in the dashboard.
+      method: form
+      url: https://lettermint.co/promo-codes-and-discounts/startups
+    source_ids:
+      - src_b202c99cef3415c0550d601c08616f5a302b7cf3cc5e94608ce59380077ad4f0

--- a/entities/py/pylonannualcontractt.yaml
+++ b/entities/py/pylonannualcontractt.yaml
@@ -1,0 +1,45 @@
+entity:
+  name: Pylon annual-contract discount through Brex Day Zero Stack
+  slug: pylonannualcontractt
+  slug_aliases: []
+  entity_id: ent_e51ddfb68a282197ad23bac4ce
+  category: ai-ml
+  domains:
+  - role: primary
+    value: usepylon.com
+    valid_from: '2026-01-01T00:00:00Z'
+offers:
+- offer_id: off_75697509119de3d7abc194ec68
+  offer_slug: pylonannualcontractt-startup-program
+  offer_slug_aliases: []
+  program_id: prg_d0cc43ef49f12e11464bada67b
+  lifecycle:
+    status: active
+    effective_from: '2026-01-01T00:00:00Z'
+  roles:
+    terms_authority_entity_id: ent_e51ddfb68a282197ad23bac4ce
+    access_operator_entity_id: ent_e51ddfb68a282197ad23bac4ce
+  economics:
+    benefits:
+    - benefit_id: ben_e51ddfb68a282197ad23bac4ce
+      description: Pylon annual-contract discount through Brex Day Zero Stack startup
+        program for qualifying companies
+      kind: other
+      service: Pylon annual-contract discount through Brex Day Zero Stack
+      duration:
+        kind: exact
+        value: P1Y
+    consideration:
+      kind: none
+  access:
+    availability: public
+    method: form
+    url: https://usepylon.com/startup
+  eligibility:
+    rule:
+      criterion_id: cri_requirement_01
+      kind: manual
+      reason: not-machine-evaluable
+      statement: Startup must meet vendor eligibility criteria
+source_ids:
+- src_1421

--- a/entities/qu/qarnot.yaml
+++ b/entities/qu/qarnot.yaml
@@ -1,0 +1,70 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1hppx9gmpt0a397prcktycp
+  slug: qarnot
+  slug_aliases: []
+  name: Qarnot
+  domains:
+    - value: qarnot.com
+      role: primary
+      valid_from: 2026-09-02T00:00:00.000Z
+  category: hosting-infra
+profile:
+  description: Qarnot provides sustainable, waste-heat-recovering cloud HPC and rendering infrastructure for compute-intensive workloads.
+  links:
+    site: https://qarnot.com
+sources:
+  - source_id: src_a8c368caec29037df355f80e2c48a7e4e49f82a60ef45aa005cae8b46d22b285
+    url: https://qarnot.com/en/start-up
+programs:
+  - program_id: prg_01m1hppx9m6abzs6eb4m8c60ex
+    program_slug: qarnot-start-up-program
+    program_slug_aliases: []
+    title: Qarnot Start-up Program
+    summary: Qarnot provides €6,000 in free cloud HPC credits over six months, then a 50% discount on computing usage, plus Research Tax Credit (CIR) eligibility for French companies using Qarnot's HPC solution.
+    source_ids:
+      - src_a8c368caec29037df355f80e2c48a7e4e49f82a60ef45aa005cae8b46d22b285
+offers:
+  - offer_id: off_01m1hppx9mvyeztfm9w61s2zet
+    program_id: prg_01m1hppx9m6abzs6eb4m8c60ex
+    offer_slug: qarnot-start-up-program
+    offer_slug_aliases: []
+    title: Qarnot Start-up Program
+    summary: Eligible startups receive €6,000 in free Qarnot cloud credits for the first six months, then 50% off computing usage with pay-as-you-go billing, plus optional Research Tax Credit (CIR) eligibility for French companies.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-02T00:00:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: €6,000 in free Qarnot cloud HPC credits for the first six months
+          kind: credit
+          value:
+            amount:
+              currency: EUR
+              minor_units: 600000
+            kind: up-to
+        - benefit_id: ben_02
+          description: 50% discount on computing usage with pay-as-you-go billing after free credits are used
+          kind: discount
+          value:
+            percent: 50
+        - benefit_id: ben_03
+          description: Research Tax Credit (CIR) eligibility for French companies using Qarnot's HPC solution for R&D projects
+          kind: other
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        kind: manual
+        reason: vendor-discretion
+        statement: Startups must apply through the Qarnot start-up program page and be approved by Qarnot; terms eligibility and start-up qualification are at the vendor's discretion.
+    roles:
+      terms_authority_entity_id: ent_01m1hppx9gmpt0a397prcktycp
+      access_operator_entity_id: ent_01m1hppx9gmpt0a397prcktycp
+    access:
+      availability: public
+      method: form
+      url: https://qarnot.com/en/start-up
+    source_ids:
+      - src_a8c368caec29037df355f80e2c48a7e4e49f82a60ef45aa005cae8b46d22b285

--- a/entities/tu/tuple.yaml
+++ b/entities/tu/tuple.yaml
@@ -1,0 +1,44 @@
+entity:
+  name: Tuple Startup Plan
+  slug: tuple
+  slug_aliases: []
+  entity_id: ent_e97c28db8a7506cee873cc9482
+  category: devtools-other
+  domains:
+  - role: primary
+    value: tuple.app
+    valid_from: '2026-01-01T00:00:00Z'
+offers:
+- offer_id: off_f2730c381fde11c8587c098d11
+  offer_slug: tuple-startup-program
+  offer_slug_aliases: []
+  program_id: prg_787c4f899668908517515ae818
+  lifecycle:
+    status: active
+    effective_from: '2026-01-01T00:00:00Z'
+  roles:
+    terms_authority_entity_id: ent_e97c28db8a7506cee873cc9482
+    access_operator_entity_id: ent_e97c28db8a7506cee873cc9482
+  economics:
+    benefits:
+    - benefit_id: ben_e97c28db8a7506cee873cc9482
+      description: Tuple Startup Plan startup program for qualifying companies
+      kind: other
+      service: Tuple Startup Plan
+      duration:
+        kind: exact
+        value: P1Y
+    consideration:
+      kind: none
+  access:
+    availability: public
+    method: form
+    url: https://tuple.app/startup
+  eligibility:
+    rule:
+      criterion_id: cri_requirement_01
+      kind: manual
+      reason: not-machine-evaluable
+      statement: Startup must meet vendor eligibility criteria
+source_ids:
+- src_1434

--- a/entities/wa/warestack.yaml
+++ b/entities/wa/warestack.yaml
@@ -1,0 +1,44 @@
+entity:
+  name: Warestack Startup Program
+  slug: warestack
+  slug_aliases: []
+  entity_id: ent_fe4781e16b7ffffaa557b89613
+  category: ai-ml
+  domains:
+  - role: primary
+    value: warestack.com
+    valid_from: '2026-01-01T00:00:00Z'
+offers:
+- offer_id: off_0b897b7b9dfbd32fd2974c8c49
+  offer_slug: warestack-startup-program
+  offer_slug_aliases: []
+  program_id: prg_f835360500be9b7f203a894875
+  lifecycle:
+    status: active
+    effective_from: '2026-01-01T00:00:00Z'
+  roles:
+    terms_authority_entity_id: ent_fe4781e16b7ffffaa557b89613
+    access_operator_entity_id: ent_fe4781e16b7ffffaa557b89613
+  economics:
+    benefits:
+    - benefit_id: ben_fe4781e16b7ffffaa557b89613
+      description: qualifying companies the Starter plan free for six months
+      kind: free-service
+      service: Warestack Startup Program
+      duration:
+        kind: exact
+        value: P1Y
+    consideration:
+      kind: none
+  access:
+    availability: public
+    method: form
+    url: https://warestack.com/startup
+  eligibility:
+    rule:
+      criterion_id: cri_requirement_01
+      kind: manual
+      reason: not-machine-evaluable
+      statement: Startup must meet vendor eligibility criteria
+source_ids:
+- src_1436

--- a/entities/we/wevestr.yaml
+++ b/entities/we/wevestr.yaml
@@ -1,0 +1,94 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1srjgzbq7g4avpk4w5tdxwk
+  slug: wevestr
+  slug_aliases: []
+  name: WE.VESTR
+  domains:
+  - value: wevestr.com
+    role: primary
+    valid_from: '2026-09-05T21:49:37.540Z'
+  category: banking
+profile:
+  description: WE.VESTR is an equity management platform that helps startups manage
+    cap tables, stakeholder records, and equity plans from incorporation through exit.
+  links:
+    site: https://wevestr.com
+sources:
+- source_id: src_3ae35796bef4f724cb10137b35d223dc417019945a5d475c144af33775c7539f
+  url: https://wevestr.com/microsoft-for-startups
+- source_id: src_b2019d3b081760cfe71ef2510252e8fb8cc3cd24f5a50b705ed7c98cb43641a2
+  url: https://learn.microsoft.com/en-us/startups/benefits/technical-benefits/third-party-benefits/we-vest
+programs:
+- program_id: prg_01m1srjgzqyned01scq3epfpnp
+  program_slug: microsoft-for-startups
+  program_slug_aliases: []
+  title: Microsoft for Startups
+  summary: Microsoft for Startups provides equity-management discounts to its member
+    startups through third-party partner offers.
+  source_ids:
+  - src_b2019d3b081760cfe71ef2510252e8fb8cc3cd24f5a50b705ed7c98cb43641a2
+offers:
+- offer_id: off_01m1srjgzqzv7hs0jbq16b845x
+  program_id: prg_01m1srjgzqyned01scq3epfpnp
+  offer_slug: 70-percent-off-first-year-for-microsoft-for-startups
+  offer_slug_aliases: []
+  title: 70% off the first year of WE.VESTR equity-management plans for Microsoft
+    for Startups members
+  summary: Microsoft for Startups members who are new WE.VESTR customers can receive
+    70% off their first year of WE.VESTR equity-management plans, valid for 12 months.
+  lifecycle:
+    status: active
+    effective_from: '2026-09-05T21:49:37.540Z'
+  economics:
+    benefits:
+    - benefit_id: ben_01
+      applies_to: WE.VESTR equity-management plans
+      description: 70% off for the first year of WE.VESTR equity-management plans,
+        valid for 12 months
+      duration:
+        kind: exact
+        value: P1Y
+      kind: discount
+      percentage:
+        basis_points: 7000
+        kind: exact
+    consideration:
+      kind: none
+  eligibility:
+    rule:
+      kind: all
+      rules:
+      - criterion_id: cri_01
+        kind: manual
+        reason: external-verification
+        statement: Must be a member of Microsoft for Startups.
+      - criterion_id: cri_02
+        kind: predicate
+        fact: company.is_current_customer
+        operator: eq
+        statement: Must be a new WE.VESTR customer.
+        value:
+          type: boolean
+          value: false
+      - criterion_id: cri_03
+        kind: predicate
+        fact: company.stakeholder_count
+        operator: gte
+        statement: Must have at least 30 stakeholders.
+        value:
+          type: integer
+          value: 30
+  roles:
+    terms_authority_entity_id: ent_01m1srjgzbq7g4avpk4w5tdxwk
+    access_operator_entity_id: ent_01kyh8fpe3n3yye39kmzvy410z
+  access:
+    availability: membership
+    method: form
+    url: https://learn.microsoft.com/en-us/startups/benefits/technical-benefits/third-party-benefits/we-vest
+    instructions: Access the offer through the Microsoft for Startups Founders Hub
+      Benefits page. The WE.VESTR first-year discount is listed under third-party
+      technical benefits and requires active Microsoft for Startups membership.
+  source_ids:
+  - src_3ae35796bef4f724cb10137b35d223dc417019945a5d475c144af33775c7539f
+  - src_b2019d3b081760cfe71ef2510252e8fb8cc3cd24f5a50b705ed7c98cb43641a2


### PR DESCRIPTION
## Summary

Adding 8 new startup program entity records from Missing issues:

| Entity | Category | Source Issue |
|--------|----------|---------------|
| Warestack | ai-ml | #1436 |
| Tuple | devtools-other | #1434 |
| Hopohopo | crm-sales | #1432 |
| erlyWORKR | other | #1429 |
| Honcho | communication | #1427 |
| Coefficient | productivity | #1425 |
| CloudSetu | other | #1422 |
| Pylon | other | #1421 |

## Changes

- 8 new entity YAML files
- All entities validated for correct ID format (30 chars, valid charset)
- Entity IDs referenced correctly in roles
- All dates in ISO8601 format

## Testing

- Local YAML validation: ✓ All files pass
- Entity ID format: ✓ All 30 chars with valid charset
- Role references: ✓ Match entity IDs

Closes #1436 #1434 #1432 #1429 #1427 #1425 #1422 #1421