### PR TITLE
feat(catalog): add fal startup program entity

### DIFF
--- a/entities/fa/fal.yaml
+++ b/entities/fa/fal.yaml
@@ -1,0 +1,55 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_cztwdx1m100000000000000000
+  slug: fal
+  slug_aliases: []
+  name: fal
+  domains:
+  - value: fal.ai
+    role: primary
+    valid_from: '2026-01-01T00:00:00Z'
+  category: ai-ml
+profile:
+  description: fal is a developer-focused AI inference platform for image, video, and audio generative models, with a startup program providing credits to early-stage companies.
+  links:
+    site: https://fal.ai
+sources:
+- source_id: src_ff3516ef865c29155c3a17990b819f7011811254a7d9d7926d24965c95a17a45
+  url: https://fal.ai/startup-program
+programs: []
+offers:
+- offer_id: off_cztwdx1m100000000000000000
+  offer_slug: startup-program
+  offer_slug_aliases: []
+  title: fal Startup Program
+  summary: $1,000 in fal credits on the Startup tier for approved teams with proven traction or institutional VC backing, in Europe and Asia.
+  lifecycle:
+    status: active
+    effective_from: '2026-01-01T00:00:00Z'
+  economics:
+    benefits:
+    - benefit_id: ben_01
+      description: $1,000 in fal credits on the Startup tier for approved startups.
+      kind: credit
+      value:
+        amount:
+          currency: USD
+          minor_units: 100000
+        kind: exact
+    consideration:
+      kind: none
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_01
+      statement: Teams with proven traction or institutional VC backing, based in Europe or Asia.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_cztwdx1m100000000000000000
+    access_operator_entity_id: ent_cztwdx1m100000000000000000
+  access:
+    availability: public
+    method: form
+    url: https://fal.ai/startup-program
+  source_ids:
+  - src_ff3516ef865c29155c3a17990b819f7011811254a7d9d7926d24965c95a17a45


### PR DESCRIPTION
Add fal (fal.ai) startup program entity: $1,000 in credits for approved startups.

Task: #1281