### PR TITLE
data: add Inference.net AI Compute Grants

### DIFF
--- a/entities/in/inference-net.yaml
+++ b/entities/in/inference-net.yaml
@@ -22,7 +22,7 @@ programs:
     program_slug: inference-net-ai-compute-grants
     program_slug_aliases: []
     title: Inference.net AI Compute Grants
-    summary: Inference.net awards up to USD 10,000 in free compute resources to developers and researchers working on open-source AI projects.
+    summary: Inference.net's Grant program offers up to $10,000 in free compute resources to developers and researchers working on open-source AI projects.
     source_ids:
       - src_cf23ea3901fea53c636e3546206a4798868f3b12cfdd9c1c80c267e2d866a4ce
 offers:
@@ -30,15 +30,15 @@ offers:
     program_id: prg_01m1yad2r24fcqg0tnpsxe074x
     offer_slug: up-to-10000-free-compute
     offer_slug_aliases: []
-    title: Up to USD 10,000 in free compute resources
-    summary: Approved applicants receive up to USD 10,000 in free Inference.net compute resources for open-source AI projects, reviewed on a rolling basis.
+    title: Up to $10,000 in free compute resources
+    summary: Inference.net offers up to $10,000 in free compute resources to developers and researchers working on open-source AI projects; grants are reviewed and awarded on a rolling basis.
     lifecycle:
       status: active
       effective_from: 2026-09-07T16:14:00.000Z
     economics:
       benefits:
         - benefit_id: ben_01
-          description: Up to USD 10,000 in free compute resources on Inference.net
+          description: up to $10,000 in free compute resources
           kind: credit
           value:
             amount:
@@ -52,7 +52,7 @@ offers:
         criterion_id: cri_01
         kind: manual
         reason: vendor-discretion
-        statement: Developers and researchers working on open-source AI projects in novel LLM applications, inference performance optimization, or AI developer tools; Inference.net reviews applications on a rolling basis.
+        statement: Developers and researchers working on open-source AI projects; Inference.net reviews and awards grants on a rolling basis.
     roles:
       terms_authority_entity_id: ent_01m1yad2qmn13qehsj1zpq24xk
       access_operator_entity_id: ent_01m1yad2qmn13qehsj1zpq24xk

--- a/entities/in/inference-net.yaml
+++ b/entities/in/inference-net.yaml
@@ -31,7 +31,7 @@ offers:
     offer_slug: up-to-10000-free-compute
     offer_slug_aliases: []
     title: Up to $10,000 in free compute resources
-    summary: Inference.net offers up to $10,000 in free compute resources to developers and researchers working on open-source AI projects; grants are reviewed and awarded on a rolling basis.
+    summary: Up to $10,000 in free compute resources for developers and researchers working on open-source AI projects.
     lifecycle:
       status: active
       effective_from: 2026-09-07T16:14:00.000Z
@@ -59,7 +59,7 @@ offers:
     access:
       availability: public
       method: form
-      instructions: Submit the grant application form on the Inference.net AI Compute Grants page with name, email, project description, GitHub repo, and project type.
+      instructions: Fill out the form on the Inference.net AI Compute Grants page and the team will be in touch.
       url: https://inference.net/grants/
     source_ids:
       - src_cf23ea3901fea53c636e3546206a4798868f3b12cfdd9c1c80c267e2d866a4ce

--- a/entities/in/inference-net.yaml
+++ b/entities/in/inference-net.yaml
@@ -1,0 +1,65 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m1yad2qmn13qehsj1zpq24xk
+  slug: inference-net
+  slug_aliases: []
+  name: Inference.net
+  domains:
+    - value: inference.net
+      role: primary
+      valid_from: 2026-09-07T16:14:00.000Z
+  category: ai-ml
+profile:
+  summary: Inference infrastructure for AI-native teams to run, monitor, and optimize production AI workloads.
+  description: Inference.net provides managed inference infrastructure for AI-native teams to run, monitor, and optimize production AI workloads.
+  links:
+    site: https://inference.net/
+sources:
+  - source_id: src_cf23ea3901fea53c636e3546206a4798868f3b12cfdd9c1c80c267e2d866a4ce
+    url: https://inference.net/grants/
+programs:
+  - program_id: prg_01m1yad2r24fcqg0tnpsxe074x
+    program_slug: inference-net-ai-compute-grants
+    program_slug_aliases: []
+    title: Inference.net AI Compute Grants
+    summary: Inference.net awards up to USD 10,000 in free compute resources to developers and researchers working on open-source AI projects.
+    source_ids:
+      - src_cf23ea3901fea53c636e3546206a4798868f3b12cfdd9c1c80c267e2d866a4ce
+offers:
+  - offer_id: off_01m1yad2r42sqey99gvna1wvwk
+    program_id: prg_01m1yad2r24fcqg0tnpsxe074x
+    offer_slug: up-to-10000-free-compute
+    offer_slug_aliases: []
+    title: Up to USD 10,000 in free compute resources
+    summary: Approved applicants receive up to USD 10,000 in free Inference.net compute resources for open-source AI projects, reviewed on a rolling basis.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-07T16:14:00.000Z
+    economics:
+      benefits:
+        - benefit_id: ben_01
+          description: Up to USD 10,000 in free compute resources on Inference.net
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 1000000
+            kind: up-to
+      consideration:
+        kind: none
+    eligibility:
+      rule:
+        criterion_id: cri_01
+        kind: manual
+        reason: vendor-discretion
+        statement: Developers and researchers working on open-source AI projects in novel LLM applications, inference performance optimization, or AI developer tools; Inference.net reviews applications on a rolling basis.
+    roles:
+      terms_authority_entity_id: ent_01m1yad2qmn13qehsj1zpq24xk
+      access_operator_entity_id: ent_01m1yad2qmn13qehsj1zpq24xk
+    access:
+      availability: public
+      method: form
+      instructions: Submit the grant application form on the Inference.net AI Compute Grants page with name, email, project description, GitHub repo, and project type.
+      url: https://inference.net/grants/
+    source_ids:
+      - src_cf23ea3901fea53c636e3546206a4798868f3b12cfdd9c1c80c267e2d866a4ce


### PR DESCRIPTION
## Summary
- Add `entities/in/inference-net.yaml` for Inference.net AI Compute Grants
- Offer: up to **USD 10,000** in free compute resources (consideration `none`)
- First-party source: https://inference.net/grants/ (live verified 2026-09-07)
- Re-authored under `entities/` after pre-cutover `vendors/` PR #755 was closed for schema migration

Closes #754

## Verification
- Entity ABSENT from upstream `entities/`
- No competing open PR for this vendor
- DCO Signed-off-by: infser <infser@users.noreply.github.com>
- Entity-only commit from `origin/main`