### PR TITLE
feat(catalog): add 7 startup program entity records

### DIFF
--- a/entities/cm/cmsaustria.yaml
+++ b/entities/cm/cmsaustria.yaml
@@ -1,0 +1,51 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_2v2kax1m100000000000000000
+  slug: cmsaustria
+  slug_aliases: []
+  name: CMS Austria
+  domains:
+  - value: cms.at
+    role: primary
+    valid_from: '2026-01-01T00:00:00Z'
+  category: legal-compliance
+profile:
+  description: Legal and business support programme for Austrian startups.
+  links:
+    site: https://cms.at
+sources:
+- source_id: src_3e3ab3ed04dff0bfe3a3ba30a8a65d9800f86a8bce2aab3543147d1e79941ed0
+  url: https://cms.at/en/equip
+programs: []
+offers:
+- offer_id: off_2v2kax1m100000000000000000
+  offer_slug: cmsaustria-startup-discount
+  offer_slug_aliases: []
+  title: CMS Austria equIP Startup Programme
+  summary: Access to legal services and business support via equIP.
+  lifecycle:
+    status: active
+    effective_from: '2026-01-01T00:00:00Z'
+  economics:
+    benefits:
+    - benefit_id: ben_01
+      description: Access to legal services and business support via equIP.
+      kind: free-service
+      service: Access to legal services and business support via equIP.
+    consideration:
+      kind: none
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_requirement_01
+      statement: Austrian startups and founders.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_2v2kax1m100000000000000000
+    access_operator_entity_id: ent_2v2kax1m100000000000000000
+  access:
+    availability: public
+    method: form
+    url: https://cms.at/en/equip
+  source_ids:
+  - src_3e3ab3ed04dff0bfe3a3ba30a8a65d9800f86a8bce2aab3543147d1e79941ed0

--- a/entities/cr/crococlick.yaml
+++ b/entities/cr/crococlick.yaml
@@ -1,0 +1,51 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_nt2kax1m100000000000000000
+  slug: crococlick
+  slug_aliases: []
+  name: CrocoClick
+  domains:
+  - value: crococlick.com
+    role: primary
+    valid_from: '2026-01-01T00:00:00Z'
+  category: marketing
+profile:
+  description: Young Enterprise program providing marketing tools access.
+  links:
+    site: https://crococlick.com
+sources:
+- source_id: src_bd8ae09726ee36934ce9211572f8a8a0cb7757d89df4ca5fea85da453912b9d0
+  url: https://crococlick.com
+programs: []
+offers:
+- offer_id: off_nt2kax1m100000000000000000
+  offer_slug: crococlick-startup-discount
+  offer_slug_aliases: []
+  title: CrocoClick Young Enterprise Program
+  summary: Access to CrocoClick marketing platform for young enterprises.
+  lifecycle:
+    status: active
+    effective_from: '2026-01-01T00:00:00Z'
+  economics:
+    benefits:
+    - benefit_id: ben_01
+      description: Access to CrocoClick marketing platform for young enterprises.
+      kind: free-service
+      service: Access to CrocoClick marketing platform for young enterprises.
+    consideration:
+      kind: none
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_requirement_01
+      statement: Young or early-stage enterprises.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_nt2kax1m100000000000000000
+    access_operator_entity_id: ent_nt2kax1m100000000000000000
+  access:
+    availability: public
+    method: form
+    url: https://crococlick.com
+  source_ids:
+  - src_bd8ae09726ee36934ce9211572f8a8a0cb7757d89df4ca5fea85da453912b9d0

--- a/entities/ge/getscreenme.yaml
+++ b/entities/ge/getscreenme.yaml
@@ -1,0 +1,51 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_5v2kax1m100000000000000000
+  slug: getscreenme
+  slug_aliases: []
+  name: Getscreen.me
+  domains:
+  - value: getscreen.me
+    role: primary
+    valid_from: '2026-01-01T00:00:00Z'
+  category: communication
+profile:
+  description: Remote access and screen sharing startup discount.
+  links:
+    site: https://getscreen.me
+sources:
+- source_id: src_26b153d52c2c87f694d961357fb1eb92468c36c1d771d2ce2f2618e33ecda076
+  url: https://getscreen.me/en/pricing/discounts/
+programs: []
+offers:
+- offer_id: off_5v2kax1m100000000000000000
+  offer_slug: getscreenme-startup-discount
+  offer_slug_aliases: []
+  title: Getscreen.me Startup Discount
+  summary: Discount on Getscreen.me remote access platform.
+  lifecycle:
+    status: active
+    effective_from: '2026-01-01T00:00:00Z'
+  economics:
+    benefits:
+    - benefit_id: ben_01
+      description: Discount on Getscreen.me remote access platform.
+      kind: free-service
+      service: Discount on Getscreen.me remote access platform.
+    consideration:
+      kind: none
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_requirement_01
+      statement: Startup companies needing remote access solutions.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_5v2kax1m100000000000000000
+    access_operator_entity_id: ent_5v2kax1m100000000000000000
+  access:
+    availability: public
+    method: form
+    url: https://getscreen.me/en/pricing/discounts/
+  source_ids:
+  - src_26b153d52c2c87f694d961357fb1eb92468c36c1d771d2ce2f2618e33ecda076

--- a/entities/im/imeetify.yaml
+++ b/entities/im/imeetify.yaml
@@ -1,0 +1,51 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_st2kax1m100000000000000000
+  slug: imeetify
+  slug_aliases: []
+  name: iMeetify
+  domains:
+  - value: imeetify.com
+    role: primary
+    valid_from: '2026-01-01T00:00:00Z'
+  category: communication
+profile:
+  description: Startup credits for video conferencing and collaboration platform.
+  links:
+    site: https://imeetify.com
+sources:
+- source_id: src_3be9d0fd697106eba587d0cb4a78f61ade63a11402dc8d10ea9e9644ad01e52d
+  url: https://imeetify.com
+programs: []
+offers:
+- offer_id: off_st2kax1m100000000000000000
+  offer_slug: imeetify-startup-discount
+  offer_slug_aliases: []
+  title: iMeetify Startup Credits
+  summary: Credits toward iMeetify video conferencing platform.
+  lifecycle:
+    status: active
+    effective_from: '2026-01-01T00:00:00Z'
+  economics:
+    benefits:
+    - benefit_id: ben_01
+      description: Credits toward iMeetify video conferencing platform.
+      kind: free-service
+      service: Credits toward iMeetify video conferencing platform.
+    consideration:
+      kind: none
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_requirement_01
+      statement: Qualified startup companies.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_st2kax1m100000000000000000
+    access_operator_entity_id: ent_st2kax1m100000000000000000
+  access:
+    availability: public
+    method: form
+    url: https://imeetify.com
+  source_ids:
+  - src_3be9d0fd697106eba587d0cb4a78f61ade63a11402dc8d10ea9e9644ad01e52d

--- a/entities/le/leadliaison.yaml
+++ b/entities/le/leadliaison.yaml
@@ -1,0 +1,51 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_yt2kax1m100000000000000000
+  slug: leadliaison
+  slug_aliases: []
+  name: Lead Liaison
+  domains:
+  - value: leadliaison.com
+    role: primary
+    valid_from: '2026-01-01T00:00:00Z'
+  category: crm-sales
+profile:
+  description: Seed-stage startup discount for Lead Liaison CRM and sales platform.
+  links:
+    site: https://leadliaison.com
+sources:
+- source_id: src_cfffc265f7e4a9b9252067917388be693599440f026e81989ce5b81058e38f53
+  url: https://www.leadliaison.com/startups/
+programs: []
+offers:
+- offer_id: off_yt2kax1m100000000000000000
+  offer_slug: leadliaison-startup-discount
+  offer_slug_aliases: []
+  title: Lead Liaison Seed-Stage Startup Discount
+  summary: Discounted access to Lead Liaison CRM and sales tools.
+  lifecycle:
+    status: active
+    effective_from: '2026-01-01T00:00:00Z'
+  economics:
+    benefits:
+    - benefit_id: ben_01
+      description: Discounted access to Lead Liaison CRM and sales tools.
+      kind: free-service
+      service: Discounted access to Lead Liaison CRM and sales tools.
+    consideration:
+      kind: none
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_requirement_01
+      statement: Seed-stage startups.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_yt2kax1m100000000000000000
+    access_operator_entity_id: ent_yt2kax1m100000000000000000
+  access:
+    availability: public
+    method: form
+    url: https://www.leadliaison.com/startups/
+  source_ids:
+  - src_cfffc265f7e4a9b9252067917388be693599440f026e81989ce5b81058e38f53

--- a/entities/le/levelui.yaml
+++ b/entities/le/levelui.yaml
@@ -1,0 +1,51 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_jt2kax1m100000000000000000
+  slug: levelui
+  slug_aliases: []
+  name: Level UI
+  domains:
+  - value: levelui.com
+    role: primary
+    valid_from: '2026-01-01T00:00:00Z'
+  category: design
+profile:
+  description: Startup partner discount for Level UI design platform.
+  links:
+    site: https://levelui.com
+sources:
+- source_id: src_4cf400822fc7f8e1f01f2f1a479419014ce89ff2c57538d0fcad70f132d601d0
+  url: https://levelui.com/promotions/startup-partner-discount
+programs: []
+offers:
+- offer_id: off_jt2kax1m100000000000000000
+  offer_slug: levelui-startup-discount
+  offer_slug_aliases: []
+  title: Level UI Startup Partner Discount
+  summary: First project discount on Level UI design platform.
+  lifecycle:
+    status: active
+    effective_from: '2026-01-01T00:00:00Z'
+  economics:
+    benefits:
+    - benefit_id: ben_01
+      description: First project discount on Level UI design platform.
+      kind: free-service
+      service: First project discount on Level UI design platform.
+    consideration:
+      kind: none
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_requirement_01
+      statement: Startups with valid business registration.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_jt2kax1m100000000000000000
+    access_operator_entity_id: ent_jt2kax1m100000000000000000
+  access:
+    availability: public
+    method: form
+    url: https://levelui.com/promotions/startup-partner-discount
+  source_ids:
+  - src_4cf400822fc7f8e1f01f2f1a479419014ce89ff2c57538d0fcad70f132d601d0

--- a/entities/mo/morrisjames.yaml
+++ b/entities/mo/morrisjames.yaml
@@ -1,0 +1,51 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_av2kax1m100000000000000000
+  slug: morrisjames
+  slug_aliases: []
+  name: Morris James LLP
+  domains:
+  - value: morris-james.com
+    role: primary
+    valid_from: '2026-01-01T00:00:00Z'
+  category: legal-compliance
+profile:
+  description: Corporate legal services programme for Delaware startups.
+  links:
+    site: https://morris-james.com
+sources:
+- source_id: src_faa9811b45035bb7c2c3cf6395664f2e918cccce25f3512700bc3ce598c1a7d0
+  url: https://morris-james.com
+programs: []
+offers:
+- offer_id: off_av2kax1m100000000000000000
+  offer_slug: morrisjames-startup-discount
+  offer_slug_aliases: []
+  title: Morris James LLP Start-Up Program
+  summary: Access to corporate legal services at startup-friendly rates.
+  lifecycle:
+    status: active
+    effective_from: '2026-01-01T00:00:00Z'
+  economics:
+    benefits:
+    - benefit_id: ben_01
+      description: Access to corporate legal services at startup-friendly rates.
+      kind: free-service
+      service: Access to corporate legal services at startup-friendly rates.
+    consideration:
+      kind: none
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_requirement_01
+      statement: Startups requiring corporate legal services.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_av2kax1m100000000000000000
+    access_operator_entity_id: ent_av2kax1m100000000000000000
+  access:
+    availability: public
+    method: form
+    url: https://morris-james.com
+  source_ids:
+  - src_faa9811b45035bb7c2c3cf6395664f2e918cccce25f3512700bc3ce598c1a7d0


### PR DESCRIPTION
Add 7 new startup program entity records:
- Level UI (levelui.com) - design - startup partner discount
- CrocoClick (crococlick.com) - marketing - Young Enterprise program
- iMeetify (imeetify.com) - communication - startup credits
- Lead Liaison (leadliaison.com) - CRM/sales - seed-stage discount
- CMS Austria (cms.at) - legal - equIP startup programme
- Getscreen.me (getscreen.me) - communication - startup discount
- Morris James LLP (morris-james.com) - legal - start-up program

Task(s): #1471 #1419 #1417 #1397 #1394 #1390 #1389

Signed-off-by: Lars <agent@larsll.com>