### PR TITLE
data: add Launchpad for Startups

### DIFF
--- a/entities/la/launchpad.yaml
+++ b/entities/la/launchpad.yaml
@@ -1,0 +1,87 @@
+schema_version: sourcey.entity-authoring/v1alpha1
+entity:
+  entity_id: ent_01m20fd7s02nynxm6az3vjn3yt
+  slug: launchpad
+  slug_aliases: []
+  name: Launchpad
+  domains:
+    - value: launchpad.io
+      role: primary
+      valid_from: 2026-09-08T12:20:50.000Z
+  category: no-code
+profile:
+  summary: Pegasystems low-code platform for building, hosting, and operating workflow-centric B2B SaaS applications.
+  description: Launchpad is a Pegasystems low-code platform for building, hosting, and operating workflow-centric B2B SaaS applications.
+  links:
+    site: https://launchpad.io/
+sources:
+  - source_id: src_ba3f199c33c653580c763d5c6a5669b825a0bff22f710a6a0769b212ce5e1059
+    url: https://launchpad.io/startups
+programs:
+  - program_id: prg_01m20fd7sn4gfzstmbws3jhzr9
+    program_slug: launchpad-for-startups
+    program_slug_aliases: []
+    title: Launchpad for Startups
+    summary: Rolling program helping eligible early-stage companies build and launch workflow-centric B2B SaaS products on Launchpad.
+    source_ids:
+      - src_ba3f199c33c653580c763d5c6a5669b825a0bff22f710a6a0769b212ce5e1059
+offers:
+  - offer_id: off_01m20fd7sp6sadtdp2bffv8h0f
+    program_id: prg_01m20fd7sn4gfzstmbws3jhzr9
+    offer_slug: starter-year-and-dev-support
+    offer_slug_aliases: []
+    title: Starter year and premium development support
+    summary: Selected startups pay for three months of access during a 90-day build, then receive one complimentary year of Starter plus USD 30,000 of premium development support.
+    lifecycle:
+      status: active
+      effective_from: 2026-09-08T12:20:50.000Z
+    economics:
+      consideration:
+        kind: variable
+        description: Selected companies pay for three months of platform access during the 90-day build period.
+      benefits:
+        - benefit_id: ben_01
+          description: One complimentary year of the Starter Launchpad Subscription Plan after completing the program
+          kind: free-service
+          service: Starter Launchpad Subscription Plan
+          duration:
+            kind: exact
+            value: P1Y
+        - benefit_id: ben_02
+          description: USD 30,000 of premium development support after completing the program
+          kind: credit
+          value:
+            amount:
+              currency: USD
+              minor_units: 3000000
+            kind: exact
+    eligibility:
+      rule:
+        kind: all
+        rules:
+          - criterion_id: cri_01
+            kind: manual
+            statement: Early-stage company with a validated business model and a clear use case ready for a 90-day MVP build.
+            reason: external-verification
+          - criterion_id: cri_02
+            kind: manual
+            statement: Team of founders ready to build.
+            reason: external-verification
+          - criterion_id: cri_03
+            kind: manual
+            statement: Generated less than USD 2 million of ARR.
+            reason: external-verification
+          - criterion_id: cri_04
+            kind: manual
+            statement: Under USD 5 million of total capital raised.
+            reason: external-verification
+    roles:
+      terms_authority_entity_id: ent_01m20fd7s02nynxm6az3vjn3yt
+      access_operator_entity_id: ent_01m20fd7s02nynxm6az3vjn3yt
+    access:
+      availability: public
+      method: form
+      url: https://www.surveymonkey.com/r/launchpadforstartups_apply
+      instructions: Apply on a rolling basis via the Launchpad for Startups application form linked from https://launchpad.io/startups.
+    source_ids:
+      - src_ba3f199c33c653580c763d5c6a5669b825a0bff22f710a6a0769b212ce5e1059


### PR DESCRIPTION
## What changed

Adds one new Entity, **Launchpad** (`entities/la/launchpad.yaml`), with the vendor-run **Launchpad for Startups** program: after a paid 90-day build period, selected startups receive **one complimentary year of the Starter Launchpad Subscription Plan** plus **USD 30,000 of premium development support**.

Closes #175

## Sources

- https://launchpad.io/startups (verified live HTTP 200 on 2026-09-08)

Published facts captured in structured fields:

- Benefit: "1 year free of the Starter Launchpad Subscription Plan" → `kind: free-service`, `duration: P1Y`
- Benefit: "$30k for premium development support" → `kind: credit`, USD 30,000 exact
- Consideration: "Companies will be required to pay for 3 months of access during the 90-day build" → `consideration.kind: variable`
- Eligibility: clear 90-day MVP use case; founders ready to build; less than $2m ARR; under $5m total capital raised
- Access: rolling applications via SurveyMonkey form linked from the startups page

## Certification

- [x] I changed only allowed repository content and did not mix Entity YAML with other paths.
- [x] Public sources substantiate every submitted factual value; any Sourcey-written prose is a neutral summary, not a fabricated vendor quote.
- [x] I did not author verification, provenance, freshness, or signature claims.
- [x] My commits include a `Signed-off-by` line.