### PR TITLE
data: add Bubble Microsoft for Startups-URM offer

### DIFF
--- a/entities/bu/bubble.yaml
+++ b/entities/bu/bubble.yaml
@@ -1,0 +1,78 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1xftksys2kgdncmbwg6af1b
+  slug: bubble
+  slug_aliases: []
+  name: Bubble
+  domains:
+    - value: bubble.io
+      role: primary
+      valid_from: 2026-09-07T08:30:16.000Z
+  category: no-code
+profile:
+  summary: Visual no-code platform for building and hosting full-stack web applications.
+  description: Bubble provides a visual development platform so founders and teams can design, integrate, host, and launch web apps without writing traditional code.
+  links:
+    site: https://bubble.io
+sources:
+  - source_id: src_c0de12594b65e7c0aaf4c18a66ed9838caae4e1a6cb8c6715a4c25d749227d0d
+    url: https://bubble.io/partnership/microsoft-for-startups-urm
+programs:
+  - program_id: prg_01m1xftksyfrmjb22yqw3yxc2q
+    program_slug: bubble-microsoft-for-startups-urm
+    program_slug_aliases: []
+    title: Bubble Microsoft for Startups-URM Offer
+    summary: Bubble offers eligible Microsoft for Startups members whose founders are from underrepresented minority backgrounds $3,500 in Bubble credits for six months.
+    source_ids:
+      - src_c0de12594b65e7c0aaf4c18a66ed9838caae4e1a6cb8c6715a4c25d749227d0d
+offers:
+  - offer_id: off_01m1xftksy14enagfpv3v16xbn
+    program_id: prg_01m1xftksyfrmjb22yqw3yxc2q
+    offer_slug: 3500-bubble-credits-microsoft-for-startups-urm
+    offer_slug_aliases: []
+    title: $3,500 Bubble Credits
+    summary: Eligible Microsoft for Startups members that are founders from underrepresented minority backgrounds can receive $3,500 in Bubble credits valid for six months on monthly subscription plans.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-07T08:30:16.000Z
+    economics:
+      consideration:
+        kind: none
+      benefits:
+        - benefit_id: ben_01
+          description: $3,500 in Bubble credits valid for six months
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 350000
+            kind: exact
+          duration:
+            kind: exact
+            value: P6M
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            reason: external-verification
+            statement: Must be a Microsoft for Startups member whose founders are from underrepresented minority backgrounds.
+          - criterion_id: cri_02
+            kind: manual
+            reason: external-verification
+            statement: Must use the same email when creating the Bubble account as the Microsoft for Startups membership email.
+          - criterion_id: cri_03
+            kind: manual
+            reason: external-verification
+            statement: Must link a credit card to redeem credits; for new paying Bubble users only; one redemption per organization; monthly plans only; cannot combine with another Bubble coupon or deal; not applicable on Dedicated plans; credits cannot be applied to one-time plugin or template purchases.
+    roles:
+      terms_authority_entity_id: ent_01m1xftksys2kgdncmbwg6af1b
+      access_operator_entity_id: ent_01m1xftksys2kgdncmbwg6af1b
+    access:
+      availability: public
+      method: form
+      url: https://bubble.io/partnership/microsoft-for-startups-urm
+      instructions: Sign up to claim on the Bubble Microsoft for Startups-URM partnership page using the matching Microsoft for Startups membership email.
+    source_ids:
+      - src_c0de12594b65e7c0aaf4c18a66ed9838caae4e1a6cb8c6715a4c25d749227d0d


### PR DESCRIPTION
Closes #180

## What changed
Adds Bubble as one new entity with one structured offer: **$3,500 Bubble Credits** for six months for eligible Microsoft for Startups members whose founders are from underrepresented minority backgrounds.

## Sources
- https://bubble.io/partnership/microsoft-for-startups-urm (live SPA render verified 2026-09-07: heading "$3,500 Bubble Credits"; eligibility and six-month validity on-page)

## Certification
- [x] I changed only allowed repository content and did not mix vendor YAML with other paths.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commits include a `Signed-off-by` line.