### PR TITLE
feat(catalog): add Userback startup programme entity

### DIFF
--- a/entities/us/userback.yaml
+++ b/entities/us/userback.yaml
@@ -1,0 +1,51 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_a1fzgx1m100000000000000000
+  slug: userback
+  slug_aliases: []
+  name: Userback
+  domains:
+  - value: userback.io
+    role: primary
+    valid_from: '2026-01-01T00:00:00Z'
+  category: productivity
+profile:
+  summary: User feedback and product management platform with a startup programme for early-stage SaaS companies.
+  description: Userback is a user feedback and product management platform that helps SaaS companies collect, analyze, and act on user feedback, with a startup programme offering 25% off annual plans for qualifying early-stage SaaS companies.
+  links:
+    site: https://userback.io
+sources:
+- source_id: src_1da5a4f2c8ee9f24f125fe78536b86543a5f897be3bf8597ab1f599384623435
+  url: https://userback.io/offer/startups/
+programs: []
+offers:
+- offer_id: off_a1fzgx1m100000000000000000
+  offer_slug: startup-programme
+  offer_slug_aliases: []
+  title: Userback Startup Programme
+  summary: 25% off all annual plans for the first year for qualifying early-stage SaaS companies via the Userback startup programme.
+  lifecycle:
+    status: active
+    effective_from: '2026-01-01T00:00:00Z'
+  economics:
+    benefits:
+    - benefit_id: ben_01
+      description: 25% off Userback annual plans for the first year for qualifying early-stage SaaS startups.
+      kind: other
+    consideration:
+      kind: none
+  eligibility:
+    rule:
+      kind: manual
+      criterion_id: cri_01
+      statement: Qualifying early-stage SaaS companies.
+      reason: not-machine-evaluable
+  roles:
+    terms_authority_entity_id: ent_a1fzgx1m100000000000000000
+    access_operator_entity_id: ent_a1fzgx1m100000000000000000
+  access:
+    availability: public
+    method: form
+    url: https://userback.io/offer/startups/
+  source_ids:
+  - src_1da5a4f2c8ee9f24f125fe78536b86543a5f897be3bf8597ab1f599384623435


### PR DESCRIPTION
Add Userback (userback.io) startup programme entity: 25% off annual plans for early-stage SaaS.

Task: #1127