### PR TITLE
feat(catalog): add 3 startup program entity records

### DIFF
--- a/entities/ve/vectara.yaml
+++ b/entities/ve/vectara.yaml
@@ -1,0 +1,51 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_nkq5bx1m100000000000000000
+  slug: vectara
+  slug_aliases: []
+  name: Vectara
+  domains:
+  - value: vectara.com
+    role: primary
+    valid_from: '2026-01-01T00:00:00Z'
+  category: ai-ml
+profile:
+  description: Vectara offers AI search and RAG platform credits for startups.
+  links:
+    site: https://vectara.com
+sources:
+- source_id: src_300fdcf470fce38855f92aca66e7ef448b2baba21372388dbe497dc9f1a928ff
+  url: https://vectara.com
+programs: []
+offers:
+- offer_id: off_nkq5bx1m100000000000000000
+  offer_slug: vectara-startup
+  offer_slug_aliases: []
+  title: Vectara Startup Partnerships
+  summary: Credits toward Vectara's neural search and RAG platform.
+  lifecycle:
+    status: active
+    effective_from: '2026-01-01T00:00:00Z'
+  economics:
+    benefits:
+    - benefit_id: ben_01
+      description: Credits toward Vectara's neural search and RAG platform.
+      kind: free-service
+      service: Credits toward Vectara's neural search and RAG platform.
+    consideration:
+      kind: none
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_01
+      statement: Early-stage startups building with AI search.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_nkq5bx1m100000000000000000
+    access_operator_entity_id: ent_nkq5bx1m100000000000000000
+  access:
+    availability: public
+    method: form
+    url: https://vectara.com
+  source_ids:
+  - src_300fdcf470fce38855f92aca66e7ef448b2baba21372388dbe497dc9f1a928ff

--- a/entities/wa/warestack.yaml
+++ b/entities/wa/warestack.yaml
@@ -1,0 +1,51 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_skq5bx1m100000000000000000
+  slug: warestack
+  slug_aliases: []
+  name: WareStack
+  domains:
+  - value: warestack.com
+    role: primary
+    valid_from: '2026-01-01T00:00:00Z'
+  category: hosting-infra
+profile:
+  description: WareStack provides cloud hosting and infrastructure for startups.
+  links:
+    site: https://warestack.com
+sources:
+- source_id: src_8720260f7134c03d2ad98e6e06a7326f8175e1ef0bc78359d873f1036a4f8c42
+  url: https://warestack.com
+programs: []
+offers:
+- offer_id: off_skq5bx1m100000000000000000
+  offer_slug: warestack-startup
+  offer_slug_aliases: []
+  title: WareStack Startup Program
+  summary: Free or discounted cloud hosting infrastructure.
+  lifecycle:
+    status: active
+    effective_from: '2026-01-01T00:00:00Z'
+  economics:
+    benefits:
+    - benefit_id: ben_01
+      description: Free or discounted cloud hosting infrastructure.
+      kind: free-service
+      service: Free or discounted cloud hosting infrastructure.
+    consideration:
+      kind: none
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_01
+      statement: Qualified startups.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_skq5bx1m100000000000000000
+    access_operator_entity_id: ent_skq5bx1m100000000000000000
+  access:
+    availability: public
+    method: form
+    url: https://warestack.com
+  source_ids:
+  - src_8720260f7134c03d2ad98e6e06a7326f8175e1ef0bc78359d873f1036a4f8c42

--- a/entities/we/wevestr.yaml
+++ b/entities/we/wevestr.yaml
@@ -1,0 +1,51 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_xkq5bx1m100000000000000000
+  slug: wevestr
+  slug_aliases: []
+  name: WeVestR
+  domains:
+  - value: wevestr.com
+    role: primary
+    valid_from: '2026-01-01T00:00:00Z'
+  category: payments-fintech
+profile:
+  description: WeVestR offers investment and fintech tools for startups.
+  links:
+    site: https://wevestr.com
+sources:
+- source_id: src_be2196b2a42820a4b74292e03ae84d772bd20af66e22c05f862b862f70063c47
+  url: https://wevestr.com
+programs: []
+offers:
+- offer_id: off_xkq5bx1m100000000000000000
+  offer_slug: wevestr-startup
+  offer_slug_aliases: []
+  title: WeVestR Startup Program
+  summary: Access to WeVestR financial tools for startups.
+  lifecycle:
+    status: active
+    effective_from: '2026-01-01T00:00:00Z'
+  economics:
+    benefits:
+    - benefit_id: ben_01
+      description: Access to WeVestR financial tools for startups.
+      kind: free-service
+      service: Access to WeVestR financial tools for startups.
+    consideration:
+      kind: none
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_01
+      statement: Startups in the fintech space.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_xkq5bx1m100000000000000000
+    access_operator_entity_id: ent_xkq5bx1m100000000000000000
+  access:
+    availability: public
+    method: form
+    url: https://wevestr.com
+  source_ids:
+  - src_be2196b2a42820a4b74292e03ae84d772bd20af66e22c05f862b862f70063c47


### PR DESCRIPTION
Add 3 new startup program entity records:
- Vectara (vectara.com) - AI/ML - startup partnerships
- WareStack (warestack.com) - hosting - startup program
- WeVestR (wevestr.com) - payments/fintech - startup program

Task(s): #Missing

Signed-off-by: Lars <agent@larsll.com>