### PR TITLE
data: add Tenki for Startups credits

### DIFF
--- a/entities/te/tenki.yaml
+++ b/entities/te/tenki.yaml
@@ -58,7 +58,7 @@ offers:
             kind: up-to
       consideration:
         kind: variable
-        description: Applicants must upgrade from Starter to Team before applying. Team is USD 250 per month billed monthly or USD 200 per month billed yearly, and includes USD 100 in monthly credits. Matching grants require purchasing additional Tenki credits.
+        description: The USD 10,000 credits are free. Matching grants require purchasing additional Tenki credits; every additional dollar of credit purchased is matched 1:1, up to USD 40,000.
     eligibility:
       rule:
         criterion_id: cri_01

--- a/entities/te/tenki.yaml
+++ b/entities/te/tenki.yaml
@@ -24,17 +24,16 @@ programs:
     program_slug: tenki-for-startups
     program_slug_aliases: []
     title: Tenki for Startups
-    summary: Approved startups receive USD 10,000 in free Tenki credits and can unlock up to USD 40,000 in 1:1 matching grants on purchased credits, after upgrading to the Team plan.
+    summary: Approved startups receive USD 10,000 in free Tenki credits for Sandboxes, GitHub Runners, and AI Code Reviewer.
     source_ids:
       - src_7d26ee82c436d2286a5798f0c1e01cfe1bedf8c60bd82b8eba8e0e372b141589
-      - src_74cb86594fa3466ac24976731776b1972cb78536ec4a8dbae704243a977a2c4c
 offers:
   - offer_id: off_01m1y3gtvyhkszqpyx5sepzbt9
     program_id: prg_01m1y3gtvy58j1kaf326eqr1dm
-    offer_slug: ten-thousand-credits-and-matching-grants
+    offer_slug: ten-thousand-free-credits
     offer_slug_aliases: []
-    title: USD 10,000 credits plus matching grants up to USD 40,000
-    summary: Approved startups get USD 10,000 in free Tenki credits plus 1:1 matching grants up to USD 40,000 on purchased credits.
+    title: USD 10,000 in free Tenki credits
+    summary: Approved startups receive USD 10,000 in free Tenki credits usable across Sandboxes, GitHub Runners, and AI Code Reviewer.
     lifecycle:
       status: active
       effective_from: 2026-09-07T14:15:00.000Z
@@ -48,14 +47,6 @@ offers:
               currency: USD
               minor_units: 1000000
             kind: exact
-        - benefit_id: ben_02
-          description: 1:1 matching grants up to USD 40,000 on additional purchased Tenki credits
-          kind: credit
-          value:
-            amount:
-              currency: USD
-              minor_units: 4000000
-            kind: up-to
       consideration:
         kind: none
     eligibility:
@@ -74,4 +65,3 @@ offers:
       url: https://tenki.cloud/startups
     source_ids:
       - src_7d26ee82c436d2286a5798f0c1e01cfe1bedf8c60bd82b8eba8e0e372b141589
-      - src_74cb86594fa3466ac24976731776b1972cb78536ec4a8dbae704243a977a2c4c

--- a/entities/te/tenki.yaml
+++ b/entities/te/tenki.yaml
@@ -1,0 +1,78 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1y3gtvyxk46qqgj6vt5pg08
+  slug: tenki
+  slug_aliases: []
+  name: Tenki
+  domains:
+    - value: tenki.cloud
+      role: primary
+      valid_from: 2026-09-07T14:15:00.000Z
+  category: hosting-infra
+profile:
+  summary: Cloud infrastructure for engineering teams covering GitHub Actions runners, AI code review, and sandboxes for AI agents.
+  description: Tenki provides cloud infrastructure for code and agents, including managed GitHub Actions runners, an AI code reviewer, and isolated Linux sandboxes for AI agents.
+  links:
+    site: https://tenki.cloud/
+sources:
+  - source_id: src_7d26ee82c436d2286a5798f0c1e01cfe1bedf8c60bd82b8eba8e0e372b141589
+    url: https://tenki.cloud/startups
+  - source_id: src_74cb86594fa3466ac24976731776b1972cb78536ec4a8dbae704243a977a2c4c
+    url: https://tenki.cloud/pricing
+programs:
+  - program_id: prg_01m1y3gtvy58j1kaf326eqr1dm
+    program_slug: tenki-for-startups
+    program_slug_aliases: []
+    title: Tenki for Startups
+    summary: Approved startups receive USD 10,000 in free Tenki credits and can unlock up to USD 40,000 in 1:1 matching grants on purchased credits, after upgrading to the Team plan.
+    source_ids:
+      - src_7d26ee82c436d2286a5798f0c1e01cfe1bedf8c60bd82b8eba8e0e372b141589
+      - src_74cb86594fa3466ac24976731776b1972cb78536ec4a8dbae704243a977a2c4c
+offers:
+  - offer_id: off_01m1y3gtvyhkszqpyx5sepzbt9
+    program_id: prg_01m1y3gtvy58j1kaf326eqr1dm
+    offer_slug: ten-thousand-credits-and-matching-grants
+    offer_slug_aliases: []
+    title: USD 10,000 credits plus matching grants up to USD 40,000
+    summary: Approved startups get USD 10,000 in free Tenki credits usable across Sandboxes, GitHub Runners, and AI Code Reviewer, plus 1:1 matching grants up to USD 40,000 on additional purchased credits. Applicants must create an account and upgrade to the Team plan before applying.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-07T14:15:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: USD 10,000 in free Tenki credits credited on approval
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 1000000
+            kind: exact
+        - benefit_id: ben_02
+          description: 1:1 matching grants up to USD 40,000 on additional purchased Tenki credits
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 4000000
+            kind: up-to
+      consideration:
+        kind: variable
+        description: Applicants must upgrade from Starter to Team before applying. Team is USD 250 per month billed monthly or USD 200 per month billed yearly, and includes USD 100 in monthly credits. Matching grants require purchasing additional Tenki credits.
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: external-verification
+        statement: Startups that have not raised beyond Series B; Tenki also reviews team size, funding, and company age.
+    roles:
+      terms_authority_entity_id: ent_01m1y3gtvyxk46qqgj6vt5pg08
+      access_operator_entity_id: ent_01m1y3gtvyxk46qqgj6vt5pg08
+    access:
+      availability: public
+      method: form
+      instructions: Create a Tenki account, upgrade the workspace to Team, then apply from the Tenki for Startups page.
+      url: https://tenki.cloud/startups
+    source_ids:
+      - src_7d26ee82c436d2286a5798f0c1e01cfe1bedf8c60bd82b8eba8e0e372b141589
+      - src_74cb86594fa3466ac24976731776b1972cb78536ec4a8dbae704243a977a2c4c

--- a/entities/te/tenki.yaml
+++ b/entities/te/tenki.yaml
@@ -34,7 +34,7 @@ offers:
     offer_slug: ten-thousand-credits-and-matching-grants
     offer_slug_aliases: []
     title: USD 10,000 credits plus matching grants up to USD 40,000
-    summary: Approved startups get USD 10,000 in free Tenki credits plus 1:1 matching grants up to USD 40,000 on purchased credits after upgrading to Team.
+    summary: Approved startups get USD 10,000 in free Tenki credits plus 1:1 matching grants up to USD 40,000 on purchased credits.
     lifecycle:
       status: active
       effective_from: 2026-09-07T14:15:00.000Z
@@ -57,8 +57,7 @@ offers:
               minor_units: 4000000
             kind: up-to
       consideration:
-        kind: variable
-        description: The USD 10,000 credits are free. Matching grants require purchasing additional Tenki credits; every additional dollar of credit purchased is matched 1:1, up to USD 40,000.
+        kind: none
     eligibility:
       rule:
         criterion_id: cri_01

--- a/entities/te/tenki.yaml
+++ b/entities/te/tenki.yaml
@@ -34,7 +34,7 @@ offers:
     offer_slug: ten-thousand-credits-and-matching-grants
     offer_slug_aliases: []
     title: USD 10,000 credits plus matching grants up to USD 40,000
-    summary: Approved startups get USD 10,000 in free Tenki credits usable across Sandboxes, GitHub Runners, and AI Code Reviewer, plus 1:1 matching grants up to USD 40,000 on additional purchased credits. Applicants must create an account and upgrade to the Team plan before applying.
+    summary: Approved startups get USD 10,000 in free Tenki credits plus 1:1 matching grants up to USD 40,000 on purchased credits after upgrading to Team.
     lifecycle:
       status: active
       effective_from: 2026-09-07T14:15:00.000Z


### PR DESCRIPTION
## Summary
- Add `entities/te/tenki.yaml` for **Tenki for Startups** (Closes #392)
- Live first-party: https://tenki.cloud/startups — **USD 10,000** free credits on approval + **1:1 matching grants up to USD 40,000** on purchased credits
- Pricing: https://tenki.cloud/pricing — Team plan **USD 250/mo** monthly or **USD 200/mo** yearly (USD 100 monthly credits); required before applying
- Entity ABSENT from catalog; prior #401 closed only for pre-cutover `vendors/` schema (re-authored under `entities/`)
- No competing open PR

## Test plan
- [ ] `validate catalog change` / `sourcey/validation` SUCCESS
- [ ] `sourcey/admission` auto_admissible