### PR TITLE
feat(catalog): add 31 startup program entity records

### DIFF
--- a/entities/ae/aerospike.yaml
+++ b/entities/ae/aerospike.yaml
@@ -1,0 +1,64 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rt22rp90myqr0axndg1w
+  slug: aerospike
+  slug_aliases: []
+  name: Aerospike
+  domains:
+  - value: aerospike.com
+    role: primary
+    valid_from: '2026-09-06T19:48:40Z'
+  category: databases
+profile:
+  description: Aerospike provides a real-time NoSQL database and data platform optimized
+    for high-performance, high-scale applications.
+  links:
+    site: https://aerospike.com
+sources:
+- source_id: src_0c3c1b7b8195196273f2bf8544a0a89dd4dbdb33d8a567fad28f5f4b0460d32b
+  url: https://aerospike.com/get/cloud-for-startups/
+programs:
+- program_id: prg_cm15c0g7b9pn84v0rm7c9xjq8d
+  program_slug: aerospike-startup-program
+  program_slug_aliases: []
+  title: Aerospike Cloud for Startups
+  summary: Aerospike Cloud for Startups offers early-stage companies USD 300 in credits,
+    10% off public pricing, one day of Solution Architect support, and zero commitment
+    to start.
+  source_ids:
+  - src_0c3c1b7b8195196273f2bf8544a0a89dd4dbdb33d8a567fad28f5f4b0460d32b
+offers:
+- offer_id: off_01m1w3rt3chhkfnr1h3ttkywp7
+  offer_slug: aerospike-cloud-for-startups
+  offer_slug_aliases: []
+  title: Aerospike Cloud for Startups
+  summary: Aerospike Cloud for Startups offers early-stage companies USD 300 in credits,
+    10% off public pricing, one day of Solution Architect support, and zero commitment
+    to start.
+  lifecycle:
+    status: active
+    effective_from: '2026-09-06T19:48:40Z'
+  economics:
+    consideration:
+      kind: variable
+      description: USD 300 in credits plus 10% off public pricing.
+    benefits:
+    - benefit_id: ben_001
+      kind: other
+      description: Startup program discount or credit; specific terms vary by program.
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_requirement_01
+      statement: Must be an early-stage company; zero commitment required to start.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_01m1w3rt22rp90myqr0axndg1w
+    access_operator_entity_id: ent_01m1w3rt22rp90myqr0axndg1w
+  access:
+    availability: public
+    method: form
+    url: https://aerospike.com/get/cloud-for-startups/
+  source_ids:
+  - src_0c3c1b7b8195196273f2bf8544a0a89dd4dbdb33d8a567fad28f5f4b0460d32b
+  program_id: prg_cm15c0g7b9pn84v0rm7c9xjq8d

--- a/entities/ai/air.yaml
+++ b/entities/ai/air.yaml
@@ -1,0 +1,63 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rtqmjhnkz6cnnd6n7wwe
+  slug: air
+  slug_aliases: []
+  name: Air
+  domains:
+  - value: air.inc
+    role: primary
+    valid_from: '2026-09-06T19:48:40Z'
+  category: productivity
+profile:
+  description: Air is a creative operations platform for managing visual content,
+    collaboration, and creative workflows for teams.
+  links:
+    site: https://air.inc
+sources:
+- source_id: src_a73f5186325c366d8cf08b17259664741390b18fcc8cfa151ba416f8b9d4e620
+  url: https://air.inc/startups
+programs:
+- program_id: prg_xr5h61gdpef77ppc6prcec1q6x
+  program_slug: air-startup-program
+  program_slug_aliases: []
+  title: Air Startup Program
+  summary: Eligible partner-network startups receive up to six months free on Air's
+    Business plan, worth up to USD 5,800.
+  source_ids:
+  - src_a73f5186325c366d8cf08b17259664741390b18fcc8cfa151ba416f8b9d4e620
+offers:
+- offer_id: off_01m1w3rtrr81pm3k1969d1ayc1
+  offer_slug: air-startup-program
+  offer_slug_aliases: []
+  title: Air Startup Program
+  summary: Eligible partner-network startups receive up to six months free on Air's
+    Business plan, worth up to USD 5,800.
+  lifecycle:
+    status: active
+    effective_from: '2026-09-06T19:48:40Z'
+  economics:
+    consideration:
+      kind: variable
+      description: Up to six months free on the Business plan, worth up to USD 5,800.
+    benefits:
+    - benefit_id: ben_002
+      kind: other
+      description: Startup program discount or credit; specific terms vary by program.
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_requirement_01
+      statement: Must be part of the partner network; specific partner-network criteria
+        are published on the vendor startup page.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_01m1w3rtqmjhnkz6cnnd6n7wwe
+    access_operator_entity_id: ent_01m1w3rtqmjhnkz6cnnd6n7wwe
+  access:
+    availability: public
+    method: form
+    url: https://air.inc/startups
+  source_ids:
+  - src_a73f5186325c366d8cf08b17259664741390b18fcc8cfa151ba416f8b9d4e620
+  program_id: prg_xr5h61gdpef77ppc6prcec1q6x

--- a/entities/ap/appsmith.yaml
+++ b/entities/ap/appsmith.yaml
@@ -1,0 +1,65 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w5647g1v1635b14h47fkz4
+  slug: appsmith
+  slug_aliases: []
+  name: Appsmith
+  domains:
+  - value: appsmith.com
+    role: primary
+    valid_from: '2026-09-06T20:04:00Z'
+  category: no-code
+profile:
+  description: Appsmith is an open-source low-code platform for building internal
+    tools, management dashboards, and business applications.
+  links:
+    site: https://www.appsmith.com
+sources:
+- source_id: src_87c35e1c74bb8730ca73c99ecec27ebf21eba3fd5519650ce3548b8749bc36e5
+  url: https://www.appsmith.com/startup-program
+programs:
+- program_id: prg_zemnwehgkxfc31gqzkgsdaxgr7
+  program_slug: appsmith-startup-program
+  program_slug_aliases: []
+  title: Appsmith Startup Program
+  summary: Early-stage startups incorporated less than 2 years ago and with less than
+    USD 10 million in funding can receive USD 30,000 in credits valid for 12 months,
+    full Business plan access, and dedicated developer advocate support.
+  source_ids:
+  - src_87c35e1c74bb8730ca73c99ecec27ebf21eba3fd5519650ce3548b8749bc36e5
+offers:
+- offer_id: off_01m1w56480z63pnwwz30g5qfav
+  offer_slug: appsmith-startup-program
+  offer_slug_aliases: []
+  title: Appsmith Startup Program
+  summary: Early-stage startups incorporated less than 2 years ago and with less than
+    USD 10 million in funding can receive USD 30,000 in credits valid for 12 months,
+    full Business plan access, and dedicated developer advocate support.
+  lifecycle:
+    status: active
+    effective_from: '2026-09-06T20:04:00Z'
+  economics:
+    consideration:
+      kind: variable
+      description: USD 30,000 in platform credits, valid for 12 months from acceptance.
+    benefits:
+    - benefit_id: ben_003
+      kind: other
+      description: Startup program discount or credit; specific terms vary by program.
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_requirement_01
+      statement: Must be incorporated less than 2 years ago and have raised less than
+        USD 10 million in funding.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_01m1w5647g1v1635b14h47fkz4
+    access_operator_entity_id: ent_01m1w5647g1v1635b14h47fkz4
+  access:
+    availability: public
+    method: form
+    url: https://www.appsmith.com/startup-program
+  source_ids:
+  - src_87c35e1c74bb8730ca73c99ecec27ebf21eba3fd5519650ce3548b8749bc36e5
+  program_id: prg_zemnwehgkxfc31gqzkgsdaxgr7

--- a/entities/ca/callmissed.yaml
+++ b/entities/ca/callmissed.yaml
@@ -1,0 +1,65 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rs3tqcmt132qbfa3m6zh
+  slug: callmissed
+  slug_aliases: []
+  name: CallMissed
+  domains:
+  - value: callmissed.com
+    role: primary
+    valid_from: '2026-09-06T19:47:36Z'
+  category: communication
+profile:
+  description: CallMissed provides communication APIs and tools for B2C and developer
+    products.
+  links:
+    site: https://www.callmissed.com
+sources:
+- source_id: src_ecedb3b26b36f07662a99743ad54ee7d4cd5d5d3c274c6c6ffcecb734e50d39b
+  url: https://www.callmissed.com/solutions/startups
+programs:
+- program_id: prg_z92dmzjkwzhrat7csb15gdh7da
+  program_slug: callmissed-startup-program
+  program_slug_aliases: []
+  title: CallMissed Startup Credits
+  summary: Qualifying early-stage startups building B2C or developer products in India
+    can apply for USD 1,000 in additional CallMissed API credits, equal to 100,000
+    credits at USD 0.01 each.
+  source_ids:
+  - src_ecedb3b26b36f07662a99743ad54ee7d4cd5d5d3c274c6c6ffcecb734e50d39b
+offers:
+- offer_id: off_01m1w3rs4hdckdds8sssj2hczm
+  offer_slug: callmissed-startup-credits
+  offer_slug_aliases: []
+  title: CallMissed Startup Credits
+  summary: Qualifying early-stage startups building B2C or developer products in India
+    can apply for USD 1,000 in additional CallMissed API credits, equal to 100,000
+    credits at USD 0.01 each.
+  lifecycle:
+    status: active
+    effective_from: '2026-09-06T19:47:36Z'
+  economics:
+    consideration:
+      kind: variable
+      description: USD 1,000 in API credits (100,000 credits at USD 0.01 each).
+    benefits:
+    - benefit_id: ben_004
+      kind: other
+      description: Startup program discount or credit; specific terms vary by program.
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_requirement_01
+      statement: Must be an early-stage startup building B2C or developer products
+        in India.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_01m1w3rs3tqcmt132qbfa3m6zh
+    access_operator_entity_id: ent_01m1w3rs3tqcmt132qbfa3m6zh
+  access:
+    availability: public
+    method: form
+    url: https://www.callmissed.com/solutions/startups
+  source_ids:
+  - src_ecedb3b26b36f07662a99743ad54ee7d4cd5d5d3c274c6c6ffcecb734e50d39b
+  program_id: prg_z92dmzjkwzhrat7csb15gdh7da

--- a/entities/ca/cardboard.yaml
+++ b/entities/ca/cardboard.yaml
@@ -1,0 +1,63 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rwykxphtyxrtjmbz13mn
+  slug: cardboard
+  slug_aliases: []
+  name: Cardboard
+  domains:
+  - value: cardboard.inc
+    role: primary
+    valid_from: '2026-09-06T19:49:38Z'
+  category: other
+profile:
+  description: Cardboard provides software subscription management and procurement
+    tools for businesses.
+  links:
+    site: https://cardboard.inc
+sources:
+- source_id: src_2ccaeb4a55b7e947192dded88a95cf6d7679a60eb8a92d7ce32bdbf632ef4758
+  url: https://cardboard.inc/pricing/
+programs:
+- program_id: prg_40gcct92qa8whencsh70y8hn5f
+  program_slug: cardboard-startup-program
+  program_slug_aliases: []
+  title: Cardboard for Startups
+  summary: Cardboard publishes an automatic 80% discount on its paid plans for companies
+    incorporated less than two years ago. The discount runs for one year from signup.
+  source_ids:
+  - src_2ccaeb4a55b7e947192dded88a95cf6d7679a60eb8a92d7ce32bdbf632ef4758
+offers:
+- offer_id: off_01m1w3rwzj759yhxgew42thh3b
+  offer_slug: cardboard-for-startups-paid-plan-discount
+  offer_slug_aliases: []
+  title: Cardboard for Startups
+  summary: Cardboard publishes an automatic 80% discount on its paid plans for companies
+    incorporated less than two years ago. The discount runs for one year from signup.
+  lifecycle:
+    status: active
+    effective_from: '2026-09-06T19:49:38Z'
+  economics:
+    consideration:
+      kind: variable
+      description: Automatic 80% discount on paid plans for one year from signup.
+    benefits:
+    - benefit_id: ben_005
+      kind: other
+      description: Startup program discount or credit; specific terms vary by program.
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_requirement_01
+      statement: Must be a company incorporated less than two years ago; discount
+        applies automatically upon signup verification.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_01m1w3rwykxphtyxrtjmbz13mn
+    access_operator_entity_id: ent_01m1w3rwykxphtyxrtjmbz13mn
+  access:
+    availability: public
+    method: form
+    url: https://cardboard.inc/campaigns/software-subscriptions/
+  source_ids:
+  - src_2ccaeb4a55b7e947192dded88a95cf6d7679a60eb8a92d7ce32bdbf632ef4758
+  program_id: prg_40gcct92qa8whencsh70y8hn5f

--- a/entities/cl/cloudsetu.yaml
+++ b/entities/cl/cloudsetu.yaml
@@ -1,0 +1,63 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rnyt9q2zk0yym0b80kx3
+  slug: cloudsetu
+  slug_aliases: []
+  name: CloudSetu
+  domains:
+  - value: cloudsetu.com
+    role: primary
+    valid_from: '2026-09-06T19:46:00Z'
+  category: hosting-infra
+profile:
+  description: CloudSetu provides cloud services and infrastructure for businesses
+    and startups in India.
+  links:
+    site: https://cloudsetu.com
+sources:
+- source_id: src_972ec5c7dfd8e22081d8623b990a1687c2589e6c1b9c3dbef7c28c4aab56df89
+  url: https://cloudsetu.com/for-startups
+programs:
+- program_id: prg_5fthxm4zr0yq7as8j6a5gwc7qw
+  program_slug: cloudsetu-startup-program
+  program_slug_aliases: []
+  title: CloudSetu Startup Credits
+  summary: CloudSetu advertises INR 21,000 in cloud credits for qualifying Indian
+    startups.
+  source_ids:
+  - src_972ec5c7dfd8e22081d8623b990a1687c2589e6c1b9c3dbef7c28c4aab56df89
+offers:
+- offer_id: off_01m1w3rnzq9840r73ts9evntbe
+  offer_slug: cloudsetu-startup-credits
+  offer_slug_aliases: []
+  title: CloudSetu Startup Credits
+  summary: CloudSetu advertises INR 21,000 in cloud credits for qualifying Indian
+    startups.
+  lifecycle:
+    status: active
+    effective_from: '2026-09-06T19:46:00Z'
+  economics:
+    consideration:
+      kind: variable
+      description: INR 21,000 in cloud credits for qualifying Indian startups.
+    benefits:
+    - benefit_id: ben_006
+      kind: other
+      description: Startup program discount or credit; specific terms vary by program.
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_requirement_01
+      statement: Must be a qualifying Indian startup; specific criteria are published
+        on the vendor startup page.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_01m1w3rnyt9q2zk0yym0b80kx3
+    access_operator_entity_id: ent_01m1w3rnyt9q2zk0yym0b80kx3
+  access:
+    availability: public
+    method: form
+    url: https://cloudsetu.com/for-startups
+  source_ids:
+  - src_972ec5c7dfd8e22081d8623b990a1687c2589e6c1b9c3dbef7c28c4aab56df89
+  program_id: prg_5fthxm4zr0yq7as8j6a5gwc7qw

--- a/entities/cm/cms-austria.yaml
+++ b/entities/cm/cms-austria.yaml
@@ -1,0 +1,66 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rgf4php658j5fpkdn73f
+  slug: cms-austria
+  slug_aliases: []
+  name: CMS Reich-Rohrwig Hainz Rechtsanwälte GmbH
+  domains:
+  - value: cms.law
+    role: primary
+    valid_from: '2026-09-06T19:43:48Z'
+  category: legal-compliance
+profile:
+  description: CMS Reich-Rohrwig Hainz is a full-service commercial law firm in Austria
+    offering legal services to businesses and startups.
+  links:
+    site: https://cms.law/en/aut
+sources:
+- source_id: src_76ded3be8a8db7e5e2b8adba038b1118cc025820da427e4d6a12c7e87353613c
+  url: https://cms.law/en/aut/insight/start-ups/cms-equip-membership
+programs:
+- program_id: prg_wvshv64v3frksvkqn507h4ck1s
+  program_slug: cms-austria-startup-program
+  program_slug_aliases: []
+  title: CMS equIP Austria
+  summary: Accepted startup members receive 50% off standard hourly legal rates for
+    three years, up to EUR 25,000 discount per year. Application and acceptance are
+    required.
+  source_ids:
+  - src_76ded3be8a8db7e5e2b8adba038b1118cc025820da427e4d6a12c7e87353613c
+offers:
+- offer_id: off_01m1w3rgfffmyxtbn1xmat0wcb
+  offer_slug: cms-equip-austria-startup-programme
+  offer_slug_aliases: []
+  title: CMS equIP Austria
+  summary: Accepted startup members receive 50% off standard hourly legal rates for
+    three years, up to EUR 25,000 discount per year. Application and acceptance are
+    required.
+  lifecycle:
+    status: active
+    effective_from: '2026-09-06T19:43:48Z'
+  economics:
+    consideration:
+      kind: variable
+      description: 50% off standard hourly legal rates for three years, capped at
+        EUR 25,000 discount per year.
+    benefits:
+    - benefit_id: ben_007
+      kind: other
+      description: Startup program discount or credit; specific terms vary by program.
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_requirement_01
+      statement: Must be an eligible startup and complete the equIP application process;
+        acceptance is required.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_01m1w3rgf4php658j5fpkdn73f
+    access_operator_entity_id: ent_01m1w3rgf4php658j5fpkdn73f
+  access:
+    availability: public
+    method: form
+    url: https://cms.law/content/download/486373/file/Application_Form_EquIP_2026.pdf
+  source_ids:
+  - src_76ded3be8a8db7e5e2b8adba038b1118cc025820da427e4d6a12c7e87353613c
+  program_id: prg_wvshv64v3frksvkqn507h4ck1s

--- a/entities/co/coefficient.yaml
+++ b/entities/co/coefficient.yaml
@@ -1,0 +1,65 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3retaxb22rx20cg7mtvgw
+  slug: coefficient
+  slug_aliases: []
+  name: Coefficient
+  domains:
+  - value: coefficient.io
+    role: primary
+    valid_from: '2026-09-06T19:42:47Z'
+  category: finance-accounting
+profile:
+  description: Coefficient provides a live data platform connecting spreadsheets to
+    real-time business data from SaaS tools and databases.
+  links:
+    site: https://coefficient.io
+sources:
+- source_id: src_29d7963ea1a24691193b60d585278f1fcbe5b6c654d03727a41e0d7487c1b557
+  url: https://coefficient.io/startup
+programs:
+- program_id: prg_7maesy18b1war7c6xvdpz8h588
+  program_slug: coefficient-startup-program
+  program_slug_aliases: []
+  title: Coefficient for Startups
+  summary: Coefficient for Startups offers up to 50% off for the first year, with
+    published eligibility requiring USD 20 million or less raised, bootstrapped/angel-funded/debt-funded/pre-seed/seed/Series
+    A status, and 25 or fewer employees.
+  source_ids:
+  - src_29d7963ea1a24691193b60d585278f1fcbe5b6c654d03727a41e0d7487c1b557
+offers:
+- offer_id: off_01m1w3retfq7w3synrc2v19s71
+  offer_slug: coefficient-for-startups
+  offer_slug_aliases: []
+  title: Coefficient for Startups
+  summary: Coefficient for Startups offers up to 50% off for the first year, with
+    published eligibility requiring USD 20 million or less raised, bootstrapped/angel-funded/debt-funded/pre-seed/seed/Series
+    A status, and 25 or fewer employees.
+  lifecycle:
+    status: active
+    effective_from: '2026-09-06T19:42:47Z'
+  economics:
+    consideration:
+      kind: variable
+      description: Up to 50% off for the first year.
+    benefits:
+    - benefit_id: ben_008
+      kind: other
+      description: Startup program discount or credit; specific terms vary by program.
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_requirement_01
+      statement: Must have raised USD 20 million or less, be in bootstrapped/angel-funded/debt-funded/pre-seed/seed/Series
+        A status, and have 25 or fewer employees.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_01m1w3retaxb22rx20cg7mtvgw
+    access_operator_entity_id: ent_01m1w3retaxb22rx20cg7mtvgw
+  access:
+    availability: public
+    method: form
+    url: https://coefficient.io/startup
+  source_ids:
+  - src_29d7963ea1a24691193b60d585278f1fcbe5b6c654d03727a41e0d7487c1b557
+  program_id: prg_7maesy18b1war7c6xvdpz8h588

--- a/entities/cr/cribl.yaml
+++ b/entities/cr/cribl.yaml
@@ -1,0 +1,66 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w5cscwqfjcckfyspvfjz0q
+  slug: cribl
+  slug_aliases: []
+  name: Cribl
+  domains:
+  - value: cribl.io
+    role: primary
+    valid_from: '2026-09-06T20:08:43Z'
+  category: observability
+profile:
+  description: Cribl provides a data processing and observability platform that enables
+    organizations to collect, process, and route machine data from any source to any
+    destination.
+  links:
+    site: https://cribl.io
+sources:
+- source_id: src_0e725493674efa9f35b17ae7eea3af9bf967e81eea63febe2c1bd0269624965d
+  url: https://cribl.io/startup/
+offers:
+- offer_id: off_01m1w5csdk1r1t8e05v4fd3rmx
+  offer_slug: cribl-for-startups
+  offer_slug_aliases: []
+  title: Cribl for Startups
+  summary: Seed-through-Series-A companies building monitoring, observability, cybersecurity,
+    or DevOps data solutions can receive free Cribl.Cloud access including Cribl Stream
+    and Cribl Search, hands-on technical advice, and access to Cribl's par...
+  lifecycle:
+    status: active
+    effective_from: '2026-09-06T20:08:43Z'
+  economics:
+    consideration:
+      kind: variable
+      description: Discounted startup pricing.
+    benefits:
+    - benefit_id: ben_001
+      kind: other
+      description: Startup program discount or credit.
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_requirement_01
+      statement: Must be a Seed-through-Series-A company building monitoring, observability,
+        cybersecurity, or DevOps data solutions; selection is made by Cribl.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_01m1w5cscwqfjcckfyspvfjz0q
+    access_operator_entity_id: ent_01m1w5cscwqfjcckfyspvfjz0q
+  access:
+    availability: public
+    method: form
+    url: https://cribl.io/startup/
+  source_ids:
+  - src_0e725493674efa9f35b17ae7eea3af9bf967e81eea63febe2c1bd0269624965d
+  program_id: prg_tcvahef19y04kzr0ny5skqh4pj
+programs:
+- program_id: prg_tcvahef19y04kzr0ny5skqh4pj
+  program_slug: cribl-startup-program
+  program_slug_aliases: []
+  title: Cribl for Startups
+  summary: Seed-through-Series-A companies building monitoring, observability, cybersecurity,
+    or DevOps data solutions can receive free Cribl.Cloud access including Cribl Stream
+    and Cribl Search, hands-on technical advice, and access to Cribl's par...
+  source_ids:
+  - src_0e725493674efa9f35b17ae7eea3af9bf967e81eea63febe2c1bd0269624965d

--- a/entities/cr/crococlick.yaml
+++ b/entities/cr/crococlick.yaml
@@ -1,0 +1,83 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w4360shgqqm3gv6948340s
+  slug: crococlick
+  slug_aliases: []
+  name: CrocoClick
+  domains:
+  - value: crococlick.com
+    role: primary
+    valid_from: '2026-09-06T19:46:41.281Z'
+  category: productivity
+profile:
+  description: CrocoClick provides productivity and collaboration tools for businesses
+    and teams.
+  links:
+    site: https://crococlick.com
+sources:
+- source_id: src_b9d2ec5e99697104baf658cbe8c618dc22f6afc9a233b2528e2a3158f653cbc6
+  url: https://help.crococlick.com/articles/0820414-crococlick-startup-program
+programs:
+- program_id: prg_7vd8sm43m8yh225exmw0waa1hh
+  program_slug: crococlick-startup-program
+  program_slug_aliases: []
+  title: Young Enterprise Program - Tiered Discount
+  summary: 'The Young Enterprise program offers qualifying companies discounted UNLIMITED
+    access for three years: 86% in year one, 70% in year two, and 50% in year three.'
+  source_ids:
+  - src_b9d2ec5e99697104baf658cbe8c618dc22f6afc9a233b2528e2a3158f653cbc6
+offers:
+- offer_id: off_01m1w43614zak99pgrtns3gc9x
+  program_id: prg_7vd8sm43m8yh225exmw0waa1hh
+  offer_slug: young-enterprise-program-tiered-discount
+  offer_slug_aliases: []
+  title: Young Enterprise Program - Tiered Discount
+  summary: 'The Young Enterprise program offers qualifying companies discounted UNLIMITED
+    access for three years: 86% in year one, 70% in year two, and 50% in year three.'
+  lifecycle:
+    status: active
+    effective_from: '2026-09-06T19:46:41.281Z'
+  economics:
+    consideration:
+      kind: none
+    benefits:
+    - benefit_id: ben_009
+      kind: other
+      description: Startup program discount or credit; specific terms vary by program.
+  eligibility:
+    rule:
+      kind: all
+      rules:
+      - criterion_id: cri_age
+        fact: company.age_months
+        kind: predicate
+        operator: lte
+        value:
+          type: number
+          value: 12
+        statement: Company is under 12 months old.
+      - criterion_id: cri_revenue
+        fact: company.annual_revenue_usd
+        kind: predicate
+        operator: lt
+        value:
+          type: number
+          value: 25000
+        statement: Company has less than EUR 25,000 in revenue.
+      - criterion_id: cri_not_previous
+        fact: company.is_current_customer
+        kind: predicate
+        operator: eq
+        value:
+          type: boolean
+          value: false
+        statement: No previous paid CrocoClick subscription.
+  roles:
+    terms_authority_entity_id: ent_01m1w4360shgqqm3gv6948340s
+    access_operator_entity_id: ent_01m1w4360shgqqm3gv6948340s
+  access:
+    availability: public
+    method: form
+    url: https://help.crococlick.com/articles/0820414-crococlick-startup-program
+  source_ids:
+  - src_b9d2ec5e99697104baf658cbe8c618dc22f6afc9a233b2528e2a3158f653cbc6

--- a/entities/cy/cyberport.yaml
+++ b/entities/cy/cyberport.yaml
@@ -1,0 +1,67 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rmnnzpnnjhw8x872jx9q
+  slug: cyberport
+  slug_aliases: []
+  name: Cyberport
+  domains:
+  - value: cyberport.hk
+    role: primary
+    valid_from: '2026-09-06T19:46:00Z'
+  category: other
+profile:
+  description: Cyberport is a digital technology hub in Hong Kong supporting tech
+    entrepreneurs and startups with infrastructure, mentorship, and community programs.
+  links:
+    site: https://www.cyberport.hk
+sources:
+- source_id: src_525507854119df43ea3bea9b1daebc6ff65356006050516474610d03faeec891
+  url: https://www.cyberport.hk/en/entrepreneurship/hong_kong_programme/
+programs:
+- program_id: prg_jvjsk7ney8ytcqchxwjnep0xth
+  program_slug: cyberport-startup-program
+  program_slug_aliases: []
+  title: Cyberport CCMF Hong Kong Programme
+  summary: A startup-specific cash grant for digital technology projects at the idea
+    or early development stage. The official page lists up to HKD 100,000 over six
+    months, subject to selection and reporting milestones.
+  source_ids:
+  - src_525507854119df43ea3bea9b1daebc6ff65356006050516474610d03faeec891
+offers:
+- offer_id: off_01m1w3rmqhajavyw47a3yxtc0p
+  offer_slug: ccmf-hong-kong-programme
+  offer_slug_aliases: []
+  title: Cyberport CCMF Hong Kong Programme
+  summary: A startup-specific cash grant for digital technology projects at the idea
+    or early development stage. The official page lists up to HKD 100,000 over six
+    months, subject to selection and reporting milestones.
+  lifecycle:
+    status: active
+    effective_from: '2026-09-06T19:46:00Z'
+  economics:
+    consideration:
+      kind: variable
+      description: Up to HKD 100,000 cash grant over six months for digital technology
+        projects.
+    benefits:
+    - benefit_id: ben_010
+      kind: other
+      description: Startup program discount or credit; specific terms vary by program.
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_requirement_01
+      statement: Must be at the idea or early development stage for a digital technology
+        project; individual and company eligibility routes apply; restrictions on
+        overlapping programmes apply.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_01m1w3rmnnzpnnjhw8x872jx9q
+    access_operator_entity_id: ent_01m1w3rmnnzpnnjhw8x872jx9q
+  access:
+    availability: public
+    method: form
+    url: https://www.cyberport.hk/en/entrepreneurship/hong_kong_programme/
+  source_ids:
+  - src_525507854119df43ea3bea9b1daebc6ff65356006050516474610d03faeec891
+  program_id: prg_jvjsk7ney8ytcqchxwjnep0xth

--- a/entities/en/enterprise-singapore.yaml
+++ b/entities/en/enterprise-singapore.yaml
@@ -1,0 +1,65 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rhdnajvn1kfpywg4nm7k
+  slug: enterprise-singapore
+  slug_aliases: []
+  name: Enterprise Singapore
+  domains:
+  - value: enterprisesg.gov.sg
+    role: primary
+    valid_from: '2026-09-06T19:45:10Z'
+  category: other
+profile:
+  description: Enterprise Singapore is a government agency supporting Singapore enterprises,
+    promoting entrepreneurship and business growth.
+  links:
+    site: https://www.enterprisesg.gov.sg
+sources:
+- source_id: src_ef81664c02cde7da07db7d711405406806710228f9d4cc174117760907e0387b
+  url: https://www.startupsg.gov.sg/programmes/4894/startup-sg-founder
+programs:
+- program_id: prg_ryghwcer6kagvrsymk3sskn13y
+  program_slug: enterprise-singapore-startup-program
+  program_slug_aliases: []
+  title: Startup SG Founder
+  summary: Startup SG Founder is a SGD 20,000-50,000 grant with 1:1 capital co-matching
+    and Accredited Mentor Partner support for eligible first-time Singaporean or permanent-resident
+    founders.
+  source_ids:
+  - src_ef81664c02cde7da07db7d711405406806710228f9d4cc174117760907e0387b
+offers:
+- offer_id: off_01m1w3rhdwe745cgktykx3r67c
+  offer_slug: startup-sg-founder
+  offer_slug_aliases: []
+  title: Startup SG Founder
+  summary: Startup SG Founder is a SGD 20,000-50,000 grant with 1:1 capital co-matching
+    and Accredited Mentor Partner support for eligible first-time Singaporean or permanent-resident
+    founders.
+  lifecycle:
+    status: active
+    effective_from: '2026-09-06T19:45:10Z'
+  economics:
+    consideration:
+      kind: variable
+      description: SGD 20,000-50,000 grant with 1:1 capital co-matching.
+    benefits:
+    - benefit_id: ben_014
+      kind: other
+      description: Startup program discount or credit; specific terms vary by program.
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_requirement_01
+      statement: Must be a first-time Singaporean or permanent-resident founder; additional
+        eligibility criteria are published on the Startup SG Founder page.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_01m1w3rhdnajvn1kfpywg4nm7k
+    access_operator_entity_id: ent_01m1w3rhdnajvn1kfpywg4nm7k
+  access:
+    availability: public
+    method: form
+    url: https://www.startupsg.gov.sg/programmes/4894/startup-sg-founder/eligibility
+  source_ids:
+  - src_ef81664c02cde7da07db7d711405406806710228f9d4cc174117760907e0387b
+  program_id: prg_ryghwcer6kagvrsymk3sskn13y

--- a/entities/fl/flawtrack.yaml
+++ b/entities/fl/flawtrack.yaml
@@ -1,0 +1,62 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rj61fd3dc49cag9v75pm
+  slug: flawtrack
+  slug_aliases: []
+  name: Flawtrack
+  domains:
+  - value: flawtrack.com
+    role: primary
+    valid_from: '2026-09-06T19:45:10Z'
+  category: observability
+profile:
+  description: Flawtrack provides software reliability and error tracking tools for
+    development teams.
+  links:
+    site: https://www.flawtrack.com
+sources:
+- source_id: src_e749af39fad0f77742d6f58028121307392c317931efa7acf9a5a1422708728d
+  url: https://www.flawtrack.com/segments/startups
+programs:
+- program_id: prg_0hyqy9qgcpzaeazjf3xr7dkn90
+  program_slug: flawtrack-startup-program
+  program_slug_aliases: []
+  title: Flawtrack Funded Startup Discount
+  summary: The vendor advertises a 90% discount for funded startups at Series A and
+    beyond. Duration and base pricing are not published on the source page.
+  source_ids:
+  - src_e749af39fad0f77742d6f58028121307392c317931efa7acf9a5a1422708728d
+offers:
+- offer_id: off_01m1w3rj73br9z8vafba7nxfn0
+  offer_slug: flawtrack-funded-startup-discount
+  offer_slug_aliases: []
+  title: Flawtrack Funded Startup Discount
+  summary: The vendor advertises a 90% discount for funded startups at Series A and
+    beyond. Duration and base pricing are not published on the source page.
+  lifecycle:
+    status: active
+    effective_from: '2026-09-06T19:45:10Z'
+  economics:
+    consideration:
+      kind: variable
+      description: 90% discount for funded startups at Series A and beyond.
+    benefits:
+    - benefit_id: ben_015
+      kind: other
+      description: Startup program discount or credit; specific terms vary by program.
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_requirement_01
+      statement: Must be a funded startup at Series A or beyond stage.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_01m1w3rj61fd3dc49cag9v75pm
+    access_operator_entity_id: ent_01m1w3rj61fd3dc49cag9v75pm
+  access:
+    availability: public
+    method: form
+    url: https://www.flawtrack.com/contact
+  source_ids:
+  - src_e749af39fad0f77742d6f58028121307392c317931efa7acf9a5a1422708728d
+  program_id: prg_0hyqy9qgcpzaeazjf3xr7dkn90

--- a/entities/ge/getscreen-me.yaml
+++ b/entities/ge/getscreen-me.yaml
@@ -1,0 +1,62 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rgq51y3mv4q532jmd87h
+  slug: getscreen-me
+  slug_aliases: []
+  name: Getscreen.me
+  domains:
+  - value: getscreen.me
+    role: primary
+    valid_from: '2026-09-06T19:43:48Z'
+  category: communication
+profile:
+  description: Getscreen.me provides remote access and screen sharing solutions for
+    individuals and teams.
+  links:
+    site: https://getscreen.me
+sources:
+- source_id: src_c35cf9c08df20d8705a5ee996a7305c6a95005494409bab26110d5182766900d
+  url: https://getscreen.me/en/pricing/discounts/
+programs:
+- program_id: prg_zbfwmb6g5jv9k19j055wgqmmjc
+  program_slug: getscreen-me-startup-program
+  program_slug_aliases: []
+  title: Getscreen.me Startup Discount
+  summary: Getscreen.me publishes a startup-specific discount of up to 25% on business
+    subscriptions for private commercial companies less than five years old.
+  source_ids:
+  - src_c35cf9c08df20d8705a5ee996a7305c6a95005494409bab26110d5182766900d
+offers:
+- offer_id: off_01m1w3rgqcesbctrfd10gc3vds
+  offer_slug: getscreen-me-startup-discount
+  offer_slug_aliases: []
+  title: Getscreen.me Startup Discount
+  summary: Getscreen.me publishes a startup-specific discount of up to 25% on business
+    subscriptions for private commercial companies less than five years old.
+  lifecycle:
+    status: active
+    effective_from: '2026-09-06T19:43:48Z'
+  economics:
+    consideration:
+      kind: variable
+      description: Up to 25% discount on business subscriptions.
+    benefits:
+    - benefit_id: ben_016
+      kind: other
+      description: Startup program discount or credit; specific terms vary by program.
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_requirement_01
+      statement: Must be a private commercial company less than five years old.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_01m1w3rgq51y3mv4q532jmd87h
+    access_operator_entity_id: ent_01m1w3rgq51y3mv4q532jmd87h
+  access:
+    availability: public
+    method: form
+    url: https://getscreen.me/en/pricing/discounts/
+  source_ids:
+  - src_c35cf9c08df20d8705a5ee996a7305c6a95005494409bab26110d5182766900d
+  program_id: prg_zbfwmb6g5jv9k19j055wgqmmjc

--- a/entities/ho/honcho.yaml
+++ b/entities/ho/honcho.yaml
@@ -1,0 +1,62 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rehgj50ky9mh2r5an0pd
+  slug: honcho
+  slug_aliases: []
+  name: Honcho
+  domains:
+  - value: honcho.dev
+    role: primary
+    valid_from: '2026-09-06T19:42:47Z'
+  category: ai-ml
+profile:
+  description: Honcho is a platform that helps businesses deploy and manage AI agents
+    and applications.
+  links:
+    site: https://honcho.dev
+sources:
+- source_id: src_02fb1fc3329d38a9961e41f6fe41e22f458814ceb8dd77a0ef4024d19fa08b1a
+  url: https://honcho.dev
+programs:
+- program_id: prg_q77dhmzkg6jrarvgyh08dsrpz5
+  program_slug: honcho-startup-program
+  program_slug_aliases: []
+  title: Honcho Startup Offer
+  summary: Startups with less than USD 5 million raised can apply for USD 1,000 in
+    credits, 12 months of subsidized pricing, and integration support.
+  source_ids:
+  - src_02fb1fc3329d38a9961e41f6fe41e22f458814ceb8dd77a0ef4024d19fa08b1a
+offers:
+- offer_id: off_01m1w3rej7kp98xqre8e5pxsdn
+  offer_slug: honcho-startup-offer
+  offer_slug_aliases: []
+  title: Honcho Startup Offer
+  summary: Startups with less than USD 5 million raised can apply for USD 1,000 in
+    credits, 12 months of subsidized pricing, and integration support.
+  lifecycle:
+    status: active
+    effective_from: '2026-09-06T19:42:47Z'
+  economics:
+    consideration:
+      kind: variable
+      description: USD 1,000 in platform credits plus 12 months of subsidized pricing.
+    benefits:
+    - benefit_id: ben_017
+      kind: other
+      description: Startup program discount or credit; specific terms vary by program.
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_requirement_01
+      statement: Must have raised less than USD 5 million.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_01m1w3rehgj50ky9mh2r5an0pd
+    access_operator_entity_id: ent_01m1w3rehgj50ky9mh2r5an0pd
+  access:
+    availability: public
+    method: form
+    url: https://honcho.dev
+  source_ids:
+  - src_02fb1fc3329d38a9961e41f6fe41e22f458814ceb8dd77a0ef4024d19fa08b1a
+  program_id: prg_q77dhmzkg6jrarvgyh08dsrpz5

--- a/entities/ho/hopohopo.yaml
+++ b/entities/ho/hopohopo.yaml
@@ -1,0 +1,62 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w435fn3rjr11pzc40wm9tx
+  slug: hopohopo
+  slug_aliases: []
+  name: Hopohopo
+  domains:
+  - value: hopohopo.io
+    role: primary
+    valid_from: '2026-09-06T19:46:41.281Z'
+  category: crm-sales
+profile:
+  description: Hopohopo is a CRM platform offering sales, marketing, and customer
+    management tools for growing businesses.
+  links:
+    site: https://www.hopohopo.io
+sources:
+- source_id: src_7f77e7d94511f6a1b44a37af09562a3004989df68707949aa21c81326ff6db55
+  url: https://www.hopohopo.io/partner-program-welcome
+programs:
+- program_id: prg_re9wv1afj29xxqyhjtbx55b6qm
+  program_slug: hopohopo-startup-program
+  program_slug_aliases: []
+  title: Partner Program Startup Discount
+  summary: Startups in participating investor or accelerator portfolios receive 50%
+    off the Hopohopo CRM Pro Plan for one year.
+  source_ids:
+  - src_7f77e7d94511f6a1b44a37af09562a3004989df68707949aa21c81326ff6db55
+offers:
+- offer_id: off_01m1w435fv3pfemcd9mes6z7hy
+  offer_slug: partner-program-startup-discount
+  offer_slug_aliases: []
+  title: Partner Program Startup Discount
+  summary: Startups in participating investor or accelerator portfolios receive 50%
+    off the Hopohopo CRM Pro Plan for one year.
+  lifecycle:
+    status: active
+    effective_from: '2026-09-06T19:46:41.281Z'
+  economics:
+    consideration:
+      kind: none
+    benefits:
+    - benefit_id: ben_018
+      kind: other
+      description: Startup program discount or credit; specific terms vary by program.
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_portfolio
+      statement: Startup must belong to a participating investor or accelerator portfolio;
+        eligibility is verified through the portfolio invitation and partner code.
+      reason: external-verification
+  roles:
+    terms_authority_entity_id: ent_01m1w435fn3rjr11pzc40wm9tx
+    access_operator_entity_id: ent_01m1w435fn3rjr11pzc40wm9tx
+  access:
+    availability: public
+    method: other
+    url: https://www.hopohopo.io/partner-program-welcome
+  source_ids:
+  - src_7f77e7d94511f6a1b44a37af09562a3004989df68707949aa21c81326ff6db55
+  program_id: prg_re9wv1afj29xxqyhjtbx55b6qm

--- a/entities/im/imeetify.yaml
+++ b/entities/im/imeetify.yaml
@@ -1,0 +1,65 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rq00nj54dr4q70k51z1d
+  slug: imeetify
+  slug_aliases: []
+  name: iMeetify
+  domains:
+  - value: imeetify.com
+    role: primary
+    valid_from: '2026-09-06T19:47:36Z'
+  category: communication
+profile:
+  description: iMeetify provides appointment scheduling and meeting management tools
+    for businesses and professionals.
+  links:
+    site: https://www.imeetify.com
+sources:
+- source_id: src_50262836e7e5769b36d3aa17a6c38c5baac93625f33ba5c8c72697e6b0069013
+  url: https://www.imeetify.com/imeetify-credits-for-startups
+programs:
+- program_id: prg_p0xz2qrzj7p0rrmwbhkh6nxs6e
+  program_slug: imeetify-startup-program
+  program_slug_aliases: []
+  title: iMeetify Startup Credits
+  summary: iMeetify publishes a startup-specific offer of USD 1,000 in credits toward
+    its appointment scheduling platform. No credit card or commitment is required;
+    a public application form is available.
+  source_ids:
+  - src_50262836e7e5769b36d3aa17a6c38c5baac93625f33ba5c8c72697e6b0069013
+offers:
+- offer_id: off_01m1w3rq0f13x0g85q8fzww2an
+  offer_slug: imeetify-startup-credits
+  offer_slug_aliases: []
+  title: iMeetify Startup Credits
+  summary: iMeetify publishes a startup-specific offer of USD 1,000 in credits toward
+    its appointment scheduling platform. No credit card or commitment is required;
+    a public application form is available.
+  lifecycle:
+    status: active
+    effective_from: '2026-09-06T19:47:36Z'
+  economics:
+    consideration:
+      kind: variable
+      description: USD 1,000 in credits toward the appointment scheduling platform.
+    benefits:
+    - benefit_id: ben_019
+      kind: other
+      description: Startup program discount or credit; specific terms vary by program.
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_requirement_01
+      statement: Must be an eligible startup and apply through the vendor's public
+        application form; no credit card or commitment required.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_01m1w3rq00nj54dr4q70k51z1d
+    access_operator_entity_id: ent_01m1w3rq00nj54dr4q70k51z1d
+  access:
+    availability: public
+    method: form
+    url: https://www.imeetify.com/imeetify-credits-for-startups
+  source_ids:
+  - src_50262836e7e5769b36d3aa17a6c38c5baac93625f33ba5c8c72697e6b0069013
+  program_id: prg_p0xz2qrzj7p0rrmwbhkh6nxs6e

--- a/entities/ke/kerno.yaml
+++ b/entities/ke/kerno.yaml
@@ -1,0 +1,63 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rqhdkc79f9bazvekpt3z
+  slug: kerno
+  slug_aliases: []
+  name: Kerno
+  domains:
+  - value: kerno.io
+    role: primary
+    valid_from: '2026-09-06T19:47:36Z'
+  category: finance-accounting
+profile:
+  description: Kerno (FYCK Limited) provides financial and business management tools
+    for startups and growing companies.
+  links:
+    site: https://www.kerno.io
+sources:
+- source_id: src_37d79161df6a35ce278a6e5976f9cda3f43776edae733ee8f6d4114f425b8d79
+  url: https://www.kerno.io/pricing/
+programs:
+- program_id: prg_qrkmp5wpzbxz5q6276bsvyscn5
+  program_slug: kerno-startup-program
+  program_slug_aliases: []
+  title: Kerno Startup Discount
+  summary: Kerno offers 50% discount for pre-Series A startups with revenue under
+    USD 2 million over the preceding 12 months.
+  source_ids:
+  - src_37d79161df6a35ce278a6e5976f9cda3f43776edae733ee8f6d4114f425b8d79
+offers:
+- offer_id: off_01m1w3rqj1qkbqbewn4tax2b7y
+  offer_slug: kerno-startup-discount
+  offer_slug_aliases: []
+  title: Kerno Startup Discount
+  summary: Kerno offers 50% discount for pre-Series A startups with revenue under
+    USD 2 million over the preceding 12 months.
+  lifecycle:
+    status: active
+    effective_from: '2026-09-06T19:47:36Z'
+  economics:
+    consideration:
+      kind: variable
+      description: 50% discount for eligible pre-Series A startups.
+    benefits:
+    - benefit_id: ben_020
+      kind: other
+      description: Startup program discount or credit; specific terms vary by program.
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_requirement_01
+      statement: Must be pre-Series A with revenue under USD 2 million over the preceding
+        12 months.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_01m1w3rqhdkc79f9bazvekpt3z
+    access_operator_entity_id: ent_01m1w3rqhdkc79f9bazvekpt3z
+  access:
+    availability: public
+    method: form
+    url: https://www.kerno.io/pricing/
+  source_ids:
+  - src_37d79161df6a35ce278a6e5976f9cda3f43776edae733ee8f6d4114f425b8d79
+  program_id: prg_qrkmp5wpzbxz5q6276bsvyscn5

--- a/entities/la/laravel.yaml
+++ b/entities/la/laravel.yaml
@@ -1,0 +1,65 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rh08gtrbrdqr32e9qaxq
+  slug: laravel
+  slug_aliases: []
+  name: Laravel
+  domains:
+  - value: laravel.com
+    role: primary
+    valid_from: '2026-09-06T19:44:08Z'
+  category: hosting-infra
+profile:
+  description: Laravel Cloud is a managed deployment platform for Laravel applications,
+    providing infrastructure and hosting services.
+  links:
+    site: https://laravel.com/cloud
+sources:
+- source_id: src_47ff47a24afdb6034cfe4872e73005f97b877c964dfa9338f709c702f19a0bd4
+  url: https://startups.aws.com/offers?lang=en-US
+programs:
+- program_id: prg_pr8c9gzg21fnmnszkvpfvm331r
+  program_slug: laravel-startup-program
+  program_slug_aliases: []
+  title: Laravel Cloud Credit through AWS Activate
+  summary: AWS Activate currently lists USD 300 in credits to deploy anything on Laravel
+    Cloud. This is a partner offer accessed through AWS Activate, not Laravel Cloud's
+    ordinary public pricing.
+  source_ids:
+  - src_47ff47a24afdb6034cfe4872e73005f97b877c964dfa9338f709c702f19a0bd4
+offers:
+- offer_id: off_01m1w3rh0m5mdrc867vw88mbw4
+  offer_slug: laravel-cloud-credit-through-aws-activate
+  offer_slug_aliases: []
+  title: Laravel Cloud Credit through AWS Activate
+  summary: AWS Activate currently lists USD 300 in credits to deploy anything on Laravel
+    Cloud. This is a partner offer accessed through AWS Activate, not Laravel Cloud's
+    ordinary public pricing.
+  lifecycle:
+    status: active
+    effective_from: '2026-09-06T19:44:08Z'
+  economics:
+    consideration:
+      kind: variable
+      description: USD 300 in Laravel Cloud credits through AWS Activate.
+    benefits:
+    - benefit_id: ben_021
+      kind: other
+      description: Startup program discount or credit; specific terms vary by program.
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_requirement_01
+      statement: Must meet AWS Activate membership and business eligibility requirements
+        as published by AWS.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_01m1w3rh08gtrbrdqr32e9qaxq
+    access_operator_entity_id: ent_01kyh8fpe10b164tj935t8k5zb
+  access:
+    availability: public
+    method: form
+    url: https://startups.aws.com/offers
+  source_ids:
+  - src_47ff47a24afdb6034cfe4872e73005f97b877c964dfa9338f709c702f19a0bd4
+  program_id: prg_pr8c9gzg21fnmnszkvpfvm331r

--- a/entities/la/layer-pr.yaml
+++ b/entities/la/layer-pr.yaml
@@ -1,0 +1,63 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rjq79m3mttr9v00wax7f
+  slug: layer-pr
+  slug_aliases: []
+  name: Layer PR
+  domains:
+  - value: layerpr.com
+    role: primary
+    valid_from: '2026-09-06T19:45:10Z'
+  category: marketing
+profile:
+  description: Layer PR is a public relations platform providing tools and services
+    for startup and technology company communications.
+  links:
+    site: https://layerpr.com
+sources:
+- source_id: src_a1cde3e748239f4ac2c3138b4a7b967b309f54cb31b3ce03645f486784f667c9
+  url: https://layerpr.com/startup-program/
+programs:
+- program_id: prg_aky1tdtqc8x1dydgjyc303ncsk
+  program_slug: layer-pr-startup-program
+  program_slug_aliases: []
+  title: Layer PR Startup Program
+  summary: Layer PR offers qualifying revenue-generating startups up to 50% off invoices
+    during its one-year startup program.
+  source_ids:
+  - src_a1cde3e748239f4ac2c3138b4a7b967b309f54cb31b3ce03645f486784f667c9
+offers:
+- offer_id: off_01m1w3rjqt1p7p5q3rqm1ktrqk
+  offer_slug: layer-pr-startup-program
+  offer_slug_aliases: []
+  title: Layer PR Startup Program
+  summary: Layer PR offers qualifying revenue-generating startups up to 50% off invoices
+    during its one-year startup program.
+  lifecycle:
+    status: active
+    effective_from: '2026-09-06T19:45:10Z'
+  economics:
+    consideration:
+      kind: variable
+      description: Up to 50% off invoices during the one-year program.
+    benefits:
+    - benefit_id: ben_022
+      kind: other
+      description: Startup program discount or credit; specific terms vary by program.
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_requirement_01
+      statement: Must be a revenue-generating startup; specific criteria are published
+        on the vendor startup program page.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_01m1w3rjq79m3mttr9v00wax7f
+    access_operator_entity_id: ent_01m1w3rjq79m3mttr9v00wax7f
+  access:
+    availability: public
+    method: form
+    url: https://layerpr.com/startup-program/
+  source_ids:
+  - src_a1cde3e748239f4ac2c3138b4a7b967b309f54cb31b3ce03645f486784f667c9
+  program_id: prg_aky1tdtqc8x1dydgjyc303ncsk

--- a/entities/le/lead-liaison.yaml
+++ b/entities/le/lead-liaison.yaml
@@ -1,0 +1,66 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rg5vfe2htdetwspdxwky
+  slug: lead-liaison
+  slug_aliases: []
+  name: Lead Liaison
+  domains:
+  - value: leadliaison.com
+    role: primary
+    valid_from: '2026-09-06T19:43:17Z'
+  category: crm-sales
+profile:
+  description: Lead Liaison provides sales and marketing automation software including
+    CRM, marketing, and revenue operations tools.
+  links:
+    site: https://www.leadliaison.com
+sources:
+- source_id: src_07e182c86eb05bcd40febc39e5d8f6e9c55bc896a3ce771eb2dd8ee1ae77acd2
+  url: https://www.leadliaison.com/startups/
+programs:
+- program_id: prg_17tzrsw8yjje551x7qj93cp56y
+  program_slug: lead-liaison-startup-program
+  program_slug_aliases: []
+  title: Lead Liaison Seed-Stage Startup Discount
+  summary: The vendor publishes 90% off subscription licenses for 24 months, then
+    50% for 12 months, with funding, partner affiliation, new-customer, and second-year
+    training conditions.
+  source_ids:
+  - src_07e182c86eb05bcd40febc39e5d8f6e9c55bc896a3ce771eb2dd8ee1ae77acd2
+offers:
+- offer_id: off_01m1w3rg6h2fbw3xnyxc0b7kyb
+  offer_slug: lead-liaison-seed-stage-startup-discount
+  offer_slug_aliases: []
+  title: Lead Liaison Seed-Stage Startup Discount
+  summary: The vendor publishes 90% off subscription licenses for 24 months, then
+    50% for 12 months, with funding, partner affiliation, new-customer, and second-year
+    training conditions.
+  lifecycle:
+    status: active
+    effective_from: '2026-09-06T19:43:17Z'
+  economics:
+    consideration:
+      kind: variable
+      description: 90% off for 24 months, then 50% off for 12 months on subscription
+        licenses.
+    benefits:
+    - benefit_id: ben_023
+      kind: other
+      description: Startup program discount or credit; specific terms vary by program.
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_requirement_01
+      statement: Subject to funding, partner affiliation, new-customer, and second-year
+        training conditions as published on the vendor startup page.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_01m1w3rg5vfe2htdetwspdxwky
+    access_operator_entity_id: ent_01m1w3rg5vfe2htdetwspdxwky
+  access:
+    availability: public
+    method: form
+    url: https://www.leadliaison.com/startups/
+  source_ids:
+  - src_07e182c86eb05bcd40febc39e5d8f6e9c55bc896a3ce771eb2dd8ee1ae77acd2
+  program_id: prg_17tzrsw8yjje551x7qj93cp56y

--- a/entities/le/lettermint.yaml
+++ b/entities/le/lettermint.yaml
@@ -1,0 +1,63 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rmckdt857tkc5fya50f5
+  slug: lettermint
+  slug_aliases: []
+  name: Lettermint
+  domains:
+  - value: lettermint.co
+    role: primary
+    valid_from: '2026-09-06T19:46:00Z'
+  category: productivity
+profile:
+  description: Lettermint provides document and letter management tools for businesses
+    and professionals.
+  links:
+    site: https://lettermint.co
+sources:
+- source_id: src_182544062d8aceb638d5eccdbf9e53a250b9c3fbb1fecc73f5491c636b152400
+  url: https://lettermint.co/promo-codes-and-discounts/startups
+programs:
+- program_id: prg_w7z22q7myzfhm6gmmm5zsx82hb
+  program_slug: lettermint-startup-program
+  program_slug_aliases: []
+  title: Lettermint Startup Account Credit
+  summary: Lettermint offers a startup-specific EUR 60 account credit, valid for 12
+    months after activation.
+  source_ids:
+  - src_182544062d8aceb638d5eccdbf9e53a250b9c3fbb1fecc73f5491c636b152400
+offers:
+- offer_id: off_01m1w3rmd51h99jdvdqf0y27dy
+  offer_slug: lettermint-startup-account-credit
+  offer_slug_aliases: []
+  title: Lettermint Startup Account Credit
+  summary: Lettermint offers a startup-specific EUR 60 account credit, valid for 12
+    months after activation.
+  lifecycle:
+    status: active
+    effective_from: '2026-09-06T19:46:00Z'
+  economics:
+    consideration:
+      kind: variable
+      description: EUR 60 account credit, valid for 12 months after activation.
+    benefits:
+    - benefit_id: ben_024
+      kind: other
+      description: Startup program discount or credit; specific terms vary by program.
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_requirement_01
+      statement: Must be an eligible startup and complete the vendor's application
+        process.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_01m1w3rmckdt857tkc5fya50f5
+    access_operator_entity_id: ent_01m1w3rmckdt857tkc5fya50f5
+  access:
+    availability: public
+    method: form
+    url: https://lettermint.co/promo-codes-and-discounts/startups
+  source_ids:
+  - src_182544062d8aceb638d5eccdbf9e53a250b9c3fbb1fecc73f5491c636b152400
+  program_id: prg_w7z22q7myzfhm6gmmm5zsx82hb

--- a/entities/li/liveblocks.yaml
+++ b/entities/li/liveblocks.yaml
@@ -1,0 +1,63 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rhnjk9123k0q7rgk5921
+  slug: liveblocks
+  slug_aliases: []
+  name: Liveblocks
+  domains:
+  - value: liveblocks.io
+    role: primary
+    valid_from: '2026-09-06T19:45:10Z'
+  category: devtools-other
+profile:
+  description: Liveblocks provides real-time collaboration infrastructure for building
+    multiplayer applications with CRDTs and conflict-free data types.
+  links:
+    site: https://liveblocks.io
+sources:
+- source_id: src_3ace73d1f69e2e086572b2eda19520018da0eeee7f3c8b6875dcad7be0b4cd0d
+  url: https://liveblocks.io/startups
+programs:
+- program_id: prg_5hyn0xvydkt5hm6fbdpf3rn0dr
+  program_slug: liveblocks-startup-program
+  program_slug_aliases: []
+  title: Liveblocks Startup Program
+  summary: The Liveblocks startup page advertises a startup program discount with
+    an application form. Specific discount percentage and duration are not published.
+  source_ids:
+  - src_3ace73d1f69e2e086572b2eda19520018da0eeee7f3c8b6875dcad7be0b4cd0d
+offers:
+- offer_id: off_01m1w3rhnqvh09g5kagd6h2h0a
+  offer_slug: liveblocks-startup-program-discount
+  offer_slug_aliases: []
+  title: Liveblocks Startup Program
+  summary: The Liveblocks startup page advertises a startup program discount with
+    an application form. Specific discount percentage and duration are not published.
+  lifecycle:
+    status: active
+    effective_from: '2026-09-06T19:45:10Z'
+  economics:
+    consideration:
+      kind: variable
+      description: Startup program discount; specific terms are not publicly published.
+    benefits:
+    - benefit_id: ben_025
+      kind: other
+      description: Startup program discount or credit; specific terms vary by program.
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_requirement_01
+      statement: Must be an eligible startup; specific criteria are published on the
+        vendor startup page and evaluated on application.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_01m1w3rhnjk9123k0q7rgk5921
+    access_operator_entity_id: ent_01m1w3rhnjk9123k0q7rgk5921
+  access:
+    availability: public
+    method: form
+    url: https://liveblocks.io/startups
+  source_ids:
+  - src_3ace73d1f69e2e086572b2eda19520018da0eeee7f3c8b6875dcad7be0b4cd0d
+  program_id: prg_5hyn0xvydkt5hm6fbdpf3rn0dr

--- a/entities/ma/manylayers.yaml
+++ b/entities/ma/manylayers.yaml
@@ -1,0 +1,64 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rtysp36jfdcnegafgew9
+  slug: manylayers
+  slug_aliases: []
+  name: ManyLayers
+  domains:
+  - value: manylayers.io
+    role: primary
+    valid_from: '2026-09-06T19:48:40Z'
+  category: ai-ml
+profile:
+  description: ManyLayers provides AI model deployment and management infrastructure
+    for AI-first teams and startups.
+  links:
+    site: https://manylayers.io
+sources:
+- source_id: src_3018885f7b4bf6e62e858a48b516964f5066f15a6e9c76f083b525bff768ad2c
+  url: https://manylayers.io/startup-program/
+programs:
+- program_id: prg_7nq83yj8bd2aj8s2xeamn77b02
+  program_slug: manylayers-startup-program
+  program_slug_aliases: []
+  title: ManyLayers Startup Program
+  summary: Eligible AI-first startups receive the ManyLayers Team tier free for 12
+    months, with platform access and dedicated support.
+  source_ids:
+  - src_3018885f7b4bf6e62e858a48b516964f5066f15a6e9c76f083b525bff768ad2c
+offers:
+- offer_id: off_01m1w3rtyz83wemmn45esb9r3g
+  offer_slug: manylayers-startup-program
+  offer_slug_aliases: []
+  title: ManyLayers Startup Program
+  summary: Eligible AI-first startups receive the ManyLayers Team tier free for 12
+    months, with platform access and dedicated support.
+  lifecycle:
+    status: active
+    effective_from: '2026-09-06T19:48:40Z'
+  economics:
+    consideration:
+      kind: variable
+      description: Team tier free for 12 months with platform access and dedicated
+        support.
+    benefits:
+    - benefit_id: ben_026
+      kind: other
+      description: Startup program discount or credit; specific terms vary by program.
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_requirement_01
+      statement: Must be an AI-first startup; specific eligibility criteria are published
+        on the vendor startup program page.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_01m1w3rtysp36jfdcnegafgew9
+    access_operator_entity_id: ent_01m1w3rtysp36jfdcnegafgew9
+  access:
+    availability: public
+    method: form
+    url: https://manylayers.io/startup-program/
+  source_ids:
+  - src_3018885f7b4bf6e62e858a48b516964f5066f15a6e9c76f083b525bff768ad2c
+  program_id: prg_7nq83yj8bd2aj8s2xeamn77b02

--- a/entities/ma/mawio.yaml
+++ b/entities/ma/mawio.yaml
@@ -1,0 +1,65 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rxnpx0bsrs6tfrem7wdx
+  slug: mawio
+  slug_aliases: []
+  name: Mawio
+  domains:
+  - value: mawio.dev
+    role: primary
+    valid_from: '2026-09-06T19:49:38Z'
+  category: ai-ml
+profile:
+  description: Mawio provides AI agent infrastructure and APIs for pre-seed to Series
+    A AI-agent startups.
+  links:
+    site: https://mawio.dev
+sources:
+- source_id: src_52fe16970547fb364601287dd30283e20a5ada6fb3760bee78e151f73a2b5672
+  url: https://mawio.dev/startups
+programs:
+- program_id: prg_bdvh0arkfe7zngvavm3y3ws68z
+  program_slug: mawio-startup-program
+  program_slug_aliases: []
+  title: Mawio Startup Program
+  summary: The page advertises USD 10,000 in free API credits for approved pre-seed
+    to Series A AI-agent startups younger than three years and below USD 5 million
+    annual revenue, alongside a six-month Startup Tier. Applications go to startups@mawio...
+  source_ids:
+  - src_52fe16970547fb364601287dd30283e20a5ada6fb3760bee78e151f73a2b5672
+offers:
+- offer_id: off_01m1w3rxnvg1zxd2fgy600pam7
+  offer_slug: mawio-startup-program
+  offer_slug_aliases: []
+  title: Mawio Startup Program
+  summary: The page advertises USD 10,000 in free API credits for approved pre-seed
+    to Series A AI-agent startups younger than three years and below USD 5 million
+    annual revenue, alongside a six-month Startup Tier. Applications go to startups@mawio...
+  lifecycle:
+    status: active
+    effective_from: '2026-09-06T19:49:38Z'
+  economics:
+    consideration:
+      kind: variable
+      description: USD 10,000 in free API credits for approved startups, with a six-month
+        Startup Tier.
+    benefits:
+    - benefit_id: ben_027
+      kind: other
+      description: Startup program discount or credit; specific terms vary by program.
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_requirement_01
+      statement: Must be a pre-seed to Series A AI-agent startup younger than three
+        years with below USD 5 million annual revenue.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_01m1w3rxnpx0bsrs6tfrem7wdx
+    access_operator_entity_id: ent_01m1w3rxnpx0bsrs6tfrem7wdx
+  access:
+    availability: public
+    method: contact
+  source_ids:
+  - src_52fe16970547fb364601287dd30283e20a5ada6fb3760bee78e151f73a2b5672
+  program_id: prg_bdvh0arkfe7zngvavm3y3ws68z

--- a/entities/mo/morris-james.yaml
+++ b/entities/mo/morris-james.yaml
@@ -1,0 +1,63 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rr0tcfvc242ahdd0ftvc
+  slug: morris-james
+  slug_aliases: []
+  name: Morris James LLP
+  domains:
+  - value: morrisjames.com
+    role: primary
+    valid_from: '2026-09-06T19:47:36Z'
+  category: legal-compliance
+profile:
+  description: Morris James LLP is a regional law firm in the United States providing
+    corporate and business legal services, including to startups and entrepreneurs.
+  links:
+    site: https://www.morrisjames.com
+sources:
+- source_id: src_1590816f64f2d1d2bf7b10039e9cb3b05ba5c07ca7d7c5aa884565fb8b8b3532
+  url: https://www.morrisjames.com/service/corporate-ma/start-up-program/
+programs:
+- program_id: prg_0k2phqhpf8b7qhq9wvexqwyg7p
+  program_slug: morris-james-startup-program
+  program_slug_aliases: []
+  title: Morris James Start-Up Program
+  summary: The Morris James Start-Up Program offers qualifying companies 30% off standard
+    corporate legal rates for the first year of engagement. Qualification is case-by-case.
+  source_ids:
+  - src_1590816f64f2d1d2bf7b10039e9cb3b05ba5c07ca7d7c5aa884565fb8b8b3532
+offers:
+- offer_id: off_01m1w3rr164y03798fvddvewkb
+  offer_slug: morris-james-start-up-program
+  offer_slug_aliases: []
+  title: Morris James Start-Up Program
+  summary: The Morris James Start-Up Program offers qualifying companies 30% off standard
+    corporate legal rates for the first year of engagement. Qualification is case-by-case.
+  lifecycle:
+    status: active
+    effective_from: '2026-09-06T19:47:36Z'
+  economics:
+    consideration:
+      kind: variable
+      description: 30% off standard corporate legal rates for the first year of engagement.
+    benefits:
+    - benefit_id: ben_028
+      kind: other
+      description: Startup program discount or credit; specific terms vary by program.
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_requirement_01
+      statement: Qualification is case-by-case; typical criteria include early-stage
+        status and legal needs consistent with startup representation.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_01m1w3rr0tcfvc242ahdd0ftvc
+    access_operator_entity_id: ent_01m1w3rr0tcfvc242ahdd0ftvc
+  access:
+    availability: public
+    method: form
+    url: https://www.morrisjames.com/service/corporate-ma/start-up-program/
+  source_ids:
+  - src_1590816f64f2d1d2bf7b10039e9cb3b05ba5c07ca7d7c5aa884565fb8b8b3532
+  program_id: prg_0k2phqhpf8b7qhq9wvexqwyg7p

--- a/entities/nv/nvoip.yaml
+++ b/entities/nv/nvoip.yaml
@@ -1,0 +1,66 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rx9c0q6k34tte4x37f7c
+  slug: nvoip
+  slug_aliases: []
+  name: Nvoip
+  domains:
+  - value: nvoip.com.br
+    role: primary
+    valid_from: '2026-09-06T19:49:38Z'
+  category: communication
+profile:
+  description: Nvoip provides communication and VoIP services and APIs for businesses
+    and startups.
+  links:
+    site: https://www.nvoip.com.br
+sources:
+- source_id: src_c770b4d01831f74317f071e33871ce355bd6cb89d619f2175f83e1aa544e973b
+  url: https://www.nvoip.com.br/en/nvoip-for-startups/
+programs:
+- program_id: prg_h9pexdyv6jg5ha2j308m4dqz7v
+  program_slug: nvoip-startup-program
+  program_slug_aliases: []
+  title: Nvoip for Startups
+  summary: Nvoip's English-language startup program page offers discounts on its communication
+    plans for startups connected with Nvoip partner hubs. The current page advertises
+    up to 90% off, with the benefit dependent on startup maturity and lasti...
+  source_ids:
+  - src_c770b4d01831f74317f071e33871ce355bd6cb89d619f2175f83e1aa544e973b
+offers:
+- offer_id: off_01m1w3rxa57eys533440jzfqn5
+  offer_slug: nvoip-for-startups
+  offer_slug_aliases: []
+  title: Nvoip for Startups
+  summary: Nvoip's English-language startup program page offers discounts on its communication
+    plans for startups connected with Nvoip partner hubs. The current page advertises
+    up to 90% off, with the benefit dependent on startup maturity and lasti...
+  lifecycle:
+    status: active
+    effective_from: '2026-09-06T19:49:38Z'
+  economics:
+    consideration:
+      kind: variable
+      description: Up to 90% off communication plans for up to two years for startups
+        connected with Nvoip partner hubs.
+    benefits:
+    - benefit_id: ben_029
+      kind: other
+      description: Startup program discount or credit; specific terms vary by program.
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_requirement_01
+      statement: Must be a startup connected with an Nvoip partner hub; specific eligibility
+        and discount levels are dependent on startup maturity.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_01m1w3rx9c0q6k34tte4x37f7c
+    access_operator_entity_id: ent_01m1w3rx9c0q6k34tte4x37f7c
+  access:
+    availability: public
+    method: form
+    url: https://www.nvoip.com.br/en/nvoip-for-startups/
+  source_ids:
+  - src_c770b4d01831f74317f071e33871ce355bd6cb89d619f2175f83e1aa544e973b
+  program_id: prg_h9pexdyv6jg5ha2j308m4dqz7v

--- a/entities/ol/olqan.yaml
+++ b/entities/ol/olqan.yaml
@@ -1,0 +1,64 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rvdpj5wmc7tfmnsdabpa
+  slug: olqan
+  slug_aliases: []
+  name: Olqan
+  domains:
+  - value: olqan.com
+    role: primary
+    valid_from: '2026-09-06T19:48:40Z'
+  category: devtools-other
+profile:
+  description: Olqan provides development and analytics tools for startups and growth-stage
+    companies.
+  links:
+    site: https://olqan.com
+sources:
+- source_id: src_587824448b383cdaea1772737b1df1a866a67cb35e7a38299fb66551802f25dc
+  url: https://olqan.com/startup-program/
+programs:
+- program_id: prg_pnhrk32c85f3s4g3p19z9vj022
+  program_slug: olqan-startup-program
+  program_slug_aliases: []
+  title: Olqan Startup Program
+  summary: Eligible new users receive the Olqan Growth plan free for 12 months, including
+    onboarding, migration, and priority support.
+  source_ids:
+  - src_587824448b383cdaea1772737b1df1a866a67cb35e7a38299fb66551802f25dc
+offers:
+- offer_id: off_01m1w3rve254d2nv61nrdnaeh5
+  offer_slug: olqan-startup-program
+  offer_slug_aliases: []
+  title: Olqan Startup Program
+  summary: Eligible new users receive the Olqan Growth plan free for 12 months, including
+    onboarding, migration, and priority support.
+  lifecycle:
+    status: active
+    effective_from: '2026-09-06T19:48:40Z'
+  economics:
+    consideration:
+      kind: variable
+      description: Growth plan free for 12 months, including onboarding, migration,
+        and priority support.
+    benefits:
+    - benefit_id: ben_030
+      kind: other
+      description: Startup program discount or credit; specific terms vary by program.
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_requirement_01
+      statement: Must be an eligible new user; specific criteria are published on
+        the vendor startup program page.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_01m1w3rvdpj5wmc7tfmnsdabpa
+    access_operator_entity_id: ent_01m1w3rvdpj5wmc7tfmnsdabpa
+  access:
+    availability: public
+    method: form
+    url: https://olqan.com/startup-program/
+  source_ids:
+  - src_587824448b383cdaea1772737b1df1a866a67cb35e7a38299fb66551802f25dc
+  program_id: prg_pnhrk32c85f3s4g3p19z9vj022

--- a/entities/op/oprex.yaml
+++ b/entities/op/oprex.yaml
@@ -1,0 +1,63 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rf7mbtjqpj8am05cc1mh
+  slug: oprex
+  slug_aliases: []
+  name: Oprex
+  domains:
+  - value: oprex.id
+    role: primary
+    valid_from: '2026-09-06T19:42:47Z'
+  category: productivity
+profile:
+  description: Oprex is a productivity and workflow platform for teams in Indonesia
+    and Southeast Asia.
+  links:
+    site: https://oprex.id
+sources:
+- source_id: src_79d65093bb8ade590fc6ad05865e0c99f2426eeb5b4109595d88efd7d24da5f0
+  url: https://oprex.id/company/startup-program
+programs:
+- program_id: prg_nf8jycm1xrqf37e2zzwh4dmnxx
+  program_slug: oprex-startup-program
+  program_slug_aliases: []
+  title: Oprex Startup Program
+  summary: Eligible early-stage teams receive the Oprex Pro plan free for 12 months.
+    The public pricing page lists Pro at Rp 1,490,000 per month.
+  source_ids:
+  - src_79d65093bb8ade590fc6ad05865e0c99f2426eeb5b4109595d88efd7d24da5f0
+offers:
+- offer_id: off_01m1w3rf7z05x7be2j663hdd5b
+  offer_slug: oprex-startup-program
+  offer_slug_aliases: []
+  title: Oprex Startup Program
+  summary: Eligible early-stage teams receive the Oprex Pro plan free for 12 months.
+    The public pricing page lists Pro at Rp 1,490,000 per month.
+  lifecycle:
+    status: active
+    effective_from: '2026-09-06T19:42:47Z'
+  economics:
+    consideration:
+      kind: variable
+      description: Pro plan free for 12 months (Rp 1,490,000/month value).
+    benefits:
+    - benefit_id: ben_031
+      kind: other
+      description: Startup program discount or credit; specific terms vary by program.
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_requirement_01
+      statement: Must be an early-stage team; specific criteria are published on the
+        vendor startup program page.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_01m1w3rf7mbtjqpj8am05cc1mh
+    access_operator_entity_id: ent_01m1w3rf7mbtjqpj8am05cc1mh
+  access:
+    availability: public
+    method: form
+    url: https://oprex.id/company/startup-program
+  source_ids:
+  - src_79d65093bb8ade590fc6ad05865e0c99f2426eeb5b4109595d88efd7d24da5f0
+  program_id: prg_nf8jycm1xrqf37e2zzwh4dmnxx

--- a/entities/pa/paypercut.yaml
+++ b/entities/pa/paypercut.yaml
@@ -1,0 +1,66 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rsm18kdmxmm54ha0zjnj
+  slug: paypercut
+  slug_aliases: []
+  name: Paypercut
+  domains:
+  - value: paypercut.com
+    role: primary
+    valid_from: '2026-09-06T19:47:36Z'
+  category: finance-accounting
+profile:
+  description: Paypercut provides payment and transaction services for businesses
+    in Europe.
+  links:
+    site: https://paypercut.com
+sources:
+- source_id: src_1907a1f06514a59d726dd006717ec20e2ea71afb6db19c765dbbfa9bf8add5fa
+  url: https://paypercut.com/paypercut-for-startups
+programs:
+- program_id: prg_771x5my78yddp21ed8d30sdqwe
+  program_slug: paypercut-startup-program
+  program_slug_aliases: []
+  title: Paypercut for Startups
+  summary: Paypercut for Startups provides eligible early-stage European startups
+    with transaction-fee waivers and reduced pricing for up to 24 months, capped at
+    EUR 10,000 in aggregate fee savings.
+  source_ids:
+  - src_1907a1f06514a59d726dd006717ec20e2ea71afb6db19c765dbbfa9bf8add5fa
+offers:
+- offer_id: off_01m1w3rsm7gk3j4y60zscy4raj
+  offer_slug: paypercut-for-startups
+  offer_slug_aliases: []
+  title: Paypercut for Startups
+  summary: Paypercut for Startups provides eligible early-stage European startups
+    with transaction-fee waivers and reduced pricing for up to 24 months, capped at
+    EUR 10,000 in aggregate fee savings.
+  lifecycle:
+    status: active
+    effective_from: '2026-09-06T19:47:36Z'
+  economics:
+    consideration:
+      kind: variable
+      description: Transaction-fee waivers and reduced pricing for up to 24 months,
+        capped at EUR 10,000 aggregate savings.
+    benefits:
+    - benefit_id: ben_032
+      kind: other
+      description: Startup program discount or credit; specific terms vary by program.
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_requirement_01
+      statement: Must be an eligible early-stage European startup; specific criteria
+        are published on the vendor startup page.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_01m1w3rsm18kdmxmm54ha0zjnj
+    access_operator_entity_id: ent_01m1w3rsm18kdmxmm54ha0zjnj
+  access:
+    availability: public
+    method: form
+    url: https://paypercut.com/paypercut-for-startups
+  source_ids:
+  - src_1907a1f06514a59d726dd006717ec20e2ea71afb6db19c765dbbfa9bf8add5fa
+  program_id: prg_771x5my78yddp21ed8d30sdqwe

--- a/entities/pu/pulseadt.yaml
+++ b/entities/pu/pulseadt.yaml
@@ -1,0 +1,66 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1w3rrtnzqfhcaeaq5decct3
+  slug: pulseadt
+  slug_aliases: []
+  name: PulseADT
+  domains:
+  - value: getpulseadt.com
+    role: primary
+    valid_from: '2026-09-06T19:47:36Z'
+  category: devtools-other
+profile:
+  description: PulseADT provides API development and testing tools for developers
+    and teams.
+  links:
+    site: https://getpulseadt.com
+sources:
+- source_id: src_90bc10365386d1e40cd29886098e1270557f90c23b2f3bacb96b571c8efe2c16
+  url: https://getpulseadt.com/for-startups
+programs:
+- program_id: prg_f44a6sqntww08tz50fgaqh1qzg
+  program_slug: pulseadt-startup-program
+  program_slug_aliases: []
+  title: PulseADT Startup Credit Program
+  summary: The API Builder track grants eligible early-stage technology startups a
+    USD 250 platform credit valid for 12 months after spending at least USD 100 on
+    API credits within 90 days, followed by an ongoing 30% discount.
+  source_ids:
+  - src_90bc10365386d1e40cd29886098e1270557f90c23b2f3bacb96b571c8efe2c16
+offers:
+- offer_id: off_01m1w3rrttzbmxnzf9v6h8vpjw
+  offer_slug: pulseadt-startup-credit-program
+  offer_slug_aliases: []
+  title: PulseADT Startup Credit Program
+  summary: The API Builder track grants eligible early-stage technology startups a
+    USD 250 platform credit valid for 12 months after spending at least USD 100 on
+    API credits within 90 days, followed by an ongoing 30% discount.
+  lifecycle:
+    status: active
+    effective_from: '2026-09-06T19:47:36Z'
+  economics:
+    consideration:
+      kind: variable
+      description: USD 250 platform credit plus ongoing 30% discount after initial
+        spending requirement.
+    benefits:
+    - benefit_id: ben_033
+      kind: other
+      description: Startup program discount or credit; specific terms vary by program.
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_requirement_01
+      statement: Must be an early-stage technology startup; the credit requires spending
+        at least USD 100 on API credits within 90 days.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_01m1w3rrtnzqfhcaeaq5decct3
+    access_operator_entity_id: ent_01m1w3rrtnzqfhcaeaq5decct3
+  access:
+    availability: public
+    method: form
+    url: https://getpulseadt.com/for-startups
+  source_ids:
+  - src_90bc10365386d1e40cd29886098e1270557f90c23b2f3bacb96b571c8efe2c16
+  program_id: prg_f44a6sqntww08tz50fgaqh1qzg


### PR DESCRIPTION
Add 31 new startup program entity records (excludes elia-asistent, already in catalog).

Task(s): #Missing

Signed-off-by: Lars <agent@larsll.com>