### PR TITLE
data: add Twelve Data Early Stage Program

### DIFF
--- a/entities/tw/twelve-data.yaml
+++ b/entities/tw/twelve-data.yaml
@@ -1,0 +1,93 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1x8xqs1q21e2vscbvtqe4hv
+  slug: twelve-data
+  slug_aliases: []
+  name: Twelve Data
+  domains:
+    - value: twelvedata.com
+      role: primary
+      valid_from: 2026-09-07T06:29:38.000Z
+  category: data-analytics
+profile:
+  summary: Financial market data API platform covering stocks, forex, crypto, funds, fundamentals, and technical indicators.
+  description: Twelve Data provides financial market data APIs for stocks, forex, crypto, funds, fundamentals, and other international market data.
+  links:
+    site: https://twelvedata.com
+sources:
+  - source_id: src_1a669d19481bd3810f9e8686c6c98d29b1cd6be8ba9cf13379ebc3ae269ce1f4
+    url: https://twelvedata.com/startups
+programs:
+  - program_id: prg_01m1x8xqsg4nj3fa4yr0tvfhgx
+    program_slug: early-stage-program
+    program_slug_aliases: []
+    title: Early Stage Program
+    summary: Twelve Data's Early Stage Program gives qualifying startups 20% off Twelve Data plans for 12 months.
+    source_ids:
+      - src_1a669d19481bd3810f9e8686c6c98d29b1cd6be8ba9cf13379ebc3ae269ce1f4
+offers:
+  - offer_id: off_01m1x8xqsgk0j7t549qcnbs8w5
+    program_id: prg_01m1x8xqsg4nj3fa4yr0tvfhgx
+    offer_slug: twenty-percent-off-for-twelve-months
+    offer_slug_aliases: []
+    title: 20% off Twelve Data plans for 12 months
+    summary: Eligible early-stage startups receive 20% off Twelve Data plans for 12 months.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-07T06:29:38.000Z
+    economics:
+      consideration:
+        kind: variable
+        description: The startup pays the remaining discounted price of its selected Twelve Data plan.
+      benefits:
+        - benefit_id: ben_01
+          description: 20% discount on Twelve Data plans for 12 months
+          applies_to: Twelve Data plans
+          duration:
+            kind: exact
+            value: P1Y
+          kind: discount
+          percentage:
+            basis_points: 2000
+            kind: exact
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            fact: company.funding_raised_usd
+            kind: predicate
+            operator: lte
+            statement: Startup has raised up to USD 1 million in funding.
+            value:
+              type: number
+              value: 1000000
+          - criterion_id: cri_02
+            fact: company.age_months
+            kind: predicate
+            operator: lt
+            statement: Startup is less than two years old.
+            value:
+              type: number
+              value: 24
+          - criterion_id: cri_03
+            fact: company.employee_count
+            kind: predicate
+            operator: lte
+            statement: Startup has 10 employees or fewer.
+            value:
+              type: number
+              value: 10
+          - criterion_id: cri_04
+            kind: manual
+            reason: external-verification
+            statement: Applicant must be a legal entity and use the product under the same company domain.
+    roles:
+      terms_authority_entity_id: ent_01m1x8xqs1q21e2vscbvtqe4hv
+      access_operator_entity_id: ent_01m1x8xqs1q21e2vscbvtqe4hv
+    access:
+      availability: public
+      method: form
+      url: https://twelvedata.com/account/perks/2
+    source_ids:
+      - src_1a669d19481bd3810f9e8686c6c98d29b1cd6be8ba9cf13379ebc3ae269ce1f4


### PR DESCRIPTION
## Summary

Adds one new Entity, **Twelve Data** (`entities/tw/twelve-data.yaml`), with the vendor-run **Early Stage Program**: **20% off Twelve Data plans for 12 months**.

Closes #689

## Facts and sourcing

All facts are taken from the single first-party source cited in the record:

- https://twelvedata.com/startups (verified live 2026-09-07)

Published facts captured in structured fields:

- Benefit: "Early-stage startups get 20% off Twelve Data plans for 12 months." → `kind: discount`, `percentage.basis_points: 2000`, `duration: P1Y`
- Eligibility:
  - "Early stage: Up to $1M in funding and less than 2 years old" → `company.funding_raised_usd` lte 1,000,000 and `company.age_months` lt 24
  - "Single structure: Legal entity and same use as domain" → manual external-verification
  - "Small team: 10 employees or less" → `company.employee_count` lte 10
- Access: public application form linked as "Apply now" → https://twelvedata.com/account/perks/2

No invented dollar figures. Closed unmerged priors: #690, #745.

## Checklist

- [x] Data-only PR: exactly one new Entity YAML under `entities/tw/`
- [x] Fresh ULIDs (`ent_`, `prg_`, `off_`) and opaque `src_`
- [x] Category `data-analytics`; `profile.summary` present
- [x] DCO sign-off present
- [x] Entity absent from `upstream/main`; no competing open PRs