### PR TITLE
feat(catalog): add Tuple startup program entity record

### DIFF
--- a/entities/tu/tuple.yaml
+++ b/entities/tu/tuple.yaml
@@ -1,0 +1,54 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_d6fkbx1m100000000000000000
+  slug: tuple
+  slug_aliases: []
+  name: Tuple
+  domains:
+  - value: tuple.app
+    role: primary
+    valid_from: '2026-01-01T00:00:00Z'
+  category: devtools-other
+profile:
+  description: Tuple is a remote pair programming tool for developer teams with built-in screen sharing, voice, and session recording.
+  links:
+    site: https://tuple.app
+sources:
+- source_id: src_0675095c667321aa57d9760389035c39c1a8ae1d976f941de674fddff54730b9
+  url: https://tuple.app/pricing
+- source_id: src_cfa1426b051576bd10548d89c4094309e97eedcb1de77febc31bcfff1fec4cbe
+  url: https://tuple.app/startups
+programs: []
+offers:
+- offer_id: off_d6fkbx1m100000000000000000
+  offer_slug: startup-subscription-discount
+  offer_slug_aliases: []
+  title: Tuple Startup Plan
+  summary: Tuple offers a startup subscription discount on its public pricing page.
+  lifecycle:
+    status: active
+    effective_from: '2026-01-01T00:00:00Z'
+  economics:
+    benefits:
+    - benefit_id: ben_01
+      description: Discounted Tuple subscription plan for startups.
+      kind: free-service
+      service: Discounted Tuple subscription plan
+    consideration:
+      kind: none
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_requirement_01
+      statement: Eligible startups (application via Tuple's startup form).
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_d6fkbx1m100000000000000000
+    access_operator_entity_id: ent_d6fkbx1m100000000000000000
+  access:
+    availability: public
+    method: form
+    url: https://tuple.app/startups
+  source_ids:
+  - src_0675095c667321aa57d9760389035c39c1a8ae1d976f941de674fddff54730b9
+  - src_cfa1426b051576bd10548d89c4094309e97eedcb1de77febc31bcfff1fec4cbe


### PR DESCRIPTION
Add Tuple (tuple.app) startup program entity.

Tuple offers a startup subscription discount on its pair programming tool.

Task(s): #1434

Signed-off-by: Lars <agent@larsll.com>